### PR TITLE
Seed external Kimaki credentials through the managed adapter

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -230,6 +230,7 @@ jobs:
           - homeboy-components
           - homeboy-dmc-provider
           - homeboy-project-id
+          - kimaki-credential-seeding
           - kimaki-install-existing
           - kimaki-launchd-start
           - kimaki-managed-plugin-rig

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -169,6 +169,7 @@ bridge_install() {
   fi
 
   if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
+    _kimaki_seed_external_credential
     log "External WordPress profile: Kimaki installed. Start it from the runtime environment with:"
     log "  WP_CONTROL_TRANSPORT_JSON='<argv-json>' $(external_wordpress_kimaki_command)"
   elif [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
@@ -184,6 +185,17 @@ bridge_install() {
   [ "${EXTERNAL_WORDPRESS:-false}" != true ] || return 0
   _kimaki_register_cli_channel
   _kimaki_register_runtime_signature
+}
+
+_kimaki_seed_external_credential() {
+  [ -n "${KIMAKI_BOT_TOKEN:-}" ] || return 0
+  [ -n "${KIMAKI_DATA_DIR:-}" ] || error "KIMAKI_DATA_DIR is required to seed an external Kimaki credential"
+
+  local helper
+  helper="$(external_wordpress_kimaki_credential_command)"
+  [ "${DRY_RUN:-false}" = true ] || [ -x "$helper" ] || error "Managed Kimaki credential helper is unavailable: $helper"
+  run_cmd node "$helper"
+  log "External Kimaki credential configured"
 }
 
 # _kimaki_register_cli_channel

--- a/lib/external-wordpress.sh
+++ b/lib/external-wordpress.sh
@@ -13,6 +13,10 @@ external_wordpress_kimaki_command() {
   printf '%s' "$(runtime_project_root)/.wp-coding-agents/bin/kimaki"
 }
 
+external_wordpress_kimaki_credential_command() {
+  printf '%s' "$(runtime_project_root)/.wp-coding-agents/bin/kimaki-seed-credential"
+}
+
 external_wordpress_prepare_transport() {
   [ "${EXTERNAL_WORDPRESS:-false}" = true ] || return 0
   [ -n "${RUNTIME_PROJECT_ROOT:-}" ] || error "--external-wordpress requires --runtime-project-root or RUNTIME_PROJECT_ROOT"
@@ -37,9 +41,10 @@ PY
   if [ "${DRY_RUN:-false}" != true ]; then
     mkdir -p "$RUNTIME_PROJECT_ROOT"
     RUNTIME_PROJECT_ROOT=$(cd "$RUNTIME_PROJECT_ROOT" && pwd)
-    local control_dir control_command kimaki_command profile_file
+    local control_dir control_command kimaki_command kimaki_credential_command profile_file
     control_command="$(external_wordpress_control_command)"
     kimaki_command="$(external_wordpress_kimaki_command)"
+    kimaki_credential_command="$(external_wordpress_kimaki_credential_command)"
     control_dir="${control_command%/*}"
     profile_file="$(runtime_project_root)/.wp-coding-agents/wordpress.json"
     if [ -L "$(runtime_project_root)/.wp-coding-agents" ]; then
@@ -48,8 +53,10 @@ PY
     mkdir -p "$control_dir"
     cp "$SCRIPT_DIR/scripts/wp-control-transport.py" "$control_command"
     cp "$SCRIPT_DIR/scripts/external-wordpress-kimaki.py" "$kimaki_command"
+    cp "$SCRIPT_DIR/scripts/seed-kimaki-credential.mjs" "$kimaki_credential_command"
     chmod 0755 "$control_command"
     chmod 0755 "$kimaki_command"
+    chmod 0755 "$kimaki_credential_command"
     python3 - "$profile_file" "$WORDPRESS_PATH" "${WORDPRESS_USER:-}" <<'PY'
 import json, sys
 path, wordpress_path, wordpress_user = sys.argv[1:]

--- a/scripts/seed-kimaki-credential.mjs
+++ b/scripts/seed-kimaki-credential.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const token = process.env.KIMAKI_BOT_TOKEN ?? "";
+if (!token) {
+  throw new Error("KIMAKI_BOT_TOKEN is required");
+}
+if (!process.env.KIMAKI_DATA_DIR) {
+  throw new Error("KIMAKI_DATA_DIR is required");
+}
+
+let packageRoot = process.env.KIMAKI_PACKAGE_ROOT;
+if (!packageRoot) {
+  const npmRoot = execFileSync("npm", ["root", "-g"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  packageRoot = path.join(npmRoot, "kimaki", "dist");
+}
+
+const { setDataDir } = await import(
+  pathToFileURL(path.join(packageRoot, "config.js"))
+);
+const { initDatabase, setBotMode, setBotToken } = await import(
+  pathToFileURL(path.join(packageRoot, "database.js"))
+);
+
+setDataDir(process.env.KIMAKI_DATA_DIR);
+await initDatabase();
+
+const separator = token.indexOf(":");
+if (separator > 0 && separator < token.length - 1) {
+  await setBotMode({
+    appId: process.env.KIMAKI_GATEWAY_APP_ID ?? "1477605701202481173",
+    clientId: token.slice(0, separator),
+    clientSecret: token.slice(separator + 1),
+    mode: "gateway",
+    proxyUrl:
+      process.env.KIMAKI_GATEWAY_PROXY_REST_URL ??
+      "https://slack-gateway.kimaki.dev",
+  });
+} else {
+  const [encodedAppId] = token.split(".", 1);
+  const appId =
+    process.env.KIMAKI_BOT_APP_ID ??
+    Buffer.from(encodedAppId, "base64").toString("utf8");
+  if (!/^\d{17,20}$/.test(appId)) {
+    throw new Error("KIMAKI_BOT_TOKEN does not contain a valid application ID");
+  }
+  await setBotToken(appId, token);
+}

--- a/setup.sh
+++ b/setup.sh
@@ -420,10 +420,15 @@ ENVIRONMENT VARIABLES:
   AI_GATEWAY_API_MODEL_ID    Model ID sent to WP AI Gateway
   AI_GATEWAY_SITE_URL        Public site URL for OPENAI_BASE_URL override
   WITH_CLAUDE_CODE_AUTH      false to skip direct OpenCode Claude Pro/Max auth
-  KIMAKI_BOT_TOKEN          Discord bot token (skip interactive setup)
+  KIMAKI_BOT_TOKEN          Bot token or gateway clientId:clientSecret
+                            (skip interactive setup)
   KIMAKI_UNIT               Kimaki systemd unit (default: kimaki.service)
   KIMAKI_DATA_DIR           Kimaki state directory
   KIMAKI_LOCK_PORT          Kimaki lock port
+  KIMAKI_PACKAGE_ROOT       Kimaki dist directory used for external credential setup
+  KIMAKI_GATEWAY_APP_ID     Gateway application ID override
+  KIMAKI_GATEWAY_PROXY_REST_URL
+                            Gateway REST URL override
   TELEGRAM_BOT_TOKEN        Telegram bot token from @BotFather (--chat telegram)
   TELEGRAM_ALLOWED_USER_ID  Numeric Telegram user ID (--chat telegram)
   OPENCODE_MODEL_PROVIDER   Default model provider for Telegram bot (default: opencode)

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -144,6 +144,7 @@ opencode_project_subagents
 [ "$(cat "$RUNTIME_PROJECT_ROOT/.wp-coding-agents/context/agent/SOUL.md")" = "agent context" ] || { echo "FAIL: agent context not projected"; exit 1; }
 [ -f "$RUNTIME_PROJECT_ROOT/.opencode/skills/upgrade-wp-coding-agents/SKILL.md" ] || { echo "FAIL: skills were not installed below runtime root"; exit 1; }
 [ -f "$RUNTIME_PROJECT_ROOT/.kimaki/kimaki-config/plugins/dm-context-filter.ts" ] || { echo "FAIL: Kimaki config was not installed below runtime root"; exit 1; }
+[ -x "$RUNTIME_PROJECT_ROOT/.wp-coding-agents/bin/kimaki-seed-credential" ] || { echo "FAIL: managed Kimaki credential helper was not installed"; exit 1; }
 [ ! -e "$RUNTIME_PROJECT_ROOT/wp-content" ] || { echo "FAIL: WordPress-side files were written below runtime root"; exit 1; }
 [ -L "$RUNTIME_PROJECT_ROOT/.wp-coding-agents/context" ] || { echo "FAIL: projected context is not atomically activated"; exit 1; }
 [ -f "$RUNTIME_PROJECT_ROOT/.opencode/agents/writer.md" ] || { echo "FAIL: embedded writer was not projected"; exit 1; }

--- a/tests/kimaki-credential-seeding.sh
+++ b/tests/kimaki-credential-seeding.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PACKAGE_ROOT="$TMP/kimaki/dist"
+mkdir -p "$PACKAGE_ROOT"
+
+cat > "$TMP/kimaki/package.json" <<'JSON'
+{"type":"module"}
+JSON
+cat > "$PACKAGE_ROOT/config.js" <<'JS'
+export function setDataDir(value) {
+  globalThis.dataDir = value;
+}
+JS
+cat > "$PACKAGE_ROOT/database.js" <<'JS'
+import { writeFile } from "node:fs/promises";
+
+export async function initDatabase() {
+  globalThis.initialized = true;
+}
+export async function setBotMode(value) {
+  await writeFile(process.env.TEST_RESULT, JSON.stringify({
+    operation: "gateway",
+    dataDir: globalThis.dataDir,
+    initialized: globalThis.initialized,
+    value,
+  }));
+}
+export async function setBotToken(appId, token) {
+  await writeFile(process.env.TEST_RESULT, JSON.stringify({
+    operation: "bot",
+    dataDir: globalThis.dataDir,
+    initialized: globalThis.initialized,
+    appId,
+    token,
+  }));
+}
+JS
+
+export KIMAKI_PACKAGE_ROOT="$PACKAGE_ROOT"
+export KIMAKI_DATA_DIR="$TMP/state"
+export TEST_RESULT="$TMP/result.json"
+
+gateway_token='gateway-client:gateway-secret'
+export KIMAKI_BOT_TOKEN="$gateway_token"
+output="$(node "$ROOT/scripts/seed-kimaki-credential.mjs" 2>&1)"
+[ -z "$output" ] || { echo "FAIL: credential helper produced output"; exit 1; }
+python3 - "$TEST_RESULT" "$KIMAKI_DATA_DIR" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+assert data == {
+    "operation": "gateway",
+    "dataDir": sys.argv[2],
+    "initialized": True,
+    "value": {
+        "appId": "1477605701202481173",
+        "clientId": "gateway-client",
+        "clientSecret": "gateway-secret",
+        "mode": "gateway",
+        "proxyUrl": "https://slack-gateway.kimaki.dev",
+    },
+}
+PY
+
+bot_token="$(printf '123456789012345678' | base64 | tr -d '\n').fixture.signature"
+export KIMAKI_BOT_TOKEN="$bot_token"
+output="$(node "$ROOT/scripts/seed-kimaki-credential.mjs" 2>&1)"
+[ -z "$output" ] || { echo "FAIL: credential helper produced output"; exit 1; }
+python3 - "$TEST_RESULT" "$KIMAKI_DATA_DIR" "$bot_token" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+assert data == {
+    "operation": "bot",
+    "dataDir": sys.argv[2],
+    "initialized": True,
+    "appId": "123456789012345678",
+    "token": sys.argv[3],
+}
+PY
+
+unset KIMAKI_BOT_TOKEN
+if node "$ROOT/scripts/seed-kimaki-credential.mjs" >"$TMP/missing.out" 2>"$TMP/missing.err"; then
+  echo "FAIL: missing credential was accepted"
+  exit 1
+fi
+grep -F 'KIMAKI_BOT_TOKEN is required' "$TMP/missing.err" >/dev/null
+
+# The external bridge owns invocation; callers only supply the credential and
+# selected Kimaki data directory.
+mkdir -p "$TMP/runtime/.wp-coding-agents/bin" "$TMP/bin"
+cp "$ROOT/scripts/seed-kimaki-credential.mjs" \
+  "$TMP/runtime/.wp-coding-agents/bin/kimaki-seed-credential"
+chmod +x "$TMP/runtime/.wp-coding-agents/bin/kimaki-seed-credential"
+cat > "$TMP/bin/kimaki" <<'SH'
+#!/bin/sh
+exit 0
+SH
+chmod +x "$TMP/bin/kimaki"
+
+export PATH="$TMP/bin:$PATH"
+export RUNTIME_PROJECT_ROOT="$TMP/runtime"
+export KIMAKI_BOT_TOKEN="$gateway_token"
+export EXTERNAL_WORDPRESS=true LOCAL_MODE=true DRY_RUN=false
+export SERVICE_HOME="$TMP/home"
+UPDATED_ITEMS=()
+log() { printf '%s\n' "$*" >> "$TMP/bridge.log"; }
+run_cmd() { "$@"; }
+error() { printf '%s\n' "$*" >&2; return 1; }
+external_wordpress_kimaki_command() { printf '%s' "$TMP/runtime/.wp-coding-agents/bin/kimaki"; }
+external_wordpress_kimaki_credential_command() { printf '%s' "$TMP/runtime/.wp-coding-agents/bin/kimaki-seed-credential"; }
+
+# shellcheck disable=SC1091
+source "$ROOT/bridges/kimaki.sh"
+_kimaki_sync_bin_helpers() { :; }
+rm -f "$TEST_RESULT"
+bridge_install
+python3 - "$TEST_RESULT" <<'PY'
+import json, sys
+assert json.load(open(sys.argv[1]))["operation"] == "gateway"
+PY
+if grep -F "$gateway_token" "$TMP/bridge.log" >/dev/null; then
+  echo "FAIL: bridge logged the gateway credential"
+  exit 1
+fi
+
+echo "PASS: tests/kimaki-credential-seeding.sh"


### PR DESCRIPTION
## Summary

- install a managed `kimaki-seed-credential` helper in external runtime profiles
- materialize supplied gateway or installed-bot credentials during Kimaki bridge setup
- keep credential values out of command arguments and output
- cover both credential shapes and the external-runtime installation contract

Closes #380.

## Verification

- `bash tests/kimaki-credential-seeding.sh`
- `bash tests/external-wordpress-runtime.sh`
- `bash tests/ci-coverage.sh`
- shell and Node syntax checks

`tests/verify.sh` continues to fail identically on unmodified `origin/main` because its healthy owned-mode fixture reports `runtime source-policy marker` missing; this patch does not touch that checker.

## AI assistance

GPT-5.6 Sol in OpenCode was used to inspect the external-runtime integration, implement the managed adapter and tests, and run verification. Chris Huber directed and reviewed the change.