### PR TITLE
Add durable inbound event bridge

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -79,6 +79,16 @@ jobs:
       - name: Run tests/smoke-cli-transport.php
         run: php tests/smoke-cli-transport.php
 
+  inbound-event-bridge:
+    name: durable inbound event bridge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/inbound-event-bridge.sh
+        run: bash tests/inbound-event-bridge.sh
+      - name: Run tests/smoke-inbound-event-bridge.php
+        run: php tests/smoke-inbound-event-bridge.php
+
   cli-channel-registry:
     name: CLI channel registry permissions
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -458,6 +458,10 @@ Kimaki is the Discord surface for OpenCode. Managed installs replace Kimaki's ge
 
 Kimaki-specific OpenCode plugins are synced into Kimaki's config directory and restored across package updates. The managed-plugin rig verifies that contract:
 
+Inbound events queue independently of a runtime. The queue intentionally has no Kimaki connector: the supported Kimaki CLI proves outbound `send --channel <id> --prompt <text>`, but not inbound event injection or a durable conversation-to-runtime mapping. A connector can be added only after that contract exists; missing mappings fail closed.
+
+The optional signed Slack adapter is configured through the inbound adapter config filter or constant with a signing secret, runtime ID, and explicit `allowed_team_ids` plus `allowed_channel_ids` allowlists.
+
 ```bash
 bash tests/kimaki-managed-plugin-rig.sh
 ```

