### PR TITLE
Project OpenCode subagents through external WordPress transport

### DIFF
--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -9,7 +9,7 @@ opencode_project_subagents() {
   done
   [ "$has_opencode" = true ] || [ "${RUNTIME:-}" = opencode ] || return 0
   [ -n "${AGENT_SLUG:-}" ] || return 0
-  [ -f "$SITE_PATH/wp-config.php" ] || return 0
+  [ -f "$SITE_PATH/wp-config.php" ] || [ "${EXTERNAL_WORDPRESS:-false}" = true ] || return 0
   [ -f "$SITE_PATH/opencode.json" ] || return 0
 
   local graph_helper projector agent_json
@@ -20,20 +20,37 @@ opencode_project_subagents() {
 
   # The Agents API registry owns child topology. Data Machine owns the
   # registered identity files and declared skill artifacts used by the reader.
-  agent_json="$(wp_cmd eval-file "$graph_helper" -- "$AGENT_SLUG" 2>/dev/null)" || {
-    warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
-    return 1
-  }
+  # External hosts only receive wp eval, so transfer this local reader as one
+  # argv-safe PHP expression and request a self-contained graph.
+  if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
+    local reader_code reader_payload slug_payload
+    reader_payload="$(base64 < "$graph_helper" | tr -d '\n')"
+    slug_payload="$(printf '%s' "$AGENT_SLUG" | base64 | tr -d '\n')"
+    reader_code="\$args=array(base64_decode('$slug_payload'),'embedded');eval('?>'.base64_decode('$reader_payload'));"
+    agent_json="$(wp_cmd eval "$reader_code" 2>/dev/null)" || {
+      warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
+      return 1
+    }
+  else
+    agent_json="$(wp_cmd eval-file "$graph_helper" -- "$AGENT_SLUG" 2>/dev/null)" || {
+      warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
+      return 1
+    }
+  fi
   local source
-  source="$(mktemp)"
-  printf '%s' "$agent_json" > "$source"
   local before after
   before="$(tar -cf - -C "$SITE_PATH" opencode.json .opencode 2>/dev/null | shasum || true)"
-  if ! python3 "$projector" "$source" "$SITE_PATH"; then
+  if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
+    printf '%s' "$agent_json" | python3 "$projector" --stdin "$SITE_PATH" || return 1
+  else
+    source="$(mktemp)"
+    printf '%s' "$agent_json" > "$source"
+    if ! python3 "$projector" "$source" "$SITE_PATH"; then
+      rm -f "$source"
+      return 1
+    fi
     rm -f "$source"
-    return 1
   fi
-  rm -f "$source"
   after="$(tar -cf - -C "$SITE_PATH" opencode.json .opencode 2>/dev/null | shasum || true)"
   if [ "$before" != "$after" ]; then
     if [ -n "${UPDATED_ITEMS+x}" ]; then

--- a/lib/project-opencode-subagents.py
+++ b/lib/project-opencode-subagents.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Safely project a Data Machine coordinator graph into OpenCode files."""
 
+import base64
 import json
 import os
 import re
@@ -81,8 +82,23 @@ def map_sources(value, name, root, kind=None):
     return result
 
 
+def embedded_sources(value, name):
+    if not isinstance(value, dict): fail(f"{name} must be a source map")
+    result = {}
+    for target, content in value.items():
+        target = rel(target, f"{name} key")
+        if not isinstance(content, str): fail(f"{name}.{target} must be base64 content")
+        try: result[target] = base64.b64decode(content, validate=True)
+        except ValueError: fail(f"{name}.{target} must be base64 content")
+    return result
+
+
+def source_bytes(source):
+    return source if isinstance(source, bytes) else source.read_bytes()
+
+
 def skill_name(skill_file):
-    raw = skill_file.read_bytes()
+    raw = source_bytes(skill_file)
     if not raw.startswith(b"---\n"): fail(f"{skill_file} must have SKILL.md frontmatter")
     try: frontmatter = raw.split(b"\n---\n", 1)[0].decode("utf-8")
     except UnicodeDecodeError: fail(f"{skill_file} frontmatter must be UTF-8")
@@ -95,6 +111,8 @@ def graph(data):
     if not isinstance(data, dict) or data.get("success") is not True: fail("agent graph must be successful")
     coordinator, nodes = text(data.get("coordinator"), "graph.coordinator"), data.get("nodes")
     if not SLUG.fullmatch(coordinator) or not isinstance(nodes, list): fail("graph coordinator or nodes is invalid")
+    embedded = data.get("source_mode") == "embedded"
+    if data.get("source_mode") not in (None, "embedded"): fail("graph source mode is invalid")
     result, edges_by_node = {}, {}
     for index, node in enumerate(nodes):
         name = f"graph.nodes[{index}]"
@@ -110,18 +128,24 @@ def graph(data):
         if not isinstance(raw_instructions, dict): fail(f"{name}.sources.instructions must be a source map")
         raw_skills, raw_references = sources.get("skills"), sources.get("references")
         if not isinstance(raw_skills, dict) or not isinstance(raw_references, dict): fail(f"{name}.sources skills and references must be source maps")
-        candidates = []
-        for kind, raw in (("instructions", raw_instructions), ("skills", raw_skills), ("references", raw_references)):
-            for target, source in raw.items():
-                target = rel(target, f"{name}.sources.{kind} key")
-                source = Path(text(source, f"{name}.sources.{kind}.{target}"))
-                candidates.append(source.parent if kind == "instructions" else source.parents[len(target.parts)])
-        if not candidates: fail(f"{name}.sources must contain an artifact")
-        root = candidates[0]
-        if any(candidate != root for candidate in candidates): fail(f"{name}.sources do not share one agent root")
-        instructions = map_sources(raw_instructions, f"{name}.sources.instructions", root)
-        skills = map_sources(raw_skills, f"{name}.sources.skills", root, "skills")
-        references = map_sources(raw_references, f"{name}.sources.references", root, "references")
+        if embedded:
+            instructions = embedded_sources(raw_instructions, f"{name}.sources.instructions")
+            skills = embedded_sources(raw_skills, f"{name}.sources.skills")
+            references = embedded_sources(raw_references, f"{name}.sources.references")
+        else:
+            candidates = []
+            for kind, raw in (("instructions", raw_instructions), ("skills", raw_skills), ("references", raw_references)):
+                for target, source in raw.items():
+                    target = rel(target, f"{name}.sources.{kind} key")
+                    source = Path(text(source, f"{name}.sources.{kind}.{target}"))
+                    candidates.append(source.parent if kind == "instructions" else source.parents[len(target.parts)])
+            if not candidates: fail(f"{name}.sources must contain an artifact")
+            root = candidates[0]
+            if any(candidate != root for candidate in candidates): fail(f"{name}.sources do not share one agent root")
+            instructions = map_sources(raw_instructions, f"{name}.sources.instructions", root)
+            skills = map_sources(raw_skills, f"{name}.sources.skills", root, "skills")
+            references = map_sources(raw_references, f"{name}.sources.references", root, "references")
+        if not instructions and not skills and not references: fail(f"{name}.sources must contain an artifact")
         policy = translated_policy(node.get("tool_policy"), name)
         declared = node.get("skill_policy", {}).get("paths") if isinstance(node.get("skill_policy"), dict) else None
         if not isinstance(declared, list) or {rel(path, f"{name}.skill_policy.paths") for path in declared} != set(skills): fail(f"{name}.skill_policy.paths must exactly match sources.skills")
@@ -137,10 +161,10 @@ def graph(data):
 
 def wrapper(instructions):
     ordered = sorted(instructions.items())
-    if len(ordered) == 1: return ordered[0][1].read_bytes()
+    if len(ordered) == 1: return source_bytes(ordered[0][1])
     # Source copies remain byte-identical beside the agent; this wrapper only
     # defines their deterministic composition order for OpenCode's prompt.
-    return b"\n\n".join(b"# " + str(path).encode() + b"\n\n" + source.read_bytes() for path, source in ordered)
+    return b"\n\n".join(b"# " + str(path).encode() + b"\n\n" + source_bytes(source) for path, source in ordered)
 
 
 def agent_bytes(child, task_edges):
@@ -195,9 +219,10 @@ def manifest(path, root):
 
 
 def main():
-    if len(sys.argv) != 3: raise SystemExit("usage: project-opencode-subagents.py GRAPH_JSON PROJECT_ROOT")
+    if len(sys.argv) != 3: raise SystemExit("usage: project-opencode-subagents.py GRAPH_JSON|--stdin PROJECT_ROOT")
     try:
-        nodes, edges, coordinator = graph(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")))
+        raw = sys.stdin.read() if sys.argv[1] == "--stdin" else Path(sys.argv[1]).read_text(encoding="utf-8")
+        nodes, edges, coordinator = graph(json.loads(raw))
         project, root = Path(sys.argv[2]), Path(sys.argv[2]) / ".opencode"
         config_path, manifest_path = project / "opencode.json", root / MANIFEST_NAME
         if not config_path.is_file() or config_path.is_symlink(): fail("opencode.json must be a regular file")
@@ -217,20 +242,20 @@ def main():
             agents.append(str(agent))
             for relative, source in child["instructions"].items():
                 target = Path("agents") / f"{slug}.instructions" / relative
-                desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+                desired[root / target] = source_bytes(source); artifacts.append(str(target))
             skill_roots = {path.parent: name for path, name in child["skill_names"].items()}
             for relative, source in child["skills"].items():
                 matching = [base for base in skill_roots if relative.is_relative_to(base)]
                 if not matching: fail(f"skill support file is not below a SKILL.md: {relative}")
                 base = max(matching, key=lambda value: len(value.parts))
                 target = Path("skills") / skill_roots[base] / relative.relative_to(base)
-                desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+                desired[root / target] = source_bytes(source); artifacts.append(str(target))
             for relative, source in child["references"].items():
                 matching = [base for base in skill_roots if relative.is_relative_to(base)]
                 if len(matching) != 1: fail(f"reference must belong to exactly one skill: {relative}")
                 base = matching[0]
                 target = Path("skills") / skill_roots[base] / "references" / relative.relative_to(base)
-                desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+                desired[root / target] = source_bytes(source); artifacts.append(str(target))
         coordinator_skill_names = sorted(nodes[coordinator]["skill_names"].values())
         coordinator_artifacts = nodes[coordinator]
         skill_roots = {path.parent: name for path, name in coordinator_artifacts["skill_names"].items()}
@@ -239,13 +264,13 @@ def main():
             if not matching: fail(f"skill support file is not below a SKILL.md: {relative}")
             base = max(matching, key=lambda value: len(value.parts))
             target = Path("skills") / skill_roots[base] / relative.relative_to(base)
-            desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+            desired[root / target] = source_bytes(source); artifacts.append(str(target))
         for relative, source in coordinator_artifacts["references"].items():
             matching = [base for base in skill_roots if relative.is_relative_to(base)]
             if len(matching) != 1: fail(f"reference must belong to exactly one skill: {relative}")
             base = matching[0]
             target = Path("skills") / skill_roots[base] / "references" / relative.relative_to(base)
-            desired[root / target] = source.read_bytes(); artifacts.append(str(target))
+            desired[root / target] = source_bytes(source); artifacts.append(str(target))
         # Only the coordinator's own task configuration belongs in opencode.json.
         task = {"*": "deny", **{edge: "allow" for edge in edges[coordinator]}}
         current = config["permission"].get("task")

--- a/lib/read-opencode-subagent-graph.php
+++ b/lib/read-opencode-subagent-graph.php
@@ -2,8 +2,9 @@
 /**
  * Read a Data Machine agent relationship as a runtime-neutral projection graph.
  *
- * Invoked through `wp eval-file ... -- <coordinator-slug>` so the Agents API
- * registry is fully initialized before this code reads its `subagents` edges.
+ * Invoked through `wp eval-file ... -- <coordinator-slug>` or embedded in
+ * `wp eval` after `$args` is initialized. The Agents API registry is therefore
+ * loaded before this code reads its `subagents` edges.
  */
 
 if ( ! function_exists( 'wp_get_agent' ) || ! function_exists( 'wp_get_ability' ) ) {
@@ -11,6 +12,7 @@ if ( ! function_exists( 'wp_get_agent' ) || ! function_exists( 'wp_get_ability' 
 }
 
 $coordinator_slug = isset( $args[0] ) ? sanitize_title( (string) $args[0] ) : '';
+$embedded         = isset( $args[1] ) && 'embedded' === $args[1];
 $coordinator      = '' === $coordinator_slug ? null : wp_get_agent( $coordinator_slug );
 if ( ! $coordinator instanceof WP_Agent ) {
 	throw new RuntimeException( 'The coordinator is not a registered Agents API agent.' );
@@ -43,20 +45,48 @@ while ( ! empty( $pending ) ) {
 	if ( empty( $memory['success'] ) || ! is_array( $memory['files'] ?? null ) ) {
 		throw new RuntimeException( sprintf( 'Could not resolve Data Machine identity files for "%s".', $slug ) );
 	}
+	if ( count( $visited ) > 64 || count( $memory['files'] ) > 256 ) {
+		throw new RuntimeException( 'The portable agent graph exceeds its projection limit.' );
+	}
 
 	$instructions = array();
+	$agent_root   = null;
+	if ( $embedded ) {
+		$directory_manager_class = '\DataMachine\Core\FilesRepository\DirectoryManager';
+		if ( ! class_exists( $directory_manager_class ) ) {
+			throw new RuntimeException( 'The Data Machine agent directory resolver is unavailable.' );
+		}
+		$directory_manager = new $directory_manager_class();
+		$agent_root        = $directory_manager->resolve_agent_directory( array( 'agent_id' => $agent_id ) );
+		if ( ! is_string( $agent_root ) || false === realpath( $agent_root ) || realpath( $agent_root ) !== $agent_root ) {
+			throw new RuntimeException( sprintf( 'Agent "%s" has an invalid Data Machine identity root.', $slug ) );
+		}
+	}
 	foreach ( $memory['files'] as $file ) {
 		if ( ! is_array( $file ) || ! is_string( $file['filename'] ?? null ) || ! is_string( $file['path'] ?? null ) ) {
 			continue;
 		}
-		$instructions[ $file['filename'] ] = $file['path'];
+		if ( $embedded && 'agent' === ( $file['layer'] ?? null ) ) {
+			opencode_subagent_assert_contained_file( $file['path'], $agent_root );
+		}
+		$instructions[ $file['filename'] ] = $embedded ? opencode_subagent_embedded_file( $file['path'] ) : $file['path'];
 	}
 
 	// Skills and references are explicit portable agent config declarations.
 	// Each map key is the relative path retained by the runtime projection.
 	$skills     = is_array( $config['skills'] ?? null ) ? $config['skills'] : array();
 	$references = is_array( $config['references'] ?? null ) ? $config['references'] : array();
+	if ( $embedded ) {
+		if ( count( $skills ) + count( $references ) > 256 ) {
+			throw new RuntimeException( 'The portable agent graph exceeds its projection limit.' );
+		}
+		$skills     = opencode_subagent_embedded_declared_files( $skills, $agent_root, 'skills' );
+		$references = opencode_subagent_embedded_declared_files( $references, $agent_root, 'references' );
+	}
 	$subagents  = $agent->get_subagents();
+	if ( count( $subagents ) > 64 ) {
+		throw new RuntimeException( 'The portable agent graph exceeds its projection limit.' );
+	}
 	foreach ( $subagents as $child ) {
 		$pending[] = $child;
 	}
@@ -77,10 +107,63 @@ while ( ! empty( $pending ) ) {
 }
 
 echo wp_json_encode(
-	array(
+	array_filter( array(
 		'success'     => true,
 		'coordinator' => $coordinator_slug,
 		'nodes'       => $nodes,
-	),
+		'source_mode' => $embedded ? 'embedded' : null,
+	) ),
 	JSON_UNESCAPED_SLASHES
 );
+
+/** Embed declared portable artifacts only from their owning Data Machine agent root. */
+function opencode_subagent_embedded_declared_files( $files, $agent_root, $kind ) {
+	$embedded = array();
+	foreach ( $files as $target => $path ) {
+		$parts = is_string( $target ) ? explode( '/', $target ) : array();
+		if ( empty( $parts ) || in_array( '.', $parts, true ) || in_array( '..', $parts, true ) || ! preg_match( '#^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$#', $target ) ) {
+			throw new RuntimeException( 'A declared portable agent artifact has an invalid relative path.' );
+		}
+		$expected = "{$agent_root}/{$kind}/{$target}";
+		if ( $path !== $expected ) {
+			throw new RuntimeException( 'A declared portable agent artifact is outside its agent root.' );
+		}
+		opencode_subagent_assert_contained_file( $path, $agent_root );
+		$embedded[ $target ] = opencode_subagent_embedded_file( $path );
+	}
+	return $embedded;
+}
+
+/** Require a regular canonical file below a canonical Data Machine agent root. */
+function opencode_subagent_assert_contained_file( $path, $agent_root ) {
+	$real_path = is_string( $path ) ? realpath( $path ) : false;
+	if ( false === $real_path || $real_path !== $path || 0 !== strpos( $path, trailingslashit( $agent_root ) ) || ! is_file( $path ) ) {
+		throw new RuntimeException( 'A declared portable agent artifact is outside its agent root.' );
+	}
+}
+
+/** Return bounded, binary-safe source content without retaining the remote path. */
+function opencode_subagent_embedded_file( $path ) {
+	static $total_bytes = 0;
+	static $file_count  = 0;
+	$max_file_bytes     = 2 * 1024 * 1024;
+	$max_total_bytes    = 16 * 1024 * 1024;
+	if ( ! is_string( $path ) || '' === $path || ! is_file( $path ) || ! is_readable( $path ) ) {
+		throw new RuntimeException( 'Could not read a declared portable agent artifact.' );
+	}
+	$real_path = realpath( $path );
+	if ( false === $real_path || $real_path !== $path ) {
+		throw new RuntimeException( 'A declared portable agent artifact is outside its agent root.' );
+	}
+	$size = filesize( $path );
+	if ( false === $size || $file_count >= 512 || $size > $max_file_bytes || $total_bytes + $size > $max_total_bytes ) {
+		throw new RuntimeException( 'Declared portable agent artifacts exceed the projection size limit.' );
+	}
+	$content = file_get_contents( $path );
+	if ( false === $content || strlen( $content ) !== $size ) {
+		throw new RuntimeException( 'Could not read a declared portable agent artifact.' );
+	}
+	$total_bytes += $size;
+	++$file_count;
+	return base64_encode( $content );
+}

--- a/setup.sh
+++ b/setup.sh
@@ -570,7 +570,7 @@ ai_gateway_configure_opencode
 runtime_install_hooks
 if [ "$EXTERNAL_WORDPRESS" != true ]; then configure_homeboy_wordpress_extension; fi
 runtime_generate_instructions
-if [ "$EXTERNAL_WORDPRESS" != true ]; then opencode_project_subagents; fi
+opencode_project_subagents
 runtime_merge_mcp_servers
 install_skills
 if [ "$EXTERNAL_WORDPRESS" != true ]; then cli_transport_install; runtime_guard_sync; fi

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -11,8 +11,28 @@ WORDPRESS_USER="agent user"
 TRANSPORT="$TMP/control transport"
 ARGS="$TMP/transport-args"
 KIMAKI_ENV="$TMP/kimaki-env"
+GRAPH="$TMP/remote-subagent-graph.json"
 
 mkdir -p "$RUNTIME_PROJECT_ROOT"
+python3 - "$GRAPH" <<'PY'
+import base64, json, sys
+encode = lambda value: base64.b64encode(value).decode()
+artifact = lambda value: encode(value.encode())
+graph = {
+  "success": True, "coordinator": "coordinator", "source_mode": "embedded", "nodes": [
+    {"slug":"coordinator", "description":"Routes work", "model":"", "subagents":["writer", "reviewer"],
+     "sources":{"instructions":{"SOUL.md":artifact("# Coordinator\n")}, "skills":{"root/SKILL.md":artifact("---\nname: root-skill\n---\n")}, "references":{}},
+     "tool_policy":{"default":"deny", "allow":["bash"]}, "skill_policy":{"paths":["root/SKILL.md"]}},
+    {"slug":"writer", "description":"Writes safely", "model":"openai/gpt-5", "subagents":["reviewer"],
+     "sources":{"instructions":{"SOUL.md":artifact("# Writer\n")}, "skills":{"writer/SKILL.md":artifact("---\nname: editorial\n---\n\nWrite exact prose.\n")}, "references":{"writer/context.bin":encode(b"reference\x00bytes")}},
+     "tool_policy":{"default":"deny", "allow":["bash"]}, "skill_policy":{"paths":["writer/SKILL.md"]}},
+    {"slug":"reviewer", "description":"Reviews safely", "model":"", "subagents":[],
+     "sources":{"instructions":{"SOUL.md":artifact("# Reviewer\n")}, "skills":{"review/SKILL.md":artifact("---\nname: review\n---\n")}, "references":{}},
+     "tool_policy":{"default":"deny", "allow":["webfetch"]}, "skill_policy":{"paths":["review/SKILL.md"]}}
+  ]
+}
+json.dump(graph, open(sys.argv[1], "w"))
+PY
 cat > "$TRANSPORT" <<'SH'
 #!/bin/bash
 printf '%s\n' "$@" >> "$WP_TEST_ARGS"
@@ -30,6 +50,21 @@ case "$3:$4" in
         ;;
     esac
     ;;
+  eval:*)
+    [ "$#" -eq 6 ] && [ "$5" = "--user=$WORDPRESS_USER" ] && [ "$6" = "--path=$WORDPRESS_PATH" ] || {
+      echo "wp eval received unsupported positional arguments" >&2
+      exit 9
+    }
+    case "$4" in
+      *"require base64_decode"*) echo "decoded PHP source was treated as a filename" >&2; exit 9 ;;
+    esac
+    printf '%s' "$4" | grep -F "\$args=array(base64_decode('" >/dev/null || { echo "wp eval did not initialize reader arguments" >&2; exit 9; }
+    printf '%s' "$4" | grep -F "'),'embedded');eval('?>'.base64_decode('" >/dev/null || { echo "wp eval did not execute embedded source" >&2; exit 9; }
+    python3 - "$WP_TEST_GRAPH" <<'PY'
+import sys
+sys.stdout.write(open(sys.argv[1]).read())
+PY
+    ;;
 esac
 SH
 chmod +x "$TRANSPORT"
@@ -40,9 +75,10 @@ printf '%s\n%s\n%s\n' "$EXTERNAL_WORDPRESS" "$WORDPRESS_PATH" "$WORDPRESS_USER" 
 SH
 chmod +x "$TMP/bin/kimaki"
 
-export SCRIPT_DIR RUNTIME_PROJECT_ROOT WORDPRESS_PATH WORDPRESS_USER
+export SCRIPT_DIR RUNTIME_PROJECT_ROOT WORDPRESS_PATH WORDPRESS_USER AGENT_SLUG=coordinator
 export WP_TEST_ARGS="$ARGS"
 export WP_TEST_KIMAKI_ENV="$KIMAKI_ENV"
+export WP_TEST_GRAPH="$GRAPH"
 export PATH="$TMP/bin:$PATH"
 export WP_CONTROL_TRANSPORT_JSON="[\"$TRANSPORT\",\"--identity\",\"secret value with spaces\"]"
 export EXTERNAL_WORDPRESS=true DRY_RUN=false LOCAL_MODE=true IS_STUDIO=false
@@ -68,6 +104,8 @@ source "$SCRIPT_DIR/lib/source-policy.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/skills.sh"
 # shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/opencode-subagents.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/runtimes/opencode.sh"
 error() { printf '%s\n' "$*" >&2; return 1; }
 
@@ -84,6 +122,7 @@ runtime_generate_instructions
 DETECTED_RUNTIMES=(opencode)
 INSTALL_SKILLS=true
 install_skills
+opencode_project_subagents
 
 [ ! -e "$RUNTIME_PROJECT_ROOT/wp-config.php" ] || { echo "FAIL: test created a local WordPress tree"; exit 1; }
 [ "$(cat "$RUNTIME_PROJECT_ROOT/.wp-coding-agents/context/shared/SITE.md")" = "site context" ] || { echo "FAIL: site context not projected"; exit 1; }
@@ -92,6 +131,10 @@ install_skills
 [ -f "$RUNTIME_PROJECT_ROOT/.kimaki/kimaki-config/plugins/dm-context-filter.ts" ] || { echo "FAIL: Kimaki config was not installed below runtime root"; exit 1; }
 [ ! -e "$RUNTIME_PROJECT_ROOT/wp-content" ] || { echo "FAIL: WordPress-side files were written below runtime root"; exit 1; }
 [ -L "$RUNTIME_PROJECT_ROOT/.wp-coding-agents/context" ] || { echo "FAIL: projected context is not atomically activated"; exit 1; }
+[ -f "$RUNTIME_PROJECT_ROOT/.opencode/agents/writer.md" ] || { echo "FAIL: embedded writer was not projected"; exit 1; }
+[ -f "$RUNTIME_PROJECT_ROOT/.opencode/agents/reviewer.md" ] || { echo "FAIL: embedded reviewer was not projected"; exit 1; }
+[ -f "$RUNTIME_PROJECT_ROOT/.opencode/skills/editorial/SKILL.md" ] || { echo "FAIL: embedded skill was not projected"; exit 1; }
+[ -f "$RUNTIME_PROJECT_ROOT/.opencode/skills/editorial/references/context.bin" ] || { echo "FAIL: embedded reference was not projected"; exit 1; }
 grep -F -- 'WordPress control: `./.wp-coding-agents/bin/wp-control`' "$RUNTIME_PROJECT_ROOT/AGENTS.md" >/dev/null
 if grep -F -- 'grep it as needed' "$RUNTIME_PROJECT_ROOT/AGENTS.md" >/dev/null; then
   echo "FAIL: external guidance claims installed source is mounted"
@@ -116,6 +159,19 @@ if provider.get("env") != ["OPENAI_API_KEY"]:
 if data.get("model") != "wp-ai-gateway/site-default":
     raise SystemExit("gateway model is not the runtime default")
 PY
+
+python3 - "$RUNTIME_PROJECT_ROOT" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+assert root.joinpath(".opencode/skills/editorial/references/context.bin").read_bytes() == b"reference\x00bytes"
+manifest = json.loads(root.joinpath(".opencode/.wp-coding-agents-subagents.json").read_text())
+assert manifest["agents"] == ["agents/reviewer.md", "agents/writer.md"]
+config = json.loads(root.joinpath("opencode.json").read_text())
+assert config["permission"]["task"] == {"*": "deny", "writer": "allow", "reviewer": "allow"}
+writer = root.joinpath(".opencode/agents/writer.md").read_text()
+assert '"task":{"*":"deny","reviewer":"allow"}' in writer
+PY
+grep -x 'eval' "$ARGS" >/dev/null || { echo "FAIL: external graph reader did not use wp eval"; exit 1; }
 
 while IFS= read -r argument; do
   case "$argument" in
@@ -145,7 +201,50 @@ if grep -R -E -- 'runtime-only\.invalid|runtime-only-secret-value' "$RUNTIME_PRO
   echo "FAIL: runtime gateway credentials persisted below runtime root"
   exit 1
 fi
+[ ! -e "$RUNTIME_PROJECT_ROOT/.wp-coding-agents-subagent-graph.json" ] || { echo "FAIL: graph payload persisted below runtime root"; exit 1; }
+if grep -R -F -- '/remote/wp-content/uploads/datamachine-files' "$RUNTIME_PROJECT_ROOT" >/dev/null 2>&1; then
+  echo "FAIL: remote artifact paths persisted below runtime root"
+  exit 1
+fi
 [ ! -e "$RUNTIME_PROJECT_ROOT/.opencode/wp-ai-gateway.env" ] || { echo "FAIL: external profile wrote a gateway env file"; exit 1; }
+
+before_subagents="$(cksum "$RUNTIME_PROJECT_ROOT/.opencode/agents/writer.md" "$RUNTIME_PROJECT_ROOT/.opencode/.wp-coding-agents-subagents.json")"
+opencode_project_subagents
+after_subagents="$(cksum "$RUNTIME_PROJECT_ROOT/.opencode/agents/writer.md" "$RUNTIME_PROJECT_ROOT/.opencode/.wp-coding-agents-subagents.json")"
+[ "$before_subagents" = "$after_subagents" ] || { echo "FAIL: embedded subagent projection is not byte-stable"; exit 1; }
+python3 - "$GRAPH" <<'PY'
+import json, sys
+path = sys.argv[1]
+graph = json.load(open(path))
+graph["nodes"] = [node for node in graph["nodes"] if node["slug"] != "reviewer"]
+graph["nodes"][0]["subagents"] = ["writer"]
+graph["nodes"][1]["subagents"] = []
+json.dump(graph, open(path, "w"))
+PY
+opencode_project_subagents
+[ ! -e "$RUNTIME_PROJECT_ROOT/.opencode/agents/reviewer.md" ] || { echo "FAIL: stale embedded child survived"; exit 1; }
+python3 - "$GRAPH" <<'PY'
+import json, sys
+path = sys.argv[1]
+graph = json.load(open(path))
+graph["nodes"][1]["sources"]["instructions"] = {"../escape.md": "aGVsbG8="}
+json.dump(graph, open(path, "w"))
+PY
+if opencode_project_subagents; then echo "FAIL: traversal graph projected"; exit 1; fi
+printf 'human configuration\n' > "$RUNTIME_PROJECT_ROOT/.opencode/agents/reviewer.md"
+python3 - "$GRAPH" <<'PY'
+import base64, json, sys
+path = sys.argv[1]
+graph = json.load(open(path))
+graph["nodes"][1]["sources"]["instructions"] = {"SOUL.md": base64.b64encode(b"# Writer\n").decode()}
+graph["nodes"].append({"slug":"reviewer", "description":"Reviewer", "model":"", "subagents":[], "sources":{"instructions":{"SOUL.md":base64.b64encode(b"# Reviewer\n").decode()}, "skills":{}, "references":{}}, "tool_policy":{}, "skill_policy":{"paths":[]}})
+graph["nodes"][0]["subagents"] = ["writer", "reviewer"]
+json.dump(graph, open(path, "w"))
+PY
+if opencode_project_subagents; then echo "FAIL: user-owned collision projected"; exit 1; fi
+[ "$(<"$RUNTIME_PROJECT_ROOT/.opencode/agents/reviewer.md")" = 'human configuration' ] || { echo "FAIL: collision changed user file"; exit 1; }
+printf '%s\n' '{"success":true,"coordinator":"coordinator","source_mode":"embedded","nodes":[{"slug":"bad_slug"}]}' > "$GRAPH"
+if opencode_project_subagents; then echo "FAIL: malformed graph projected"; exit 1; fi
 
 mkdir -p "$TMP/outside"
 printf 'outside-safe\n' > "$TMP/outside/SOUL.md"

--- a/tests/opencode-subagents-reader.php
+++ b/tests/opencode-subagents-reader.php
@@ -14,12 +14,26 @@ final class WP_Agent {
 	public function get_meta(): array { return $this->meta; }
 }
 
+$root = sys_get_temp_dir() . '/opencode-subagents-reader-' . getmypid();
+mkdir( $root . '/coordinator', 0777, true );
+$root = realpath( $root );
+mkdir( $root . '/writer/skills/writer', 0777, true );
+mkdir( $root . '/writer/references/writer', 0777, true );
+mkdir( $root . '/writer/contexts', 0777, true );
+file_put_contents( $root . '/coordinator/SOUL.md', "# Coordinator\n" );
+file_put_contents( $root . '/writer/SOUL.md', "# Writer\n" );
+file_put_contents( $root . '/writer/contexts/chat.md', "# Nested context\n" );
+file_put_contents( $root . '/writer/skills/writer/SKILL.md', "---\nname: writer\n---\n" );
+file_put_contents( $root . '/writer/references/writer/context.md', "reference\x00bytes" );
+$outside = $root . '/outside.md';
+file_put_contents( $outside, "must not leave WordPress\n" );
+
 $agents = array(
 	'coordinator' => new WP_Agent( 'Routes work', array( 'writer' ), array(), array( 'datamachine_agent_id' => 1 ) ),
 	'writer'      => new WP_Agent( 'Writes prose', array(), array(
 		'default_model' => 'openai/gpt-5',
-		'skills'        => array( 'writer/SKILL.md' => '/agents/writer/skills/writer/SKILL.md' ),
-		'references'    => array( 'writer/context.md' => '/agents/writer/references/writer/context.md' ),
+		'skills'        => array( 'writer/SKILL.md' => $root . '/writer/skills/writer/SKILL.md' ),
+		'references'    => array( 'writer/context.md' => $root . '/writer/references/writer/context.md' ),
 	), array( 'datamachine_agent_id' => 2 ) ),
 );
 
@@ -27,30 +41,78 @@ function sanitize_title( string $value ): string { return $value; }
 function wp_get_agent( string $slug ): ?WP_Agent { global $agents; return $agents[ $slug ] ?? null; }
 function wp_get_agents(): array { global $agents; return $agents; }
 function wp_json_encode( $value, int $flags = 0 ): string { return json_encode( $value, $flags | JSON_THROW_ON_ERROR ); }
+function trailingslashit( string $value ): string { return rtrim( $value, '/\\' ) . '/'; }
+eval( 'namespace DataMachine\\Core\\FilesRepository; class DirectoryManager { public function resolve_agent_directory(array $context): string { return $GLOBALS["root"] . "/" . (1 === $context["agent_id"] ? "coordinator" : "writer"); } }' );
 function wp_get_ability( string $slug ): object {
 	if ( 'datamachine/list-injectable-memory-files' !== $slug ) {
 		throw new RuntimeException( 'Unexpected ability.' );
 	}
 	return new class {
 		public function execute( array $input ): array {
-			return array( 'success' => true, 'files' => array(
-				array( 'filename' => 'SOUL.md', 'path' => '/agents/' . ( 1 === $input['agent_id'] ? 'coordinator' : 'writer' ) . '/SOUL.md' ),
-			) );
+			$directory = $GLOBALS['root'] . '/' . ( 1 === $input['agent_id'] ? 'coordinator' : 'writer' );
+			$files     = array( array( 'filename' => 'SOUL.md', 'layer' => 'agent', 'path' => $directory . '/SOUL.md' ) );
+			if ( 2 === $input['agent_id'] ) {
+				$files[] = array( 'filename' => 'contexts/chat.md', 'layer' => 'agent', 'path' => $directory . '/contexts/chat.md' );
+			}
+			return array( 'success' => true, 'files' => $files );
 		}
 	};
 }
 
-$args = array( 'coordinator' );
+$embedded = isset( $argv[1] ) && '--embedded' === $argv[1];
+$scenario = $argv[2] ?? '';
+if ( 'outside' === $scenario ) {
+	$agents['writer'] = new WP_Agent( 'Writes prose', array(), array(
+		'skills' => array( 'writer/SKILL.md' => $outside ),
+	), array( 'datamachine_agent_id' => 2 ) );
+} elseif ( 'oversize' === $scenario ) {
+	file_put_contents( $root . '/writer/references/writer/large.bin', str_repeat( 'x', 2 * 1024 * 1024 + 1 ) );
+	$agents['writer'] = new WP_Agent( 'Writes prose', array(), array(
+		'references' => array( 'writer/large.bin' => $root . '/writer/references/writer/large.bin' ),
+	), array( 'datamachine_agent_id' => 2 ) );
+} elseif ( 'graph-limit' === $scenario ) {
+	$agents['coordinator'] = new WP_Agent( 'Routes work', array_fill( 0, 65, 'writer' ), array(), array( 'datamachine_agent_id' => 1 ) );
+}
+$args     = $embedded ? array( 'coordinator', 'embedded' ) : array( 'coordinator' );
 ob_start();
-require __DIR__ . '/../lib/read-opencode-subagent-graph.php';
+$rejected = false;
+try {
+	require __DIR__ . '/../lib/read-opencode-subagent-graph.php';
+} catch ( RuntimeException $error ) {
+	$rejected = true;
+	ob_end_clean();
+}
+if ( '' !== $scenario ) {
+	if ( ! $rejected ) {
+		fwrite( STDERR, "FAIL: unsafe embedded artifact was exported\n" );
+		exit( 1 );
+	}
+	echo "ok: embedded reader rejects unsafe portable artifacts\n";
+	exit( 0 );
+}
+if ( $rejected ) {
+	throw $error;
+}
 $graph = json_decode( ob_get_clean(), true, 512, JSON_THROW_ON_ERROR );
 
 if ( array( 'writer' ) !== $graph['nodes'][0]['subagents'] ||
 	'openai/gpt-5' !== $graph['nodes'][1]['model'] ||
-	'/agents/writer/skills/writer/SKILL.md' !== $graph['nodes'][1]['sources']['skills']['writer/SKILL.md'] ||
-	'/agents/writer/references/writer/context.md' !== $graph['nodes'][1]['sources']['references']['writer/context.md'] ||
 	array( 'writer/SKILL.md' ) !== $graph['nodes'][1]['skill_policy']['paths'] ) {
 	fwrite( STDERR, "FAIL: reader did not project the registered relationship and declared artifacts\n" );
+	exit( 1 );
+}
+
+if ( $embedded ) {
+	if ( 'embedded' !== $graph['source_mode'] ||
+		"---\nname: writer\n---\n" !== base64_decode( $graph['nodes'][1]['sources']['skills']['writer/SKILL.md'], true ) ||
+		"# Nested context\n" !== base64_decode( $graph['nodes'][1]['sources']['instructions']['contexts/chat.md'], true ) ||
+		false !== strpos( wp_json_encode( $graph ), $root ) ) {
+		fwrite( STDERR, "FAIL: embedded reader did not return self-contained artifact content\n" );
+		exit( 1 );
+	}
+} elseif ( $root . '/writer/skills/writer/SKILL.md' !== $graph['nodes'][1]['sources']['skills']['writer/SKILL.md'] ||
+	$root . '/writer/references/writer/context.md' !== $graph['nodes'][1]['sources']['references']['writer/context.md'] ) {
+	fwrite( STDERR, "FAIL: path-backed reader output changed\n" );
 	exit( 1 );
 }
 

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -24,6 +24,10 @@ assert_python() { local name="$1"; shift; if python3 - "$@"; then printf '  ok  
 wp_cmd() { [ "$1" = eval-file ] && [ "$2" = "$SCRIPT_DIR/lib/read-opencode-subagent-graph.php" ] && [ "$3" = -- ] && [ "$4" = "$AGENT_SLUG" ]; cat "$TMP/graph.json"; }
 
 php "$SCRIPT_DIR/tests/opencode-subagents-reader.php"
+php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --embedded
+php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --embedded outside
+php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --embedded oversize
+php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --embedded graph-limit
 
 printf '# Writer identity\n\nWrite exact prose.\n' > "$TMP/identity/writer-soul.md"
 mkdir -p "$TMP/identity-review"


### PR DESCRIPTION
Closes #362

## Summary
- export a bounded, self-contained Agents API graph through argv-safe `wp eval`
- project embedded instructions, skills, references, policies, and child topology into external OpenCode runtimes
- preserve path-backed local projection while enforcing remote root containment, collision safety, atomic writes, and stale cleanup
- run specialist projection during external profile setup

## Verification
- `bash tests/opencode-subagents.sh`
- `bash tests/external-wordpress-runtime.sh`
- `bash tests/ci-coverage.sh`
- syntax checks for every tracked shell script
- PHP lint and Python compilation
- live `studio wp eval` of the embedded reader against a registered persisted agent

## AI assistance
OpenAI `gpt-5.6-sol` via OpenCode implemented and reviewed the portable projection changes, including runtime-contract verification and security hardening. Chris Huber reviewed and is responsible for every line.