### PR TITLE
Fix hanging Kimaki version probe

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -230,6 +230,7 @@ jobs:
           - homeboy-components
           - homeboy-dmc-provider
           - homeboy-project-id
+          - kimaki-install-existing
           - kimaki-launchd-start
           - kimaki-managed-plugin-rig
           - kimaki-multi-instance

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -165,7 +165,7 @@ bridge_install() {
   if ! command -v kimaki &> /dev/null || [ "$DRY_RUN" = true ]; then
     run_cmd npm install -g kimaki
   else
-    log "Kimaki already installed: $(kimaki --version 2>/dev/null | head -1)"
+    log "Kimaki already installed: $(command -v kimaki)"
   fi
 
   if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then

--- a/tests/kimaki-install-existing.sh
+++ b/tests/kimaki-install-existing.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# An installed Kimaki may keep running after printing --version. Detection must
+# not launch it just to decorate setup logs.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/kimaki" <<'SH'
+#!/bin/sh
+if [ "${1:-}" = --version ]; then
+  touch "$TEST_TMP/version-invoked"
+  sleep 30
+fi
+SH
+chmod +x "$TMP/bin/kimaki"
+
+export TEST_TMP="$TMP"
+export PATH="$TMP/bin:/usr/bin:/bin"
+export DRY_RUN=false
+export EXTERNAL_WORDPRESS=true
+export LOCAL_MODE=false
+export PLATFORM=linux
+
+log() { :; }
+run_cmd() { "$@"; }
+external_wordpress_kimaki_command() { printf 'kimaki'; }
+
+source "$ROOT/bridges/kimaki.sh"
+_kimaki_sync_bin_helpers() { :; }
+
+bridge_install
+test ! -e "$TMP/version-invoked"
+
+echo "PASS: tests/kimaki-install-existing.sh"


### PR DESCRIPTION
Fixes #378.

## Changes

- Treat `command -v kimaki` as the installed-binary proof instead of launching `kimaki --version` for log decoration.
- Add a fixture whose version command hangs and prove setup never invokes it.
- Wire the regression into the complete shell matrix.

## Verification

- `bash tests/kimaki-install-existing.sh`
- `bash tests/ci-coverage.sh`
- `bash -n bridges/kimaki.sh tests/kimaki-install-existing.sh`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the live SecEx process tree, isolated the stuck version probe, and implemented the minimal fix and regression coverage. Chris Huber directed the work and remains responsible for every line.