### PR TITLE
fix: configure gateway for external runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ The setup profile compiler emits this credential-bearing start command
 separately from the one-shot setup command. The first portable profile supports
 OpenCode; select `runtime.selection=opencode` explicitly.
 
+Add `--with-ai-gateway` to generate the credential-free
+`wp-ai-gateway/site-default` OpenCode provider. External mode does not install
+gateway plugins, configure a route, mint a token, or write an env file. Supply
+`OPENAI_BASE_URL` and `OPENAI_API_KEY` in the runtime environment when starting
+Kimaki.
+
 Use the same transport input when validating an external profile. `verify.sh`
 continues to validate colocated WordPress installs; external runtime validation
 is the transport's `core is-installed` check performed by setup plus inspection

--- a/lib/ai-gateway.sh
+++ b/lib/ai-gateway.sh
@@ -197,7 +197,11 @@ PY
 
   UPDATED_ITEMS+=("opencode.json WP AI Gateway provider")
   log "Merged WP AI Gateway provider into $config_file"
-  log "OpenCode env file: $env_file"
+  if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
+    log "OpenCode gateway credentials: runtime environment (OPENAI_BASE_URL and OPENAI_API_KEY)"
+  else
+    log "OpenCode env file: $env_file"
+  fi
 }
 
 setup_ai_gateway() {

--- a/scripts/compile-setup-profile.mjs
+++ b/scripts/compile-setup-profile.mjs
@@ -177,6 +177,7 @@ function compile(profile) {
   const effectiveBridge = bridge === "auto" && runtime.primary === "codex" ? "none" : bridge
 
   if (overlays.homeboy) addFlag(command, "--with-homeboy")
+  if (profile.codex_path === "external-openai-compatible-endpoint") addFlag(command, "--with-ai-gateway")
   if (overlays.multisite || overlays.subdomain_multisite) addFlag(command, "--multisite")
   if (overlays.subdomain_multisite) addFlag(command, "--subdomain")
   if (overlays.skip_deps) addFlag(command, "--skip-deps")

--- a/setup.sh
+++ b/setup.sh
@@ -566,7 +566,7 @@ runtime_discover_dm_paths
 external_wordpress_project_context
 discover_dm_workspace_dir
 runtime_generate_config
-if [ "$EXTERNAL_WORDPRESS" != true ]; then ai_gateway_configure_opencode; fi
+ai_gateway_configure_opencode
 runtime_install_hooks
 if [ "$EXTERNAL_WORDPRESS" != true ]; then configure_homeboy_wordpress_extension; fi
 runtime_generate_instructions

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -60,6 +60,8 @@ source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/wordpress.sh"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/ai-gateway.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/external-wordpress.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/source-policy.sh"
@@ -73,6 +75,11 @@ external_wordpress_prepare_transport
 external_wordpress_validate
 external_wordpress_project_context
 runtime_generate_config
+WITH_AI_GATEWAY=true
+OPENAI_BASE_URL='https://runtime-only.invalid/private-endpoint'
+OPENAI_API_KEY='runtime-only-secret-value'
+export WITH_AI_GATEWAY OPENAI_BASE_URL OPENAI_API_KEY
+ai_gateway_configure_opencode
 runtime_generate_instructions
 DETECTED_RUNTIMES=(opencode)
 INSTALL_SKILLS=true
@@ -101,6 +108,13 @@ if data.get("instructions") != expected:
 for plugin in data.get("plugin", []):
     if not plugin.startswith(root + "/"):
         raise SystemExit(f"plugin escaped runtime root: {plugin}")
+provider = data.get("provider", {}).get("wp-ai-gateway", {})
+if provider.get("options", {}).get("baseURL") != "${OPENAI_BASE_URL}":
+    raise SystemExit("gateway provider does not use the runtime base URL placeholder")
+if provider.get("env") != ["OPENAI_API_KEY"]:
+    raise SystemExit("gateway provider does not declare runtime API key input")
+if data.get("model") != "wp-ai-gateway/site-default":
+    raise SystemExit("gateway model is not the runtime default")
 PY
 
 while IFS= read -r argument; do
@@ -127,6 +141,11 @@ if grep -R -F -- "secret value with spaces" "$RUNTIME_PROJECT_ROOT" >/dev/null 2
   echo "FAIL: transport credential persisted below runtime root"
   exit 1
 fi
+if grep -R -E -- 'runtime-only\.invalid|runtime-only-secret-value' "$RUNTIME_PROJECT_ROOT" >/dev/null 2>&1; then
+  echo "FAIL: runtime gateway credentials persisted below runtime root"
+  exit 1
+fi
+[ ! -e "$RUNTIME_PROJECT_ROOT/.opencode/wp-ai-gateway.env" ] || { echo "FAIL: external profile wrote a gateway env file"; exit 1; }
 
 mkdir -p "$TMP/outside"
 printf 'outside-safe\n' > "$TMP/outside/SOUL.md"
@@ -162,6 +181,7 @@ external_wordpress_prepare_transport
 before="$(cksum "$RUNTIME_PROJECT_ROOT/opencode.json" "$RUNTIME_PROJECT_ROOT/AGENTS.md")"
 external_wordpress_project_context
 runtime_generate_config
+ai_gateway_configure_opencode
 runtime_generate_instructions
 after="$(cksum "$RUNTIME_PROJECT_ROOT/opencode.json" "$RUNTIME_PROJECT_ROOT/AGENTS.md")"
 [ "$before" = "$after" ] || { echo "FAIL: external profile is not idempotent"; exit 1; }

--- a/tests/setup-profile-compiler.mjs
+++ b/tests/setup-profile-compiler.mjs
@@ -21,12 +21,14 @@ function compile(profile) {
     },
     runtime: { selection: "opencode" },
     chat_bridge: { selection: "kimaki" },
+    codex_path: "external-openai-compatible-endpoint",
     overlays: {},
     agent: { slug: "remote" },
   })
   assert.match(plan.commands.apply, /RUNTIME_PROJECT_ROOT='\/tmp\/runtime root'/)
   assert.match(plan.commands.apply, /WP_CONTROL_TRANSPORT_JSON='\["\/usr\/local\/bin\/control transport","--identity","value with spaces"\]'/)
   assert.match(plan.commands.apply, /--external-wordpress --wordpress-path '\/remote\/site root' --wordpress-user 'agent user'/)
