### PR TITLE
Harden external context projection transports

### DIFF
--- a/lib/external-wordpress.sh
+++ b/lib/external-wordpress.sh
@@ -124,7 +124,7 @@ external_wordpress_project_context() {
     case "$layer" in ''|*[!A-Za-z0-9_-]*) error "Unsafe injectable context layer: $layer" ;; esac
     destination="$staging/$layer/$filename"
     mkdir -p "$(dirname "$destination")"
-    content="$(wp_cmd datamachine memory read "$filename" "${agent_args[@]}" 2>/dev/null)" || error "Could not read injectable Data Machine context '$filename' through the external control transport"
+    content="$(wp_cmd datamachine memory read "$filename" "${agent_args[@]}" </dev/null 2>/dev/null)" || error "Could not read injectable Data Machine context '$filename' through the external control transport"
     printf '%s\n' "$content" > "$destination"
     DM_AGENT_FILES="${DM_AGENT_FILES}${DM_AGENT_FILES:+$'\n'}.wp-coding-agents/context/$layer/$filename"
   done < <(printf '%s' "$json" | python3 -c 'import json,sys; [print(item["filename"] + "\t" + item["layer"]) for item in json.load(sys.stdin) if isinstance(item, dict) and isinstance(item.get("filename"), str) and isinstance(item.get("layer"), str)]')

--- a/lib/external-wordpress.sh
+++ b/lib/external-wordpress.sh
@@ -70,7 +70,20 @@ PY
 external_wordpress_validate() {
   [ "${EXTERNAL_WORDPRESS:-false}" = true ] || return 0
   [ "${DRY_RUN:-false}" = true ] && return 0
-  wp_cmd core is-installed >/dev/null 2>&1 || error "External WordPress validation failed through the supplied control transport"
+  external_wordpress_wp_cmd core is-installed >/dev/null 2>&1 || error "External WordPress validation failed through the supplied control transport"
+}
+
+external_wordpress_wp_cmd() {
+  local attempt=1 delay=1
+  while [ "$attempt" -le 5 ]; do
+    if wp_cmd "$@" </dev/null; then
+      return 0
+    fi
+    [ "$attempt" -lt 5 ] || return 1
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
 }
 
 # Materialize remote Data Machine files locally. Validated paths cannot escape
@@ -110,7 +123,7 @@ external_wordpress_project_context() {
   done
   printf '%s\n' "$lock_owner" > "$lock/pid"
 
-  raw="$(wp_cmd datamachine memory injectable-files --format=json "${agent_args[@]}" 2>/dev/null)" || error "Could not list injectable Data Machine context through the external control transport"
+  raw="$(external_wordpress_wp_cmd datamachine memory injectable-files --format=json "${agent_args[@]}" 2>/dev/null)" || error "Could not list injectable Data Machine context through the external control transport"
   json="$(printf '%s\n' "$raw" | sed -n '/^\[/,/^\]/p')"
   [ -n "$json" ] || error "External Data Machine context listing returned no JSON"
   mkdir -p "$generations"
@@ -124,7 +137,7 @@ external_wordpress_project_context() {
     case "$layer" in ''|*[!A-Za-z0-9_-]*) error "Unsafe injectable context layer: $layer" ;; esac
     destination="$staging/$layer/$filename"
     mkdir -p "$(dirname "$destination")"
-    content="$(wp_cmd datamachine memory read "$filename" "${agent_args[@]}" </dev/null 2>/dev/null)" || error "Could not read injectable Data Machine context '$filename' through the external control transport"
+    content="$(external_wordpress_wp_cmd datamachine memory read "$filename" "${agent_args[@]}" 2>/dev/null)" || error "Could not read injectable Data Machine context '$filename' through the external control transport"
     printf '%s\n' "$content" > "$destination"
     DM_AGENT_FILES="${DM_AGENT_FILES}${DM_AGENT_FILES:+$'\n'}.wp-coding-agents/context/$layer/$filename"
   done < <(printf '%s' "$json" | python3 -c 'import json,sys; [print(item["filename"] + "\t" + item["layer"]) for item in json.load(sys.stdin) if isinstance(item, dict) and isinstance(item.get("filename"), str) and isinstance(item.get("layer"), str)]')

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -12,6 +12,7 @@ TRANSPORT="$TMP/control transport"
 ARGS="$TMP/transport-args"
 KIMAKI_ENV="$TMP/kimaki-env"
 GRAPH="$TMP/remote-subagent-graph.json"
+TRANSIENT_READ_MARKER="$TMP/transient-read"
 
 mkdir -p "$RUNTIME_PROJECT_ROOT"
 python3 - "$GRAPH" <<'PY'
@@ -46,6 +47,10 @@ case "$5:$6" in
       injectable-files) printf '%s\n' '[{"filename":"SITE.md","layer":"shared","priority":10,"path":"/remote/wp-content/uploads/datamachine-files/shared/SITE.md"},{"filename":"SOUL.md","layer":"agent","priority":20,"path":"/remote/wp-content/uploads/datamachine-files/agents/remote/SOUL.md"}]' ;;
       read)
         cat >/dev/null
+        if [ ! -e "$WP_TEST_TRANSIENT_READ_MARKER" ]; then
+          touch "$WP_TEST_TRANSIENT_READ_MARKER"
+          exit 255
+        fi
         case "$8" in
           SITE.md) printf '%s\n' 'site context' ;;
           SOUL.md) printf '%s\n' 'agent context' ;;
@@ -94,6 +99,7 @@ export SCRIPT_DIR RUNTIME_PROJECT_ROOT WORDPRESS_PATH WORDPRESS_USER AGENT_SLUG=
 export WP_TEST_ARGS="$ARGS"
 export WP_TEST_KIMAKI_ENV="$KIMAKI_ENV"
 export WP_TEST_GRAPH="$GRAPH"
+export WP_TEST_TRANSIENT_READ_MARKER="$TRANSIENT_READ_MARKER"
 export PATH="$TMP/bin:$PATH"
 export WP_CONTROL_TRANSPORT_JSON="[\"$TRANSPORT\",\"--identity\",\"secret value with spaces\"]"
 export EXTERNAL_WORDPRESS=true DRY_RUN=false LOCAL_MODE=true IS_STUDIO=false

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -45,6 +45,7 @@ case "$5:$6" in
     case "$7" in
       injectable-files) printf '%s\n' '[{"filename":"SITE.md","layer":"shared","priority":10,"path":"/remote/wp-content/uploads/datamachine-files/shared/SITE.md"},{"filename":"SOUL.md","layer":"agent","priority":20,"path":"/remote/wp-content/uploads/datamachine-files/agents/remote/SOUL.md"}]' ;;
       read)
+        cat >/dev/null
         case "$8" in
           SITE.md) printf '%s\n' 'site context' ;;
           SOUL.md) printf '%s\n' 'agent context' ;;


### PR DESCRIPTION
## Summary

- detach remote context reads from projection-loop stdin
- retry transient external WordPress validation, listing, and content reads with bounded backoff
- make the external transport fixture consume stdin and fail one read before recovering

Fixes #390.

## Verification

- `bash tests/external-wordpress-runtime.sh`
- `bash -n lib/external-wordpress.sh tests/external-wordpress-runtime.sh`

## AI assistance

GPT-5.6 Sol was used through OpenCode to identify stdin consumption and transient transport handling gaps, implement the fixes, and run focused regression tests. Chris Huber remains responsible for every line.