--- a/lib/inbound-event-bridge.sh
+++ b/lib/inbound-event-bridge.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Generated durable inbound event bridge installer.
+
+inbound_event_bridge_mu_plugin_path() {
+  [ -n "${SITE_PATH:-}" ] || return 1
+  printf '%s' "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-inbound-events.php"
+}
+
+inbound_event_bridge_install() {
+  local file template dir
+  file="$(inbound_event_bridge_mu_plugin_path)" || { warn "  inbound_event_bridge_install: SITE_PATH not set — skipping"; return 1; }
+  template="$SCRIPT_DIR/templates/wp-coding-agents-inbound-events.php"
+  [ -f "$template" ] || { warn "  inbound_event_bridge_install: missing template $template"; return 1; }
+  dir="${file%/*}"
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would sync inbound event bridge mu-plugin to $file"
+    return 0
+  fi
+  mkdir -p "$dir"
+  if [ ! -f "$file" ] || ! cmp -s "$template" "$file"; then
+    cp "$template" "$file"
+    log "  Synced inbound event bridge mu-plugin: $file"
+    [ -z "${UPDATED_ITEMS+x}" ] || UPDATED_ITEMS+=("Inbound event bridge")
+  fi
+  service_file_normalize_perms "$file"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect source-policy owned-source-discovery wordpress external-wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance opencode-subagents; do
+for lib in common detect source-policy owned-source-discovery wordpress external-wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance opencode-subagents; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -594,7 +594,7 @@ runtime_generate_instructions
 opencode_project_subagents
 runtime_merge_mcp_servers
 install_skills
-if [ "$EXTERNAL_WORDPRESS" != true ]; then cli_transport_install; runtime_guard_sync; fi
+if [ "$EXTERNAL_WORDPRESS" != true ]; then cli_transport_install; inbound_event_bridge_install; runtime_guard_sync; fi
 # Install the reconciler, then run it once so a fresh install converges the same
 # way a live change will.
 if [ "$EXTERNAL_WORDPRESS" != true ]; then source_reconcile_sync; source_reconcile_run; fi

--- a/templates/wp-coding-agents-inbound-events.php
+++ b/templates/wp-coding-agents-inbound-events.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Plugin Name: wp-coding-agents - inbound event bridge
+ * Description: Durable, provider-neutral ingress queue for signed inbound events. Managed by wp-coding-agents.
+ *
+ * Adapters register through `wp_coding_agents_inbound_event_adapters`. Each
+ * adapter receives a WP_REST_Request and must authenticate it before returning
+ * either a WP_Error, an immediate `response`, or a normalized event array:
+ * source, external_id, type, conversation_id, runtime_id, message. Authentication material
+ * remains in the request and is never passed to the queue or diagnostics.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WpCodingAgents_Inbound_Events', false ) ) {
+	class WpCodingAgents_Inbound_Events {
+		private const TABLE_SUFFIX = 'wp_coding_agents_inbound_events';
+		private const SCHEMA_VERSION = 1;
+		private const SCHEMA_OPTION = 'wp_coding_agents_inbound_events_schema';
+		private const LEASE_SECONDS = 300;
+
+		public static function register(): void {
+			add_action( 'rest_api_init', array( self::class, 'routes' ) );
+			add_action( 'plugins_loaded', array( self::class, 'install' ) );
+			add_action( 'wp_coding_agents_runtime_wake', array( self::class, 'wake_runtime' ), 10, 2 );
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				WP_CLI::add_command( 'coding-agents inbound', array( self::class, 'cli' ) );
+			}
+		}
+
+		public static function install(): void {
+			global $wpdb;
+			if ( ! isset( $wpdb ) || ! isset( $wpdb->prefix ) ) { return; }
+			if ( (int) get_option( self::SCHEMA_OPTION, 0 ) >= self::SCHEMA_VERSION ) { return; }
+			$table = self::table();
+			$charset = method_exists( $wpdb, 'get_charset_collate' ) ? $wpdb->get_charset_collate() : '';
+			$sql = "CREATE TABLE {$table} (id bigint unsigned NOT NULL AUTO_INCREMENT, source varchar(64) NOT NULL, external_id varchar(191) NOT NULL, envelope longtext NOT NULL, status varchar(16) NOT NULL DEFAULT 'queued', attempts int unsigned NOT NULL DEFAULT 0, available_at datetime NOT NULL, lease_token varchar(64) NULL, lease_expires_at datetime NULL, created_at datetime NOT NULL, updated_at datetime NOT NULL, PRIMARY KEY (id), UNIQUE KEY source_external (source, external_id), KEY claim (status, available_at, lease_expires_at)) {$charset};";
+			if ( ! function_exists( 'dbDelta' ) ) { require_once ABSPATH . 'wp-admin/includes/upgrade.php'; }
+			dbDelta( $sql );
+			if ( $table === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) ) {
+				update_option( self::SCHEMA_OPTION, self::SCHEMA_VERSION, false );
+			}
+		}
+
+		public static function routes(): void {
+			register_rest_route( 'wp-coding-agents/v1', '/inbound/(?P<adapter>[a-z0-9_-]+)', array(
+				'methods' => 'POST', 'callback' => array( self::class, 'ingress' ), 'permission_callback' => '__return_true',
+			) );
+		}
+
+		/** The adapter owns signature verification and URL-verification replies. */
+		public static function ingress( WP_REST_Request $request ) {
+			$adapters = apply_filters( 'wp_coding_agents_inbound_event_adapters', array(), $request );
+			$adapter = $adapters[ $request['adapter'] ] ?? null;
+			if ( 'slack' === $request['adapter'] && ! is_callable( $adapter ) ) { $adapter = array( self::class, 'slack' ); }
+			if ( ! is_callable( $adapter ) ) { return new WP_Error( 'wp_coding_agents_inbound_unknown_adapter', 'Unknown inbound adapter.', array( 'status' => 404 ) ); }
+			$result = $adapter( $request );
+			if ( is_wp_error( $result ) ) { return $result; }
+			if ( ! is_array( $result ) ) { return new WP_Error( 'wp_coding_agents_inbound_invalid_adapter', 'Adapter returned no verified event.', array( 'status' => 400 ) ); }
+			if ( isset( $result['response'] ) ) { return rest_ensure_response( $result['response'] ); }
+			$event = self::normalize( $result );
+			if ( is_wp_error( $event ) ) { return $event; }
+			$queued = self::enqueue( $event );
+			if ( is_wp_error( $queued ) ) { return $queued; }
+			if ( $queued['new'] ) {
+				do_action( 'wp_coding_agents_inbound_event_queued', $event, $queued['id'] );
+			}
+			$wake = self::schedule_runtime_wake( $event['runtime_id'] );
+			if ( is_wp_error( $wake ) ) { return $wake; }
+			return rest_ensure_response( array( 'accepted' => true, 'duplicate' => ! $queued['new'] ) );
+		}
+
+		/** Dispatch the runtime request only from the asynchronous cron callback. */
+		public static function wake_runtime( string $runtime_id, string $wake_reason ): void {
+			do_action( 'wp_coding_agents_runtime_requested', $runtime_id, $wake_reason );
+		}
+
+		/** @return true|WP_Error */
+		private static function schedule_runtime_wake( string $runtime_id ) {
+			$hook = 'wp_coding_agents_runtime_wake';
+			$args = array( $runtime_id, 'inbound_event' );
+			if ( wp_next_scheduled( $hook, $args ) ) { return true; }
+			$scheduled = wp_schedule_single_event( time(), $hook, $args, true );
+			if ( is_wp_error( $scheduled ) || false === $scheduled ) {
+				return new WP_Error( 'wp_coding_agents_inbound_wake_unavailable', 'Inbound event queued; runtime wake will be retried.', array( 'status' => 503 ) );
+			}
+			if ( function_exists( 'spawn_cron' ) ) { spawn_cron( time() ); }
+			return true;
+		}
+
+		/** @return array<string,string>|WP_Error */
+		public static function normalize( array $event ) {
+			$normalized = array();
+			foreach ( array( 'source', 'external_id', 'type', 'conversation_id', 'runtime_id', 'message' ) as $key ) {
+				$value = $event[ $key ] ?? null;
+				if ( ! is_scalar( $value ) || '' === trim( (string) $value ) || strlen( (string) $value ) > 65535 ) { return new WP_Error( 'wp_coding_agents_inbound_invalid_event', 'Verified event is missing a required field.', array( 'status' => 400 ) ); }
+				$normalized[ $key ] = (string) $value;
+			}
+			if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]{0,63}$/', $normalized['source'] ) || strlen( $normalized['external_id'] ) > 191 || strlen( $normalized['runtime_id'] ) > 191 ) { return new WP_Error( 'wp_coding_agents_inbound_invalid_event', 'Verified event has invalid identifiers.', array( 'status' => 400 ) ); }
+			return $normalized;
+		}
+
+		/**
+		 * Validate and normalize Slack's signed Events API request.
+		 *
+		 * Configuration comes only from the generic adapter-config filter, or the
+		 * optional WP_CODING_AGENTS_INBOUND_EVENT_ADAPTER_CONFIG constant. Its
+ * `slack` entry contains signing_secret, runtime_id, allowed_team_ids, and
+ * allowed_channel_ids.
+		 * The connector deliberately remains absent: the installed Kimaki contract
+		 * proves outbound send only, not inbound event injection or mapping.
+		 */
+		public static function slack( WP_REST_Request $request ) {
+			$config = self::adapter_config( 'slack' );
+			$secret = $config['signing_secret'] ?? null;
+			$runtime_id = $config['runtime_id'] ?? null;
+			$allowed = $config['allowed_channel_ids'] ?? null;
+			$teams = $config['allowed_team_ids'] ?? null;
+			if ( ! is_string( $secret ) || '' === $secret || ! is_string( $runtime_id ) || '' === $runtime_id || ! self::valid_ids( $allowed, '/^[A-Z][A-Z0-9]{1,63}$/' ) || ! self::valid_ids( $teams, '/^T[A-Z0-9]{1,63}$/' ) ) { return new WP_Error( 'wp_coding_agents_inbound_not_configured', 'Inbound adapter is not configured.', array( 'status' => 404 ) ); }
+			$timestamp = $request->get_header( 'x-slack-request-timestamp' );
+			$signature = $request->get_header( 'x-slack-signature' );
+			$body = $request->get_body();
+			if ( ! ctype_digit( $timestamp ) || abs( time() - (int) $timestamp ) > 300 || ! is_string( $signature ) ) { return new WP_Error( 'wp_coding_agents_inbound_invalid_signature', 'Invalid signed request.', array( 'status' => 403 ) ); }
+			$expected = 'v0=' . hash_hmac( 'sha256', 'v0:' . $timestamp . ':' . $body, $secret );
+			if ( ! hash_equals( $expected, $signature ) ) { return new WP_Error( 'wp_coding_agents_inbound_invalid_signature', 'Invalid signed request.', array( 'status' => 403 ) ); }
+			$payload = json_decode( $body, true );
+			if ( ! is_array( $payload ) ) { return new WP_Error( 'wp_coding_agents_inbound_invalid_payload', 'Invalid event payload.', array( 'status' => 400 ) ); }
+			if ( 'url_verification' === ( $payload['type'] ?? null ) && is_string( $payload['challenge'] ?? null ) ) { return array( 'response' => array( 'challenge' => $payload['challenge'] ) ); }
+			$event = $payload['event'] ?? null;
+			if ( 'event_callback' !== ( $payload['type'] ?? null ) || ! is_array( $event ) || 'message' !== ( $event['type'] ?? null ) ) { return array( 'response' => array( 'accepted' => true ) ); }
+			$team = $payload['team_id'] ?? null;
+			if ( ! is_string( $team ) || ! preg_match( '/^T[A-Z0-9]{1,63}$/', $team ) || ! in_array( $team, $teams, true ) ) { return array( 'response' => array( 'accepted' => true ) ); }
+			if ( isset( $event['bot_id'] ) || ! empty( $event['subtype'] ) ) { return array( 'response' => array( 'accepted' => true ) ); }
+			$channel = $event['channel'] ?? null;
+			$thread = $event['thread_ts'] ?? $event['ts'] ?? null;
+			if ( ! is_string( $channel ) || ! preg_match( '/^[A-Z0-9]{1,64}$/', $channel ) || ! in_array( $channel, $allowed, true ) ) { return array( 'response' => array( 'accepted' => true ) ); }
+			if ( ! is_string( $thread ) || ! preg_match( '/^\d{1,20}\.\d{1,6}$/', $thread ) || ! is_string( $payload['event_id'] ?? null ) || ! preg_match( '/^[A-Za-z0-9_-]{1,191}$/', $payload['event_id'] ) || ! is_string( $event['text'] ?? null ) || '' === trim( $event['text'] ) ) { return new WP_Error( 'wp_coding_agents_inbound_invalid_payload', 'Invalid event payload.', array( 'status' => 400 ) ); }
+			return array( 'source' => 'slack', 'external_id' => $payload['event_id'], 'type' => 'message', 'conversation_id' => $channel . ':' . $thread, 'runtime_id' => $runtime_id, 'message' => $event['text'] );
+		}
+
+		/** @param mixed $ids */
+		private static function valid_ids( $ids, string $pattern ): bool {
+			if ( ! is_array( $ids ) || empty( $ids ) ) { return false; }
+			foreach ( $ids as $id ) { if ( ! is_string( $id ) || ! preg_match( $pattern, $id ) ) { return false; } }
+			return true;
+		}
+
+		/** @return array<string,mixed> */
+		private static function adapter_config( string $adapter ): array {
+			$config = defined( 'WP_CODING_AGENTS_INBOUND_EVENT_ADAPTER_CONFIG' ) ? constant( 'WP_CODING_AGENTS_INBOUND_EVENT_ADAPTER_CONFIG' ) : array();
+			$config = is_array( $config ) ? $config : array();
+			$config = apply_filters( 'wp_coding_agents_inbound_event_adapter_config', $config, $adapter );
+			$value = $config[ $adapter ] ?? array();
+			return is_array( $value ) ? $value : array();
+		}
+
+		/** @return array{id:int,new:bool}|WP_Error */
+		public static function enqueue( array $event ) {
+			global $wpdb;
+			$now = current_time( 'mysql', true );
+			$json = wp_json_encode( $event );
+			if ( false === $json ) { return new WP_Error( 'wp_coding_agents_inbound_encode_failed', 'Could not queue event.' ); }
+			$inserted = $wpdb->query( $wpdb->prepare( 'INSERT IGNORE INTO ' . self::table() . ' (source, external_id, envelope, available_at, created_at, updated_at) VALUES (%s, %s, %s, %s, %s, %s)', $event['source'], $event['external_id'], $json, $now, $now, $now ) );
+			if ( false === $inserted ) { return new WP_Error( 'wp_coding_agents_inbound_queue_failed', 'Could not queue event.' ); }
+			if ( 1 === $inserted ) { return array( 'id' => (int) $wpdb->insert_id, 'new' => true ); }
+			$id = $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM ' . self::table() . ' WHERE source = %s AND external_id = %s', $event['source'], $event['external_id'] ) );
+			return array( 'id' => (int) $id, 'new' => false );
+		}
+
+		/** Atomically recover stale leases and claim one available event. */
+		public static function claim(): ?array {
+			global $wpdb;
+			$now = current_time( 'mysql', true ); $token = wp_generate_uuid4(); $until = gmdate( 'Y-m-d H:i:s', time() + self::LEASE_SECONDS );
+			$wpdb->query( $wpdb->prepare( "UPDATE " . self::table() . " SET status = 'queued', lease_token = NULL, lease_expires_at = NULL, updated_at = %s WHERE status = 'leased' AND lease_expires_at < %s", $now, $now ) );
+			$row = $wpdb->get_row( $wpdb->prepare( "SELECT id FROM " . self::table() . " WHERE status = 'queued' AND available_at <= %s ORDER BY id ASC LIMIT 1", $now ), ARRAY_A );
+			if ( ! is_array( $row ) ) { return null; }
+			$changed = $wpdb->query( $wpdb->prepare( "UPDATE " . self::table() . " SET status = 'leased', lease_token = %s, lease_expires_at = %s, attempts = attempts + 1, updated_at = %s WHERE id = %d AND status = 'queued'", $token, $until, $now, $row['id'] ) );
+			if ( 1 !== $changed ) { return null; }
+			$event = $wpdb->get_row( $wpdb->prepare( 'SELECT id, envelope FROM ' . self::table() . ' WHERE id = %d AND lease_token = %s', $row['id'], $token ), ARRAY_A );
+			$envelope = is_array( $event ) ? json_decode( $event['envelope'], true ) : null;
+			return is_array( $envelope ) ? array( 'id' => (int) $row['id'], 'lease_token' => $token, 'event' => $envelope ) : null;
+		}
+
+		public static function acknowledge( int $id, string $token ): bool { global $wpdb; return 1 === $wpdb->query( $wpdb->prepare( "UPDATE " . self::table() . " SET status = 'acked', lease_token = NULL, lease_expires_at = NULL, updated_at = %s WHERE id = %d AND status = 'leased' AND lease_token = %s", current_time( 'mysql', true ), $id, $token ) ); }
+		public static function retry( int $id, string $token, int $delay = 0 ): bool { global $wpdb; $at = gmdate( 'Y-m-d H:i:s', time() + max( 0, $delay ) ); return 1 === $wpdb->query( $wpdb->prepare( "UPDATE " . self::table() . " SET status = 'queued', lease_token = NULL, lease_expires_at = NULL, available_at = %s, updated_at = %s WHERE id = %d AND status = 'leased' AND lease_token = %s", $at, current_time( 'mysql', true ), $id, $token ) ); }
+		private static function table(): string { global $wpdb; return $wpdb->prefix . self::TABLE_SUFFIX; }
+
+		public static function cli( array $args, array $assoc ): void {
+			$verb = $args[0] ?? '';
+			if ( 'claim' === $verb ) { $claim = self::claim(); $claim ? WP_CLI::print_value( $claim, array( 'format' => $assoc['format'] ?? 'json' ) ) : WP_CLI::halt( 1 ); return; }
+			$id = isset( $args[1] ) ? (int) $args[1] : 0; $token = isset( $assoc['lease-token'] ) ? (string) $assoc['lease-token'] : '';
+			$ok = 'ack' === $verb ? self::acknowledge( $id, $token ) : ( 'retry' === $verb ? self::retry( $id, $token, isset( $assoc['delay'] ) ? (int) $assoc['delay'] : 0 ) : false );
+			$ok ? WP_CLI::success( $verb . 'nowledged.' ) : WP_CLI::halt( 1 );
+		}
+	}
+}
+
+WpCodingAgents_Inbound_Events::register();