+  assert.match(plan.commands.apply, /--with-ai-gateway/)
   assert.match(plan.commands.start, /WP_CONTROL_TRANSPORT_JSON=.*\/tmp\/runtime root\/\.wp-coding-agents\/bin\/kimaki/)
   assert.ok(plan.verification.overlays.includes("verify-external-wordpress-transport"))
 }


### PR DESCRIPTION
## Summary

- configure the existing credential-free `wp-ai-gateway/site-default` provider for external OpenCode runtimes
- continue skipping WordPress plugin installation, route mutation, token minting, and gateway env-file writes
- keep endpoint and API key delivery in the Kimaki/OpenCode process environment
- compile the existing external-endpoint profile selection into `--with-ai-gateway`

Closes #360.

## Verification

- `bash tests/external-wordpress-runtime.sh`
- `bash tests/ai-gateway.sh`
- `node tests/setup-profile-compiler.mjs`
- `bash tests/opencode-local-plugin-path.sh`
- `bash tests/repair-opencode-json.sh`
- `bash tests/ci-coverage.sh`
- shell syntax and `git diff --check`

The external regression injects fake endpoint/key values and proves neither value nor `.opencode/wp-ai-gateway.env` is persisted.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to trace the external runtime and gateway contracts, implement the focused fix, and run verification. Chris Huber reviewed and is responsible for every line.