### PR TITLE
refactor: drop the opencode-claude-auth wrapper strip, keep the decision pinned

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -32,13 +32,13 @@ jobs:
       - name: Run tests/bridge-render.sh
         run: ./tests/bridge-render.sh
 
-  opencode-wrapper-removal:
-    name: opencode wrapper removal regression (#117)
+  opencode-claude-auth-retired:
+    name: opencode-claude-auth stays retired (#117)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run tests/opencode-wrapper-removal.sh
-        run: ./tests/opencode-wrapper-removal.sh
+      - name: Run tests/opencode-claude-auth-retired.sh
+        run: ./tests/opencode-claude-auth-retired.sh
 
   opencode-subagents:
     name: Data Machine graph OpenCode subagents (#355)

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -10,7 +10,6 @@ runtime_install() {
     log "OpenCode already installed: $(opencode --version 2>/dev/null || echo 'unknown')"
   fi
 
-  _remove_legacy_opencode_wrapper
   _opencode_register_runtime_signature
 }
 
@@ -77,66 +76,6 @@ _opencode_register_runtime_signature() {
   runtime_signature_register \
     "opencode" \
     '{"run_id":"OPENCODE_RUN_ID"}'
-}
-
-# Remove any legacy wp-coding-agents-opencode-wrapper-v2 bash shim that prior
-# upgrades installed at the global `opencode` path. The wrapper existed to
-# feed Anthropic OAuth credentials into ~/.claude/.credentials.json for the
-# opencode-claude-auth plugin. wp-coding-agents no longer ships, installs, or
-# patches that plugin: Kimaki's built-in AnthropicAuthPlugin handles OAuth
-# (token refresh, multi-account rotation, request rewriting), and non-kimaki
-# bridges authenticate via opencode's native auth flow. The wrapper is purely
-# legacy and must not be re-installed by any future upgrade run.
-_remove_legacy_opencode_wrapper() {
-  local OPENCODE_BIN
-  OPENCODE_BIN=$(command -v opencode 2>/dev/null || echo "")
-  [ -n "$OPENCODE_BIN" ] || return 0
-  [ -f "$OPENCODE_BIN" ] || return 0
-
-  # Only act on the known wp-coding-agents wrapper sentinel — never touch a
-  # binary or a wrapper installed by anything else.
-  if ! grep -q "wp-coding-agents-opencode-wrapper" "$OPENCODE_BIN" 2>/dev/null; then
-    return 0
-  fi
-
-  # Recover the real binary path from the wrapper's `exec` line so we can
-  # restore the global `opencode` symlink/hardlink to it.
-  local REAL_BIN=""
-  while IFS= read -r line; do
-    case "$line" in
-      exec\ *opencode*|exec\ /*opencode*)
-        set -- $line
-        REAL_BIN="${2#\'}"
-        REAL_BIN="${REAL_BIN%\'}"
-        REAL_BIN="${REAL_BIN#\"}"
-        REAL_BIN="${REAL_BIN%\"}"
-        ;;
-    esac
-  done < "$OPENCODE_BIN"
-
-  # Fall back to the npm-shipped layout: opencode-ai keeps the real binary at
-  # bin/.opencode and ships a wrapper at bin/opencode in older versions; newer
-  # versions hardlink them. Either way, .opencode is the canonical real binary.
-  if [ -z "$REAL_BIN" ] || [ ! -f "$REAL_BIN" ]; then
-    REAL_BIN="/usr/lib/node_modules/opencode-ai/bin/.opencode"
-  fi
-
-  if [ ! -f "$REAL_BIN" ]; then
-    warn "Legacy opencode wrapper detected at $OPENCODE_BIN but real binary not found — leaving alone"
-    return 0
-  fi
-
-  if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} Would remove legacy opencode wrapper at $OPENCODE_BIN and link to $REAL_BIN"
-    return 0
-  fi
-
-  log "Removing legacy opencode wrapper at $OPENCODE_BIN (real binary: $REAL_BIN)"
-  rm -f "$OPENCODE_BIN" "${OPENCODE_BIN}.bak."* 2>/dev/null || true
-  if ! ln "$REAL_BIN" "$OPENCODE_BIN" 2>/dev/null; then
-    ln -s "$REAL_BIN" "$OPENCODE_BIN"
-  fi
-  UPDATED_ITEMS+=("removed legacy opencode wrapper")
 }
 
 runtime_discover_dm_paths() {

--- a/tests/opencode-claude-auth-retired.sh
+++ b/tests/opencode-claude-auth-retired.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
-# tests/opencode-wrapper-removal.sh — regression for #117 cleanup.
+# tests/opencode-claude-auth-retired.sh — regression for #117.
 #
 # wp-coding-agents previously installed a `wp-coding-agents-opencode-wrapper-v2`
-# bash shim at the global `opencode` binary path on every Kimaki VPS upgrade.
-# That whole integration was retired (Kimaki ships its own AnthropicAuthPlugin
-# and non-kimaki bridges use opencode's native auth). The runtime now only
-# removes legacy wrappers — it must never re-install one. These tests pin
-# both behaviors.
+# bash shim at the global `opencode` binary path so the third-party
+# opencode-claude-auth plugin could read Anthropic OAuth credentials. That whole
+# integration was retired in #117 on 2026-05-03: Kimaki ships its own
+# AnthropicAuthPlugin and non-kimaki bridges use opencode native auth.
+#
+# The upgrade-time strip that removed leftover wrappers is gone too. It could
+# only fire on an install that had skipped every upgrade since May, so it was a
+# check that ran forever and could never match.
+#
+# What remains worth pinning is the DECISION: the install machinery must never
+# come back. These assertions are cheap, have no runtime dependencies, and fail
+# loudly if someone reintroduces the plugin or its patcher.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -97,44 +104,6 @@ EOF
   chmod +x "$wrapper"
 }
 
-echo "==> legacy wrapper is removed and real binary linked back"
-REAL_BIN="$(make_real_opencode)"
-BIN_DIR="$TMPDIR_TEST/bin"
-mkdir -p "$BIN_DIR"
-LEGACY_WRAPPER="$BIN_DIR/opencode"
-make_legacy_wrapper "$LEGACY_WRAPPER" "$REAL_BIN"
-# Simulate stale .bak file from a prior upgrade run.
-cp "$LEGACY_WRAPPER" "${LEGACY_WRAPPER}.bak.20240101000000"
-
-CHAT_BRIDGE=kimaki
-LOCAL_MODE=false
-DRY_RUN=false
-PATH="$BIN_DIR:$PATH"
-
-_remove_legacy_opencode_wrapper
-
-assert_file_lacks "wrapper sentinel removed" "$LEGACY_WRAPPER" "wp-coding-agents-opencode-wrapper"
-assert_file_absent "stale .bak file removed" "${LEGACY_WRAPPER}.bak.20240101000000"
-assert_eq "global opencode runs the real binary" "real opencode" "$("$LEGACY_WRAPPER" 2>/dev/null | head -1)"
-
-# Idempotent: running again on a clean (non-wrapper) binary is a no-op.
-_remove_legacy_opencode_wrapper
-assert_eq "rerun is idempotent" "real opencode" "$("$LEGACY_WRAPPER" 2>/dev/null | head -1)"
-
-echo "==> non-wrapper binaries are never touched"
-NON_WRAPPER_DIR="$TMPDIR_TEST/non-wrapper/bin"
-mkdir -p "$NON_WRAPPER_DIR"
-NON_WRAPPER="$NON_WRAPPER_DIR/opencode"
-cat > "$NON_WRAPPER" <<'EOF'
-#!/bin/sh
-echo not-a-wrapper
-EOF
-chmod +x "$NON_WRAPPER"
-NON_WRAPPER_HASH_BEFORE="$(cat "$NON_WRAPPER")"
-PATH="$NON_WRAPPER_DIR:$PATH"
-_remove_legacy_opencode_wrapper
-assert_eq "non-wrapper binary untouched" "$NON_WRAPPER_HASH_BEFORE" "$(cat "$NON_WRAPPER")"
-
 echo "==> repo no longer ships legacy install machinery"
 assert_file_absent "lib/patch-claude-auth.py is gone" lib/patch-claude-auth.py
 assert_file_lacks "runtimes/opencode.sh has no _install_opencode_wrapper" runtimes/opencode.sh "_install_opencode_wrapper"
@@ -142,7 +111,8 @@ assert_file_lacks "runtimes/opencode.sh has no _patch_claude_auth_plugin" runtim
 assert_file_lacks "runtimes/opencode.sh does not list opencode-claude-auth as a managed plugin" runtimes/opencode.sh '"opencode-claude-auth@latest"'
 assert_file_lacks "lib/repair-opencode-json.py does not append opencode-claude-auth" lib/repair-opencode-json.py 'plugins.append("opencode-claude-auth@latest")'
 assert_file_lacks "upgrade.sh has no reapply_claude_auth_patch" upgrade.sh "reapply_claude_auth_patch"
-assert_file_contains "upgrade.sh wires the removal phase" upgrade.sh "remove_legacy_opencode_wrapper_phase"
+assert_file_lacks "upgrade.sh no longer carries the wrapper-removal phase" upgrade.sh "remove_legacy_opencode_wrapper"
+assert_file_lacks "runtimes/opencode.sh no longer defines the wrapper remover" runtimes/opencode.sh "_remove_legacy_opencode_wrapper"
 
 echo
 if [ "$FAIL" -gt 0 ]; then

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -28,7 +28,7 @@
 #      Each unit's existing Environment= lines are preserved (host custom
 #      values, secrets) while structural lines are refreshed from the same
 #      template the install path uses (bridges/<name>.sh::bridge_render_*).
-#   7. Remove legacy opencode-claude-auth bash wrapper, if any (#117)
+#   7. Refresh the opencode runtime signature
 #   8. Summary — prints the right restart + verify commands per bridge × env.
 #
 # Usage:
@@ -1244,18 +1244,22 @@ update_datamachine_worker_service() {
 }
 
 # ============================================================================
-# Phase 7: Remove legacy opencode-claude-auth wrapper, if any
+# Phase 7: Refresh the opencode runtime signature
 #
-# wp-coding-agents used to install a bash wrapper at the global `opencode`
-# binary path that synced Kimaki's Anthropic OAuth credentials into
-# ~/.claude/.credentials.json so the third-party `opencode-claude-auth`
-# plugin could read them. That whole integration was retired (see #117):
-# Kimaki has a built-in AnthropicAuthPlugin and non-kimaki bridges use
-# opencode's native auth flow. This phase deletes any leftover wrapper
-# left behind by older upgrades and restores the npm-shipped binary.
+# Keeps the worktree runtime-signature registration current, so existing
+# installs pick up the opencode entry on upgrade and track any future
+# signature drift. Idempotent — only mutates the mu-plugin file when the
+# env-var map actually differs from what is already on disk.
+#
+# This phase also used to strip a legacy opencode-claude-auth bash wrapper.
+# That integration was retired in #117 on 2026-05-03, and the strip could only
+# ever fire on an install that had skipped every upgrade since — so it was
+# removed rather than carried as a check that runs forever and never matches.
+# The repo-level guards against reintroducing the plugin live in
+# tests/opencode-claude-auth-retired.sh and are the durable half of #117.
 # ============================================================================
 
-remove_legacy_opencode_wrapper_phase() {
+refresh_opencode_runtime_signature_phase() {
   _run_filter_active patch || return 0
 
   if [ "$RUNTIME" != "opencode" ] && [ "$CHAT_BRIDGE" != "kimaki" ]; then
@@ -1263,20 +1267,14 @@ remove_legacy_opencode_wrapper_phase() {
     return 0
   fi
 
-  log "Phase 7: Checking for legacy opencode wrapper..."
+  log "Phase 7: Refreshing opencode runtime signature..."
 
-  if ! declare -F _remove_legacy_opencode_wrapper >/dev/null; then
+  if ! declare -F _opencode_register_runtime_signature >/dev/null; then
     # Source runtime file for the helper without running a full install.
     # shellcheck disable=SC1091
     source "$SCRIPT_DIR/runtimes/opencode.sh"
   fi
 
-  _remove_legacy_opencode_wrapper
-
-  # Refresh the worktree runtime-signature registration so existing installs
-  # pick up the opencode entry on upgrade (and any future signature drift).
-  # Idempotent — only mutates the mu-plugin file when the env-var map
-  # actually differs from what is already on disk.
   if declare -F _opencode_register_runtime_signature >/dev/null; then
     _opencode_register_runtime_signature
   fi
@@ -1425,5 +1423,5 @@ opencode_project_subagents
 update_chat_bridge_systemd
 update_chat_bridge_launchd
 update_datamachine_worker_service
-remove_legacy_opencode_wrapper_phase
+refresh_opencode_runtime_signature_phase
 print_summary


### PR DESCRIPTION
Closes #386.

## What

`upgrade.sh` Phase 7 stripped a legacy `opencode-claude-auth` bash wrapper from installs predating its retirement. That integration was retired in **#117 on 2026-05-03**, so the strip could only fire on an install that had skipped every upgrade since — a check that ran on every install forever and could never match.

## What I did NOT delete

Phase 7 was doing **two** things and only one was dead. It also refreshes the opencode runtime signature, which is live.

So the phase is renamed `refresh_opencode_runtime_signature_phase` — what it actually does now, and arguably what it should always have been called. The live half was documented as an afterthought to the dead half.

## The test is narrowed, not deleted

Its assertions split cleanly:

| | |
|---|---|
| exercises the removed function | **dropped** |
| pins the #117 *decision* | **kept** |

The kept ones — no `patch-claude-auth.py`, no `_install_opencode_wrapper`, no `opencode-claude-auth` in the managed plugin list or `opencode.json` — are the durable half of #117. They have no runtime dependencies and fail loudly if anyone reintroduces the plugin.

Renamed to `tests/opencode-claude-auth-retired.sh` to say so, CI job renamed to match. Two new assertions pin the removal itself so the strip cannot quietly return.

## Verification

- `8/8` assertions pass
- `bash -n` clean on all three touched shell files
- workflow YAML parses, 24 jobs
- no dangling references to either old name

## Scope note

This was going to be a three-part PR covering #387 and #388 as well. Investigating those turned up counter-evidence to my own analysis, so they are **not** included here — see the comments I left on both issues. This change stands on its own.