### PR TITLE
Fix empty portable subagent maps

### DIFF
--- a/lib/read-opencode-subagent-graph.php
+++ b/lib/read-opencode-subagent-graph.php
@@ -91,17 +91,22 @@ while ( ! empty( $pending ) ) {
 		$pending[] = $child;
 	}
 
+	$description = trim( $agent->get_description() );
+	if ( '' === $description ) {
+		$description = $agent->get_label();
+	}
+
 	$nodes[] = array(
 		'slug'         => $slug,
-		'description'  => $agent->get_description(),
+		'description'  => $description,
 		'model'        => is_string( $config['default_model'] ?? null ) ? $config['default_model'] : '',
 		'subagents'    => $subagents,
 		'sources'      => array(
-			'instructions' => $instructions,
-			'skills'       => $skills,
-			'references'   => $references,
+			'instructions' => (object) $instructions,
+			'skills'       => (object) $skills,
+			'references'   => (object) $references,
 		),
-		'tool_policy'  => is_array( $config['tool_policy'] ?? null ) ? $config['tool_policy'] : array(),
+		'tool_policy'  => (object) ( is_array( $config['tool_policy'] ?? null ) ? $config['tool_policy'] : array() ),
 		'skill_policy' => array( 'paths' => array_keys( $skills ) ),
 	);
 }

--- a/tests/opencode-subagents-reader.php
+++ b/tests/opencode-subagents-reader.php
@@ -9,6 +9,7 @@ final class WP_Agent {
 		private array $meta
 	) {}
 	public function get_description(): string { return $this->description; }
+	public function get_label(): string { return '' !== $this->description ? $this->description : 'Fallback label'; }
 	public function get_subagents(): array { return $this->subagents; }
 	public function get_default_config(): array { return $this->config; }
 	public function get_meta(): array { return $this->meta; }
@@ -29,7 +30,7 @@ $outside = $root . '/outside.md';
 file_put_contents( $outside, "must not leave WordPress\n" );
 
 $agents = array(
-	'coordinator' => new WP_Agent( 'Routes work', array( 'writer' ), array(), array( 'datamachine_agent_id' => 1 ) ),
+	'coordinator' => new WP_Agent( '', array( 'writer' ), array(), array( 'datamachine_agent_id' => 1 ) ),
 	'writer'      => new WP_Agent( 'Writes prose', array(), array(
 		'default_model' => 'openai/gpt-5',
 		'skills'        => array( 'writer/SKILL.md' => $root . '/writer/skills/writer/SKILL.md' ),
@@ -93,9 +94,11 @@ if ( '' !== $scenario ) {
 if ( $rejected ) {
 	throw $error;
 }
-$graph = json_decode( ob_get_clean(), true, 512, JSON_THROW_ON_ERROR );
+$encoded = ob_get_clean();
+$graph   = json_decode( $encoded, true, 512, JSON_THROW_ON_ERROR );
 
-if ( array( 'writer' ) !== $graph['nodes'][0]['subagents'] ||
+if ( 'Fallback label' !== $graph['nodes'][0]['description'] ||
+	array( 'writer' ) !== $graph['nodes'][0]['subagents'] ||
 	'openai/gpt-5' !== $graph['nodes'][1]['model'] ||
 	array( 'writer/SKILL.md' ) !== $graph['nodes'][1]['skill_policy']['paths'] ) {
 	fwrite( STDERR, "FAIL: reader did not project the registered relationship and declared artifacts\n" );
@@ -104,6 +107,9 @@ if ( array( 'writer' ) !== $graph['nodes'][0]['subagents'] ||
 
 if ( $embedded ) {
 	if ( 'embedded' !== $graph['source_mode'] ||
+		false === strpos( $encoded, '"skills":{}' ) ||
+		false === strpos( $encoded, '"references":{}' ) ||
+		false === strpos( $encoded, '"tool_policy":{}' ) ||
 		"---\nname: writer\n---\n" !== base64_decode( $graph['nodes'][1]['sources']['skills']['writer/SKILL.md'], true ) ||
 		"# Nested context\n" !== base64_decode( $graph['nodes'][1]['sources']['instructions']['contexts/chat.md'], true ) ||
 		false !== strpos( wp_json_encode( $graph ), $root ) ) {


### PR DESCRIPTION
Closes #364

## Summary
- serialize empty instruction, skill, reference, and tool-policy maps as JSON objects
- fall back to the registered agent label when its optional description is empty
- cover both contracts in the graph-reader fixture

## Verification
- `bash tests/opencode-subagents.sh`
- `bash tests/external-wordpress-runtime.sh`
- PHP lint and `git diff --check`
- live SecEx bootstrap against the dedicated WP Cloud North control plane projected all three specialists and executed generated `wp-control` successfully

## AI assistance
OpenAI `gpt-5.6-sol` via OpenCode diagnosed the live WP Cloud serialization failures, implemented the fix, and verified the actual SecEx projection. Chris Huber reviewed and is responsible for every line.