--- a/tests/ci-coverage.sh
+++ b/tests/ci-coverage.sh
@@ -85,7 +85,7 @@ fi
 
 # Non-shell suites are invoked directly by their own jobs; assert the ones that
 # exist stay wired, since they are the easiest to lose in a restructure.
-for other in tests/dm-agent-sync.mjs tests/setup-profile-compiler.mjs tests/smoke-cli-transport.php; do
+for other in tests/dm-agent-sync.mjs tests/setup-profile-compiler.mjs tests/smoke-cli-transport.php tests/smoke-inbound-event-bridge.php; do
   [ -e "$other" ] || continue
   case "$workflow_text" in
     *"$(basename "$other")"*) echo "  ok   $(basename "$other") is referenced" ;;

--- a/tests/inbound-event-bridge.sh
+++ b/tests/inbound-event-bridge.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/wp-content/mu-plugins"
+export SITE_PATH="$TMP" DRY_RUN=false
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/inbound-event-bridge.sh"
+log() { :; }
+warn() { printf '%s\n' "$1" >&2; }
+inbound_event_bridge_install
+test -f "$TMP/wp-content/mu-plugins/wp-coding-agents-inbound-events.php"
+cmp -s "$SCRIPT_DIR/templates/wp-coding-agents-inbound-events.php" "$TMP/wp-content/mu-plugins/wp-coding-agents-inbound-events.php"
+php -l "$TMP/wp-content/mu-plugins/wp-coding-agents-inbound-events.php" >/dev/null
+echo "OK: inbound event bridge installation assertions passed"

