### PR TITLE
Skip PHP package detection when dependencies are disabled

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -222,6 +222,7 @@ jobs:
           - ci-coverage
           - codex-runtime
           - datamachine-worker
+          - detect-php-version
           - detect-site-domain
           - external-wordpress-runtime
           - dm-workspace-discovery

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -8,6 +8,12 @@ detect_php_version() {
     return
   fi
 
+  if [ "${SKIP_DEPS:-false}" = true ]; then
+    PHP_VERSION=""
+    warn "PHP is unavailable and dependency installation is disabled"
+    return
+  fi
+
   if [ "$DRY_RUN" = true ]; then
     PHP_VERSION="8.3"
     log "PHP version (dry-run assumed): $PHP_VERSION"

--- a/tests/detect-php-version.sh
+++ b/tests/detect-php-version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# PHP detection must not contact package repositories when dependencies are skipped.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+log() { :; }
+warn() { :; }
+command() {
+  if [ "$1" = -v ] && [ "$2" = php ]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+apt() {
+  printf 'apt\n' >> "$TMP/calls"
+}
+apt-cache() {
+  printf 'php8.4-fpm - server-side scripting language\n'
+}
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/detect.sh"
+
+PLATFORM=linux
+DRY_RUN=false
+SKIP_DEPS=true
+PHP_VERSION=stale
+detect_php_version
+[ -z "$PHP_VERSION" ] || { echo "FAIL: skipped detection retained a stale PHP version"; exit 1; }
+[ ! -e "$TMP/calls" ] || { echo "FAIL: skipped dependency detection invoked apt"; exit 1; }
+
+SKIP_DEPS=false
+detect_php_version
+[ "$PHP_VERSION" = 8.4 ] || { echo "FAIL: package detection did not select the available PHP version"; exit 1; }
+[ "$(cat "$TMP/calls")" = apt ] || { echo "FAIL: package detection did not refresh apt metadata"; exit 1; }
+
+echo "PASS: PHP detection honors dependency policy"


### PR DESCRIPTION
## Summary

- honor `SKIP_DEPS` before probing apt for an available PHP version
- clear any stale detected version and continue through the existing no-PHP fallback
- cover skipped and enabled package-detection branches in CI

Fixes #373.

## Verification

- `bash tests/detect-php-version.sh`
- `bash tests/external-wordpress-runtime.sh`
- `bash tests/ci-coverage.sh`
- Full `tests/*.sh` sweep reached four existing `tests/service-migration.sh` failures; all four reproduce unchanged on `main`.

## AI assistance

GPT-5.6-sol via OpenCode traced the live external-runtime failure, implemented the scoped fix, and ran the verification commands. Chris Huber reviewed and remains responsible for every line.