### PR TITLE
Retry stalled external graph reads

### DIFF
--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -1,6 +1,41 @@
 #!/bin/bash
 # Project Data Machine's persisted portable agent graph for OpenCode.
 
+opencode_external_graph_eval() {
+  local reader_code="$1"
+  local timeout_seconds="${OPENCODE_EXTERNAL_GRAPH_TIMEOUT_SECONDS:-120}"
+  local response_file pid elapsed status attempt
+  case "$timeout_seconds" in
+    ''|*[!0-9]*) timeout_seconds=120 ;;
+  esac
+  [ "$timeout_seconds" -gt 0 ] || timeout_seconds=120
+  response_file="$(mktemp)" || return 1
+  for attempt in 1 2 3; do
+    : > "$response_file"
+    wp_cmd eval "$reader_code" > "$response_file" 2>/dev/null &
+    pid=$!
+    elapsed=0
+    while kill -0 "$pid" 2>/dev/null; do
+      if [ "$elapsed" -ge "$timeout_seconds" ]; then
+        kill "$pid" 2>/dev/null || true
+        sleep 1
+        kill -9 "$pid" 2>/dev/null || true
+        break
+      fi
+      sleep 1
+      elapsed=$((elapsed + 1))
+    done
+    if wait "$pid" 2>/dev/null; then status=0; else status=$?; fi
+    if [ "$status" -eq 0 ]; then
+      cat "$response_file"
+      rm -f "$response_file"
+      return 0
+    fi
+  done
+  rm -f "$response_file"
+  return 1
+}
+
 opencode_project_subagents() {
   [ "${DRY_RUN:-false}" = true ] && return 0
   local runtime has_opencode=false
@@ -29,7 +64,7 @@ opencode_project_subagents() {
     slug_payload="$(printf '%s' "$AGENT_SLUG" | base64 | tr -d '\n')"
     while [ -z "$expected_size" ] || [ "$offset" -lt "$expected_size" ]; do
       reader_code="ob_start();\$args=array(base64_decode('$slug_payload'),'embedded');eval('?>'.base64_decode('$reader_payload'));\$graph=ob_get_clean();echo json_encode(array('size'=>strlen(\$graph),'chunk'=>base64_encode(substr(\$graph,$offset,$chunk_size))));"
-      response="$(wp_cmd eval "$reader_code" 2>/dev/null)" || {
+      response="$(opencode_external_graph_eval "$reader_code")" || {
         warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
         return 1
       }

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -64,6 +64,10 @@ case "$5:$6" in
     esac
     printf '%s' "$4" | grep -F "\$args=array(base64_decode('" >/dev/null || { echo "wp eval did not initialize reader arguments" >&2; exit 9; }
     printf '%s' "$4" | grep -F "'),'embedded');eval('?>'.base64_decode('" >/dev/null || { echo "wp eval did not execute embedded source" >&2; exit 9; }
+    if [ "${WP_TEST_GRAPH_HANG_ONCE:-}" = 1 ] && [ ! -e "$WP_TEST_GRAPH_HANG_MARKER" ]; then
+      touch "$WP_TEST_GRAPH_HANG_MARKER"
+      sleep 10
+    fi
     python3 - "$WP_TEST_GRAPH" "$4" <<'PY'
 import base64, json, os, re, sys
 value = open(sys.argv[1], "rb").read()
@@ -194,6 +198,13 @@ fi
 unset WP_TEST_GRAPH_SIZE_DRIFT
 after_drift="$(cksum "$RUNTIME_PROJECT_ROOT/.opencode/agents/writer.md" "$RUNTIME_PROJECT_ROOT/.opencode/.wp-coding-agents-subagents.json")"
 [ "$before_drift" = "$after_drift" ] || { echo "FAIL: graph size drift mutated projected files"; exit 1; }
+
+export WP_TEST_GRAPH_HANG_ONCE=1
+export WP_TEST_GRAPH_HANG_MARKER="$TMP/graph-hung-once"
+export OPENCODE_EXTERNAL_GRAPH_TIMEOUT_SECONDS=1
+opencode_project_subagents
+unset WP_TEST_GRAPH_HANG_ONCE WP_TEST_GRAPH_HANG_MARKER OPENCODE_EXTERNAL_GRAPH_TIMEOUT_SECONDS
+[ -e "$TMP/graph-hung-once" ] || { echo "FAIL: graph retry fixture did not exercise its timeout"; exit 1; }
 
 while IFS= read -r argument; do
   case "$argument" in


### PR DESCRIPTION
## Summary

- enforce a process-level deadline around each deterministic external graph chunk
- retry failed or stalled chunk reads up to three times
- cover a forced first-attempt hang and successful reconstruction

Follow-up for #375.

## Verification

- `bash tests/external-wordpress-runtime.sh`
- `bash -n lib/opencode-subagents.sh tests/external-wordpress-runtime.sh`
- `git diff --check`

## AI assistance

GPT-5.6-sol via OpenCode identified the live stalled-response boundary, implemented bounded retries, and ran verification. Chris Huber reviewed and remains responsible for every line.