--- a/tests/smoke-inbound-event-bridge.php
+++ b/tests/smoke-inbound-event-bridge.php
@@ -1,0 +1,110 @@
+<?php
+declare( strict_types=1 );
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'ARRAY_A', 'ARRAY_A' );
+class WP_Error { public function __construct( public string $code = '', public string $message = '', public mixed $data = null ) {} }
+function is_wp_error( mixed $value ): bool { return $value instanceof WP_Error; }
+function wp_json_encode( mixed $value ): string|false { return json_encode( $value ); }
+function current_time( string $type, bool $gmt = false ): string { return gmdate( 'Y-m-d H:i:s' ); }
+function wp_generate_uuid4(): string { static $n = 0; return 'lease-' . ++$n; }
+function rest_ensure_response( mixed $value ): mixed { return $value; }
+$options = array(); $filters = array(); $actions = array(); $db_delta_calls = 0; $scheduled = array(); $schedule_calls = array(); $schedule_row_counts = array(); $schedule_fail = false; $spawn_calls = 0;
+function get_option( string $key, mixed $default = false ): mixed { global $options; return $options[ $key ] ?? $default; }
+function update_option( string $key, mixed $value, mixed $autoload = null ): bool { global $options; $options[ $key ] = $value; return true; }
+function dbDelta( string $sql ): void { global $db_delta_calls; ++$db_delta_calls; }
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted = 1 ): void {}
+function do_action( string $hook, mixed ...$args ): void { global $actions; $actions[] = array( $hook, $args ); }
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted = 1 ): void { global $filters; $filters[ $hook ][] = $callback; }
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed { global $filters; foreach ( $filters[ $hook ] ?? array() as $callback ) $value = $callback( $value, ...$args ); return $value; }
+function wp_next_scheduled( string $hook, array $args = array() ): int|false { global $scheduled; foreach ( $scheduled as $event ) if ( $event['hook'] === $hook && $event['args'] === $args ) return $event['timestamp']; return false; }
+function wp_schedule_single_event( int $timestamp, string $hook, array $args = array(), bool $wp_error = false ): bool|WP_Error { global $scheduled, $schedule_calls, $schedule_row_counts, $schedule_fail, $wpdb; $schedule_calls[] = array( $hook, $args ); $schedule_row_counts[] = count( $wpdb->rows ); if ( $schedule_fail ) return new WP_Error( 'schedule_failed' ); $scheduled[] = compact( 'timestamp', 'hook', 'args' ); return true; }
+function spawn_cron( int $timestamp = 0 ): bool { global $spawn_calls; ++$spawn_calls; return true; }
+class WP_REST_Request implements ArrayAccess {
+	public function __construct( private array $params, private array $headers, private string $body ) {}
+	public function get_header( string $name ): string { return $this->headers[ strtolower( $name ) ] ?? ''; }
+	public function get_body(): string { return $this->body; }
+	public function offsetExists( mixed $offset ): bool { return isset( $this->params[ $offset ] ); }
+	public function offsetGet( mixed $offset ): mixed { return $this->params[ $offset ] ?? null; }
+	public function offsetSet( mixed $offset, mixed $value ): void {} public function offsetUnset( mixed $offset ): void {}
+}
+
+class FakeDb {
+	public string $prefix = 'wp_'; public int $insert_id = 0; public array $rows = array();
+	public function prepare( string $query, ...$args ): string { return json_encode( array( $query, $args ) ); }
+	private function args( string $prepared ): array { return json_decode( $prepared, true )[1]; }
+	public function query( string $prepared ): int|false {
+		[$sql, $a] = json_decode( $prepared, true );
+		if ( str_starts_with( $sql, 'INSERT IGNORE' ) ) { foreach ( $this->rows as $r ) { if ( $r['source'] === $a[0] && $r['external_id'] === $a[1] ) return 0; } $this->insert_id = count( $this->rows ) + 1; $this->rows[] = array( 'id' => $this->insert_id, 'source' => $a[0], 'external_id' => $a[1], 'envelope' => $a[2], 'status' => 'queued', 'attempts' => 0, 'available_at' => $a[3], 'lease_token' => null, 'lease_expires_at' => null ); return 1; }
+		if ( str_contains( $sql, "SET status = 'queued', lease_token = NULL, lease_expires_at = NULL, updated_at") && str_contains( $sql, "lease_expires_at <") ) { foreach ( $this->rows as &$r ) if ( $r['status'] === 'leased' && $r['lease_expires_at'] < $a[1] ) { $r['status'] = 'queued'; $r['lease_token'] = null; $r['lease_expires_at'] = null; } return 1; }
+		if ( str_contains( $sql, "SET status = 'leased'" ) ) { foreach ( $this->rows as &$r ) if ( $r['id'] === (int) $a[3] && $r['status'] === 'queued' ) { $r['status'] = 'leased'; $r['lease_token'] = $a[0]; $r['lease_expires_at'] = $a[1]; ++$r['attempts']; return 1; } return 0; }
+		if ( str_contains( $sql, "SET status = 'acked'" ) ) { foreach ( $this->rows as &$r ) if ( $r['id'] === (int) $a[1] && $r['status'] === 'leased' && $r['lease_token'] === $a[2] ) { $r['status'] = 'acked'; return 1; } return 0; }
+		if ( str_contains( $sql, "SET status = 'queued', lease_token = NULL, lease_expires_at = NULL, available_at") ) { foreach ( $this->rows as &$r ) if ( $r['id'] === (int) $a[2] && $r['status'] === 'leased' && $r['lease_token'] === $a[3] ) { $r['status'] = 'queued'; $r['lease_token'] = null; return 1; } return 0; }
+		return 0;
+	}
+	public function get_var( string $prepared ): mixed { [$sql, $a] = json_decode( $prepared, true ); if ( str_starts_with( $sql, 'SHOW TABLES LIKE' ) ) return $a[0]; foreach ( $this->rows as $r ) if ( $r['source'] === $a[0] && $r['external_id'] === $a[1] ) return $r['id']; return null; }
+	public function get_row( string $prepared, mixed $format ): ?array { [$sql, $a] = json_decode( $prepared, true ); if ( str_contains( $sql, "WHERE status = 'queued'" ) ) foreach ( $this->rows as $r ) if ( $r['status'] === 'queued' ) return array( 'id' => $r['id'] ); foreach ( $this->rows as $r ) if ( $r['id'] === (int) $a[0] && $r['lease_token'] === $a[1] ) return array( 'id' => $r['id'], 'envelope' => $r['envelope'] ); return null; }
+}
+$wpdb = new FakeDb();
+require __DIR__ . '/../templates/wp-coding-agents-inbound-events.php';
+$failures = array(); $assert = static function( string $name, bool $ok ) use ( &$failures ): void { echo ($ok ? 'PASS' : 'FAIL') . ": $name\n"; if ( ! $ok ) $failures[] = $name; };
+$event = array( 'source' => 'signed-source', 'external_id' => 'event-1', 'type' => 'message', 'conversation_id' => 'conversation-1', 'runtime_id' => 'runtime-opaque-1', 'message' => 'hello' );
+$normalized = WpCodingAgents_Inbound_Events::normalize( $event );
+$assert( 'normalizes the minimal envelope', is_array( $normalized ) && $normalized === $event );
+$with_auth = WpCodingAgents_Inbound_Events::normalize( $event + array( 'signature' => 'secret', 'authorization' => 'Bearer secret' ) );
+$assert( 'normalization drops adapter authentication material', is_array( $with_auth ) && ! array_key_exists( 'signature', $with_auth ) && ! array_key_exists( 'authorization', $with_auth ) );
+$assert( 'runtime ID is required and bounded', is_wp_error( WpCodingAgents_Inbound_Events::normalize( array_diff_key( $event, array( 'runtime_id' => true ) ) ) ) && is_wp_error( WpCodingAgents_Inbound_Events::normalize( array_merge( $event, array( 'runtime_id' => str_repeat( 'x', 192 ) ) ) ) ) );
+$first = WpCodingAgents_Inbound_Events::enqueue( $event ); $second = WpCodingAgents_Inbound_Events::enqueue( $event );
+$assert( 'durably deduplicates source and external ID', $first['new'] && ! $second['new'] && $first['id'] === $second['id'] );
+$assert( 'queue record excludes adapter-only authentication material', ! str_contains( $wpdb->rows[0]['envelope'], 'signature' ) );
+$claim = WpCodingAgents_Inbound_Events::claim();
+$assert( 'claims an available event with a lease token', is_array( $claim ) && $claim['event'] === $event && '' !== $claim['lease_token'] );
+$assert( 'second claimant cannot take an active lease', null === WpCodingAgents_Inbound_Events::claim() );
+$assert( 'wrong lease token cannot acknowledge', ! WpCodingAgents_Inbound_Events::acknowledge( $claim['id'], 'wrong' ) );
+$assert( 'lease owner can retry', WpCodingAgents_Inbound_Events::retry( $claim['id'], $claim['lease_token'] ) );
+$retry = WpCodingAgents_Inbound_Events::claim();
+$assert( 'retried event is claimable again', is_array( $retry ) && 2 === $wpdb->rows[0]['attempts'] );
+$wpdb->rows[0]['lease_expires_at'] = '2000-01-01 00:00:00';
+$recovered = WpCodingAgents_Inbound_Events::claim();
+$assert( 'stale lease is recovered before a new claim', is_array( $recovered ) && 3 === $wpdb->rows[0]['attempts'] );
+$assert( 'lease owner can acknowledge exactly once', WpCodingAgents_Inbound_Events::acknowledge( $recovered['id'], $recovered['lease_token'] ) && ! WpCodingAgents_Inbound_Events::acknowledge( $recovered['id'], $recovered['lease_token'] ) );
+WpCodingAgents_Inbound_Events::install(); WpCodingAgents_Inbound_Events::install();
+$assert( 'schema installation is version-gated', 1 === $db_delta_calls );
+
+add_filter( 'wp_coding_agents_inbound_event_adapter_config', static function( array $config, string $adapter ): array { $config['slack'] = array( 'signing_secret' => 'test-signing-secret', 'runtime_id' => 'opaque-runtime-id', 'allowed_team_ids' => array( 'T123' ), 'allowed_channel_ids' => array( 'C123' ) ); return $config; } );
+$payload = json_encode( array( 'type' => 'event_callback', 'team_id' => 'T123', 'event_id' => 'slack-event-1', 'event' => array( 'type' => 'message', 'channel' => 'C123', 'ts' => '1710000000.000001', 'text' => 'signed hello' ) ) );
+$timestamp = (string) time(); $signature = 'v0=' . hash_hmac( 'sha256', 'v0:' . $timestamp . ':' . $payload, 'test-signing-secret' );
+$request = new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $timestamp, 'x-slack-signature' => $signature ), $payload );
+$response = WpCodingAgents_Inbound_Events::ingress( $request );
+$assert( 'signed Slack event is acknowledged after durable queue insertion', is_array( $response ) && true === $response['accepted'] && 2 === count( $wpdb->rows ) );
+$assert( 'queue is durable before runtime wake scheduling', array( 2 ) === $schedule_row_counts && 1 === count( $schedule_calls ) );
+$assert( 'ingress does not synchronously execute the runtime action', 1 === count( $actions ) && 'wp_coding_agents_inbound_event_queued' === $actions[0][0] && 1 === $spawn_calls );
+$duplicate = WpCodingAgents_Inbound_Events::ingress( $request );
+$assert( 'duplicate coalesces the pending runtime wake', is_array( $duplicate ) && true === $duplicate['duplicate'] && 1 === count( $schedule_calls ) && 1 === count( $actions ) );
+$scheduled = array(); $schedule_fail = true;
+$repair_payload = json_encode( array( 'type' => 'event_callback', 'team_id' => 'T123', 'event_id' => 'slack-event-repair', 'event' => array( 'type' => 'message', 'channel' => 'C123', 'ts' => '1710000001.000001', 'text' => 'repair wake' ) ) ); $repair_signature = 'v0=' . hash_hmac( 'sha256', 'v0:' . $timestamp . ':' . $repair_payload, 'test-signing-secret' ); $repair_request = new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $timestamp, 'x-slack-signature' => $repair_signature ), $repair_payload );
+$failed_wake = WpCodingAgents_Inbound_Events::ingress( $repair_request );
+$assert( 'failed scheduling returns retryable error after durable queueing', is_wp_error( $failed_wake ) && 3 === count( $wpdb->rows ) && 2 === count( $schedule_calls ) );
+$schedule_fail = false; $repaired_wake = WpCodingAgents_Inbound_Events::ingress( $repair_request );
+$assert( 'duplicate repairs a missing pending runtime wake', is_array( $repaired_wake ) && true === $repaired_wake['duplicate'] && 3 === count( $schedule_calls ) && 1 === count( $scheduled ) );
+WpCodingAgents_Inbound_Events::wake_runtime( 'opaque-runtime-id', 'inbound_event' );
+$assert( 'runtime action executes only from the cron callback', 3 === count( $actions ) && 'wp_coding_agents_runtime_requested' === $actions[2][0] && array( 'opaque-runtime-id', 'inbound_event' ) === $actions[2][1] );
+$assert( 'Slack queue envelope excludes request credentials and raw payload', ! str_contains( $wpdb->rows[1]['envelope'], 'test-signing-secret' ) && ! str_contains( $wpdb->rows[1]['envelope'], $signature ) && ! str_contains( $wpdb->rows[1]['envelope'], 'event_callback' ) );
+$url_body = json_encode( array( 'type' => 'url_verification', 'challenge' => 'challenge-value' ) ); $url_signature = 'v0=' . hash_hmac( 'sha256', 'v0:' . $timestamp . ':' . $url_body, 'test-signing-secret' );
+$url_response = WpCodingAgents_Inbound_Events::ingress( new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $timestamp, 'x-slack-signature' => $url_signature ), $url_body ) );
+$assert( 'Slack URL verification returns immediately without queueing', array( 'challenge' => 'challenge-value' ) === $url_response && 3 === count( $wpdb->rows ) );
+$bad_signature = WpCodingAgents_Inbound_Events::ingress( new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $timestamp, 'x-slack-signature' => 'v0=bad' ), $payload ) );
+$assert( 'Slack rejects invalid signatures before queueing', is_wp_error( $bad_signature ) && 3 === count( $wpdb->rows ) );
+$stale_timestamp = (string) ( time() - 301 ); $stale_signature = 'v0=' . hash_hmac( 'sha256', 'v0:' . $stale_timestamp . ':' . $payload, 'test-signing-secret' );
+$stale = WpCodingAgents_Inbound_Events::ingress( new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $stale_timestamp, 'x-slack-signature' => $stale_signature ), $payload ) );
+$assert( 'Slack rejects stale timestamps before queueing', is_wp_error( $stale ) && 3 === count( $wpdb->rows ) );
+$bot_payload = json_encode( array( 'type' => 'event_callback', 'team_id' => 'T123', 'event_id' => 'slack-event-bot', 'event' => array( 'type' => 'message', 'channel' => 'C123', 'ts' => '1710000002.000001', 'text' => 'ignore', 'bot_id' => 'B1' ) ) ); $bot_signature = 'v0=' . hash_hmac( 'sha256', 'v0:' . $timestamp . ':' . $bot_payload, 'test-signing-secret' );
+$bot_response = WpCodingAgents_Inbound_Events::ingress( new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $timestamp, 'x-slack-signature' => $bot_signature ), $bot_payload ) );
+$assert( 'Slack bot events are acknowledged without queueing', is_array( $bot_response ) && true === $bot_response['accepted'] && 3 === count( $wpdb->rows ) );
+$foreign_team_payload = json_encode( array( 'type' => 'event_callback', 'team_id' => 'T999', 'event_id' => 'slack-event-foreign', 'event' => array( 'type' => 'message', 'channel' => 'C123', 'ts' => '1710000004.000001', 'text' => 'ignore foreign team' ) ) ); $foreign_team_signature = 'v0=' . hash_hmac( 'sha256', 'v0:' . $timestamp . ':' . $foreign_team_payload, 'test-signing-secret' );
+$foreign_team_response = WpCodingAgents_Inbound_Events::ingress( new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $timestamp, 'x-slack-signature' => $foreign_team_signature ), $foreign_team_payload ) );
+$assert( 'Slack events from a different team are acknowledged without queueing', is_array( $foreign_team_response ) && true === $foreign_team_response['accepted'] && 3 === count( $wpdb->rows ) );
+$root = WpCodingAgents_Inbound_Events::slack( $request );
+$reply_payload = json_encode( array( 'type' => 'event_callback', 'team_id' => 'T123', 'event_id' => 'slack-event-reply', 'event' => array( 'type' => 'message', 'channel' => 'C123', 'ts' => '1710000003.000001', 'thread_ts' => '1710000000.000001', 'text' => 'thread reply' ) ) ); $reply_signature = 'v0=' . hash_hmac( 'sha256', 'v0:' . $timestamp . ':' . $reply_payload, 'test-signing-secret' );
+$reply = WpCodingAgents_Inbound_Events::slack( new WP_REST_Request( array( 'adapter' => 'slack' ), array( 'x-slack-request-timestamp' => $timestamp, 'x-slack-signature' => $reply_signature ), $reply_payload ) );
+$assert( 'Slack root and replies retain stable thread conversation identity', is_array( $root ) && is_array( $reply ) && 'C123:1710000000.000001' === $root['conversation_id'] && $root['conversation_id'] === $reply['conversation_id'] );
+exit( $failures ? 1 : 0 );

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents; do
+for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -567,6 +567,7 @@ sync_cli_transport_runtime() {
 
   log "Phase 2b: Syncing CLI dispatch transport..."
   cli_transport_install
+  inbound_event_bridge_install
   runtime_guard_sync
   source_reconcile_sync
   source_reconcile_run


### PR DESCRIPTION
## Summary
- install a provider-neutral signed inbound-event queue in WordPress
- add a Slack adapter with signature, workspace, and channel validation
- asynchronously request opaque runtimes while preserving durable dedupe and leased delivery

## Testing
- `php tests/smoke-inbound-event-bridge.php`
- `bash tests/inbound-event-bridge.sh`
- `bash tests/cli-transport-install.sh`
- `bash tests/ci-coverage.sh`
- shell and PHP syntax checks

Closes #382.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the repository, implement the bridge and tests, and verify the changes. Chris Huber reviewed and remains responsible for every line.