### PR TITLE
Use the native OpenAI SDK for OpenAI gateway identities

### DIFF
--- a/lib/ai-gateway.sh
+++ b/lib/ai-gateway.sh
@@ -182,7 +182,10 @@ api_model_id = sys.argv[4]
 data = json.loads(path.read_text(encoding="utf-8"))
 provider = data.setdefault("provider", {}).setdefault(provider_id, {})
 provider.setdefault("name", "WP AI Gateway")
-provider.setdefault("npm", "@ai-sdk/openai-compatible")
+if provider_id == "openai":
+    provider["npm"] = "@ai-sdk/openai"
+else:
+    provider.setdefault("npm", "@ai-sdk/openai-compatible")
 provider.setdefault("env", ["OPENAI_API_KEY"])
 provider.setdefault("options", {})
 provider["options"].setdefault("baseURL", "{env:OPENAI_BASE_URL}")

--- a/tests/ai-gateway.sh
+++ b/tests/ai-gateway.sh
@@ -181,6 +181,7 @@ with open(sys.argv[1], encoding="utf-8") as handle:
     data = json.load(handle)
 
 model = data["provider"]["openai"]["models"]["gpt-5.6-sol"]
+assert data["provider"]["openai"]["npm"] == "@ai-sdk/openai"
 assert data["model"] == "openai/gpt-5.6-sol"
 assert model["id"] == "site-default"
 PY


### PR DESCRIPTION
## Summary
- generate `@ai-sdk/openai` when the visible gateway provider is `openai`
- retain `@ai-sdk/openai-compatible` for custom provider identities
- repair previously generated OpenAI provider entries

Closes #371.

## Verification
- `bash tests/ai-gateway.sh`
- `bash tests/external-wordpress-runtime.sh`
- `bash -n lib/ai-gateway.sh tests/ai-gateway.sh`
- live OpenCode Responses tool loop through the generated `openai/gpt-5.6-sol` identity

## AI assistance
OpenAI `gpt-5.6-sol` via OpenCode diagnosed the live SDK mismatch, implemented the generator repair and regression, and verified the corrected runtime. Chris Huber reviewed and remains responsible for every line.