### PR TITLE
Bound external subagent graph reads

### DIFF
--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -24,11 +24,44 @@ opencode_project_subagents() {
   # argv-safe PHP expression and request a self-contained graph.
   if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
     local reader_code reader_payload slug_payload
+    local chunk_size=1024 offset=0 expected_size='' response reported_size encoded_chunk encoded_chunks=''
     reader_payload="$(base64 < "$graph_helper" | tr -d '\n')"
     slug_payload="$(printf '%s' "$AGENT_SLUG" | base64 | tr -d '\n')"
-    reader_code="\$args=array(base64_decode('$slug_payload'),'embedded');eval('?>'.base64_decode('$reader_payload'));"
-    agent_json="$(wp_cmd eval "$reader_code" 2>/dev/null)" || {
-      warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
+    while [ -z "$expected_size" ] || [ "$offset" -lt "$expected_size" ]; do
+      reader_code="ob_start();\$args=array(base64_decode('$slug_payload'),'embedded');eval('?>'.base64_decode('$reader_payload'));\$graph=ob_get_clean();echo json_encode(array('size'=>strlen(\$graph),'chunk'=>base64_encode(substr(\$graph,$offset,$chunk_size))));"
+      response="$(wp_cmd eval "$reader_code" 2>/dev/null)" || {
+        warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
+        return 1
+      }
+      IFS=$'\t' read -r reported_size encoded_chunk < <(printf '%s' "$response" | python3 -c '
+import json, sys
+value = json.load(sys.stdin)
+size, chunk = value.get("size"), value.get("chunk")
+if not isinstance(size, int) or size < 0 or size > 4 * 1024 * 1024 or not isinstance(chunk, str):
+    raise SystemExit(1)
+print(f"{size}\t{chunk}")
+') || {
+        warn "External subagent graph returned an invalid chunk"
+        return 1
+      }
+      if [ -z "$expected_size" ]; then
+        expected_size="$reported_size"
+      elif [ "$reported_size" != "$expected_size" ]; then
+        warn "External subagent graph changed during chunked transfer"
+        return 1
+      fi
+      encoded_chunks+="$encoded_chunk"$'\n'
+      offset=$((offset + chunk_size))
+    done
+    agent_json="$(printf '%s' "$encoded_chunks" | python3 -c '
+import base64, sys
+expected = int(sys.argv[1])
+value = b"".join(base64.b64decode(line, validate=True) for line in sys.stdin.buffer.read().splitlines())
+if len(value) != expected:
+    raise SystemExit(1)
+sys.stdout.buffer.write(value)
+' "$expected_size")" || {
+      warn "External subagent graph transfer was incomplete"
       return 1
     }
   else

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -64,9 +64,15 @@ case "$5:$6" in
     esac
     printf '%s' "$4" | grep -F "\$args=array(base64_decode('" >/dev/null || { echo "wp eval did not initialize reader arguments" >&2; exit 9; }
     printf '%s' "$4" | grep -F "'),'embedded');eval('?>'.base64_decode('" >/dev/null || { echo "wp eval did not execute embedded source" >&2; exit 9; }
-    python3 - "$WP_TEST_GRAPH" <<'PY'
-import sys
-sys.stdout.write(open(sys.argv[1]).read())
+    python3 - "$WP_TEST_GRAPH" "$4" <<'PY'
+import base64, json, os, re, sys
+value = open(sys.argv[1], "rb").read()
+match = re.search(r"substr\(\$graph,(\d+),(\d+)\)", sys.argv[2])
+if not match:
+    raise SystemExit("chunk bounds missing from graph reader")
+offset, length = map(int, match.groups())
+size = len(value) + (1 if offset and os.environ.get("WP_TEST_GRAPH_SIZE_DRIFT") == "1" else 0)
+sys.stdout.write(json.dumps({"size": size, "chunk": base64.b64encode(value[offset:offset + length]).decode()}))
 PY
     ;;
 esac
@@ -177,6 +183,17 @@ writer = root.joinpath(".opencode/agents/writer.md").read_text()
 assert '"task":{"*":"deny","reviewer":"allow"}' in writer
 PY
 grep -x 'eval' "$ARGS" >/dev/null || { echo "FAIL: external graph reader did not use wp eval"; exit 1; }
+[ "$(grep -xc 'eval' "$ARGS")" -gt 1 ] || { echo "FAIL: external graph reader did not use bounded chunks"; exit 1; }
+
+before_drift="$(cksum "$RUNTIME_PROJECT_ROOT/.opencode/agents/writer.md" "$RUNTIME_PROJECT_ROOT/.opencode/.wp-coding-agents-subagents.json")"
+export WP_TEST_GRAPH_SIZE_DRIFT=1
+if opencode_project_subagents; then
+  echo "FAIL: graph size drift was accepted"
+  exit 1
+fi
+unset WP_TEST_GRAPH_SIZE_DRIFT
+after_drift="$(cksum "$RUNTIME_PROJECT_ROOT/.opencode/agents/writer.md" "$RUNTIME_PROJECT_ROOT/.opencode/.wp-coding-agents-subagents.json")"
+[ "$before_drift" = "$after_drift" ] || { echo "FAIL: graph size drift mutated projected files"; exit 1; }
 
 while IFS= read -r argument; do
   case "$argument" in


### PR DESCRIPTION
## Summary

- transfer external WordPress subagent graphs through deterministic 1 KiB application-level chunks
- validate stable graph size, a 4 MiB aggregate ceiling, base64 integrity, and exact reconstruction before projection
- fail without mutating projected files when the graph changes during transfer

Fixes #375.

## Verification

- `bash tests/external-wordpress-runtime.sh`
- `bash tests/detect-php-version.sh`
- `bash -n lib/opencode-subagents.sh tests/external-wordpress-runtime.sh`
- `git diff --check`

## AI assistance

GPT-5.6-sol via OpenCode recovered the established relay evidence, diagnosed the single-response graph boundary, implemented bounded graph reconstruction, and ran verification. Chris Huber reviewed and remains responsible for every line.