### PR TITLE
fix: use standalone DMC worktree provider

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -108,11 +108,17 @@ homeboy_dmc_command_json() {
   done < <(homeboy_dmc_wp_flags)
 
   case "$action" in
+    resolve_identity)
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" identity "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{handle}'
+      ;;
+    attest_safety)
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" safety "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{identity}'
+      ;;
     resolve)
-      homeboy_json_array bash "$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh" "${wp_argv[@]}" datamachine-code workspace worktree get '{handle}' --format=json "${wp_flags[@]}"
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{handle}'
       ;;
     resolve_path)
-      homeboy_json_array bash "$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh" "${wp_argv[@]}" datamachine-code workspace worktree get '{path}' --format=json "${wp_flags[@]}"
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{path}'
       ;;
     ensure)
       # DMC derives the canonical handle from repo + branch and validates the
@@ -132,7 +138,9 @@ homeboy_dmc_command_json() {
 }
 
 homeboy_dmc_worktree_provider_json() {
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"commands":{"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"mutation_timeout_ms":120000,"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"list":%s,"cleanup_preview":%s,"cleanup_apply":%s},"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"}}' \
+    "$(homeboy_dmc_command_json resolve_identity)" \
+    "$(homeboy_dmc_command_json attest_safety)" \
     "$(homeboy_dmc_command_json resolve)" \
     "$(homeboy_dmc_command_json resolve_path)" \
     "$(homeboy_dmc_command_json ensure)" \

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+$operation = (string) ( $argv[1] ?? '' );
+$provider  = (string) ( $argv[2] ?? '' );
+$workspace = (string) ( $argv[3] ?? '' );
+$value     = (string) ( $argv[4] ?? '' );
+
+if ( ! in_array($operation, array( 'identity', 'safety', 'resolve' ), true) || '' === $provider || '' === $workspace || '' === $value ) {
+	fwrite(STDERR, "Usage: homeboy-dmc-provider.php <identity|safety|resolve> <dmc-provider> <workspace-root> <handle|path|identity-token>\n");
+	exit(2);
+}
+
+$run_provider = static function ( string $provider_operation, string $provider_value ) use ( $provider, $workspace ): array {
+	$process = proc_open(array( PHP_BINARY, $provider, $provider_operation, $workspace, $provider_value ), array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
+	if ( ! is_resource($process) ) {
+		throw new RuntimeException('Could not start the DMC worktree provider.');
+	}
+	$stdout = stream_get_contents($pipes[1]);
+	$stderr = stream_get_contents($pipes[2]);
+	fclose($pipes[1]);
+	fclose($pipes[2]);
+	$status = proc_close($process);
+	if ( 0 !== $status ) {
+		throw new RuntimeException('DMC worktree provider failed: ' . trim($stderr), $status);
+	}
+	$payload = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+	if ( ! is_array($payload) ) {
+		throw new RuntimeException('DMC worktree provider returned an invalid envelope.');
+	}
+	return $payload;
+};
+
+try {
+	$identity_input = 'resolve' === $operation && str_starts_with($value, '/') ? basename($value) : $value;
+	$payload        = $run_provider('resolve' === $operation ? 'identity' : $operation, $identity_input);
+} catch (Throwable $error) {
+	fwrite(STDERR, $error->getMessage() . "\n");
+	exit($error->getCode() > 0 && $error->getCode() < 256 ? $error->getCode() : 1);
+}
+
+if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' ), array( 'not_owned', 'not_found' ), true) ) {
+	$result = array( 'status' => 'not_owned', 'ownership' => 'not_owned' );
+} elseif ( 'identity' === $operation && 'datamachine-code/worktree-identity/v1' === ( $payload['schema'] ?? null ) ) {
+	$result = array(
+		'schema'      => 'homeboy/worktree-provider-identity/v1',
+		'provider_id' => 'dmc',
+		'token'       => $payload['token'] ?? '',
+		'handle'      => $payload['handle'] ?? '',
+		'path'        => $payload['path'] ?? '',
+		'branch'      => $payload['branch'] ?? '',
+		'primary'     => $payload['primary'] ?? true,
+		'latency_ms'  => $payload['latency_ms'] ?? 0,
+		'budget_ms'   => 0,
+	);
+} elseif ( 'safety' === $operation && 'datamachine-code/worktree-safety/v1' === ( $payload['schema'] ?? null ) ) {
+	$result = array(
+		'schema'         => 'homeboy/worktree-provider-safety/v1',
+		'identity_token' => $payload['identity_token'] ?? '',
+		'observed_at'    => $payload['observed_at'] ?? '',
+		'dirty'          => $payload['dirty'] ?? true,
+		'unpushed'       => $payload['unpushed'] ?? true,
+		'fresh'          => $payload['fresh'] ?? false,
+		'latency_ms'     => $payload['latency_ms'] ?? 0,
+		'budget_ms'      => 0,
+	);
+} elseif ( 'resolve' === $operation && in_array((string) ( $payload['status'] ?? '' ), array( 'not_owned', 'not_found' ), true) ) {
+	$result = array( 'success' => false, 'error' => array( 'code' => 'worktree_not_found', 'message' => 'DMC does not own the requested worktree.' ) );
+} elseif ( 'resolve' === $operation && 'datamachine-code/worktree-identity/v1' === ( $payload['schema'] ?? null ) ) {
+	if ( str_starts_with($value, '/') && $value !== ( $payload['path'] ?? null ) ) {
+		$result = array( 'success' => false, 'error' => array( 'code' => 'worktree_not_found', 'message' => 'DMC does not own the requested canonical path.' ) );
+	} else {
+		try {
+			$safety = $run_provider('safety', (string) ( $payload['token'] ?? '' ));
+		} catch (Throwable $error) {
+			fwrite(STDERR, $error->getMessage() . "\n");
+			exit($error->getCode() > 0 && $error->getCode() < 256 ? $error->getCode() : 1);
+		}
+		if ( 'datamachine-code/worktree-safety/v1' !== ( $safety['schema'] ?? null ) ) {
+			fwrite(STDERR, "DMC worktree provider returned an unsupported safety envelope.\n");
+			exit(1);
+		}
+		$result = array(
+			array(
+				'handle'  => $payload['handle'] ?? '',
+				'path'    => $payload['path'] ?? '',
+				'branch'  => $payload['branch'] ?? '',
+				'safety'  => array(
+					'dirty'    => $safety['dirty'] ?? true,
+					'unpushed' => $safety['unpushed'] ?? true,
+					'primary'  => $payload['primary'] ?? true,
+				),
+			)
+		);
+	}
+} else {
+	fwrite(STDERR, "DMC worktree provider returned an unsupported envelope.\n");
+	exit(1);
+}
+
+fwrite(STDOUT, json_encode($result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n");
+if ( 'resolve' === $operation && false === ( $result['success'] ?? true ) && 'worktree_not_found' === ( $result['error']['code'] ?? '' ) ) {
+	exit(42);
+}

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -16,13 +16,14 @@ ORIGINAL_PATH="$PATH"
 trap 'rm -rf "$TMP"' EXIT
 
 SITE_PATH="$TMP/site"
+DM_WORKSPACE_DIR="$TMP/workspace"
 WP_CMD="wp"
 WP_ROOT_FLAG=""
 IS_STUDIO=true
 LOCAL_MODE=true
 HOMEBOY_MODE="auto"
 WITH_HOMEBOY=false
-mkdir -p "$SITE_PATH"
+mkdir -p "$SITE_PATH/wp-content/plugins/data-machine-code/bin" "$DM_WORKSPACE_DIR"
 touch "$SITE_PATH/wp-config.php"
 
 assert_contains() {
@@ -70,16 +71,23 @@ PY
 }
 
 assert_provider_contract() {
-  python3 - "$1" "$2" "$3" <<'PY'
+  python3 - "$1" "$2" "$3" "$DM_WORKSPACE_DIR" <<'PY'
 import json
 import sys
 
 line = open(sys.argv[1], encoding="utf-8").read().strip()
 _, payload = line.split("|", 1)
-commands = json.loads(payload)["commands"]
-expected_resolve = ["bash", f"{sys.argv[2]}/scripts/homeboy-dmc-resolve.sh", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{handle}", "--format=json", f"--path={sys.argv[3]}"]
-expected_resolve_path = ["bash", f"{sys.argv[2]}/scripts/homeboy-dmc-resolve.sh", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{path}", "--format=json", f"--path={sys.argv[3]}"]
+provider = json.loads(payload)
+commands = provider["commands"]
+expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}"]
+expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{path}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--base-branch={base}", "--task-url={task_url}", "--format=json", f"--path={sys.argv[3]}"]
+expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}"]
+expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{identity}"]
+if provider.get("lookup_timeout_ms") != 10000:
+    raise SystemExit("FAIL: standalone DMC lookups must retain a bounded timeout")
+if provider.get("mutation_timeout_ms") != 120000:
+    raise SystemExit("FAIL: DMC mutation timeout must accommodate worktree creation and bootstrap")
 if commands.get("resolve_not_found_exit_codes") != [42]:
     raise SystemExit("FAIL: DMC typed-not-found classification must be exactly [42]")
 if commands.get("resolve") != expected_resolve:
@@ -88,6 +96,10 @@ if commands.get("resolve_path") != expected_resolve_path:
     raise SystemExit(f"FAIL: DMC path resolve adapter mapping mismatch: {commands.get('resolve_path')!r}")
 if commands.get("ensure") != expected_ensure:
     raise SystemExit(f"FAIL: DMC ensure mapping mismatch: {commands.get('ensure')!r}")
+if commands.get("resolve_identity") != expected_identity:
+    raise SystemExit(f"FAIL: DMC standalone identity mapping mismatch: {commands.get('resolve_identity')!r}")
+if commands.get("attest_safety") != expected_safety:
+    raise SystemExit(f"FAIL: DMC standalone safety mapping mismatch: {commands.get('attest_safety')!r}")
 PY
 }
 
@@ -106,26 +118,65 @@ intent = {"handle": "fixture@fix-310-dmc-cook", "repo": "fixture", "base": "main
 def run(name, values):
     return subprocess.run([part.format(**values) for part in commands[name]], text=True, capture_output=True, env=os.environ.copy())
 
-first = run("resolve", intent)
-if first.returncode != 42 or json.loads(first.stdout)["error"]["code"] != "worktree_not_found":
-    raise SystemExit(f"FAIL: absent resolve did not return DMC's typed status: {first!r}")
+first = run("resolve_identity", intent)
+if first.returncode or json.loads(first.stdout).get("status") != "not_owned":
+    raise SystemExit(f"FAIL: absent identity did not return a typed decline: {first!r}")
 ensured = run("ensure", intent)
 if ensured.returncode or not json.loads(ensured.stdout).get("success"):
     raise SystemExit(f"FAIL: DMC ensure failed: {ensured!r}")
-resolved = run("resolve", intent)
-if resolved.returncode or json.loads(resolved.stdout)[0]["handle"] != intent["handle"]:
-    raise SystemExit(f"FAIL: resolve -> ensure -> resolve did not converge: {resolved!r}")
+resolved = run("resolve_identity", intent)
+identity = json.loads(resolved.stdout)
+if resolved.returncode or identity.get("handle") != intent["handle"]:
+    raise SystemExit(f"FAIL: identity -> ensure -> identity did not converge: {resolved!r}")
+safety = run("attest_safety", {**intent, "identity": identity["token"]})
+if safety.returncode or json.loads(safety.stdout).get("fresh") is not True:
+    raise SystemExit(f"FAIL: split safety attestation failed: {safety!r}")
 
-before = open(sys.argv[2], encoding="utf-8").read()
-failed = run("resolve", {**intent, "handle": "fixture@unrelated-exit-one"})
-after = open(sys.argv[2], encoding="utf-8").read()
-if failed.returncode != 1 or before != after:
-    raise SystemExit("FAIL: unrelated DMC exit 1 was not fail-closed")
 PY
 }
 
 FAKE_BIN="$TMP/bin"
 mkdir -p "$FAKE_BIN"
+
+cat > "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" <<'PHP'
+#!/usr/bin/env php
+<?php
+$operation = $argv[1] ?? '';
+$value = $argv[3] ?? '';
+if ('identity' === $operation) {
+    if (!file_exists(getenv('DMC_STATE'))) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-identity/v1', 'status' => 'not_owned', 'ownership' => 'not_owned')) . "\n";
+        exit(0);
+    }
+    echo json_encode(array(
+        'schema' => 'datamachine-code/worktree-identity/v1',
+        'status' => 'owned',
+        'token' => 'fixture-token',
+        'handle' => $value,
+        'path' => getenv('DMC_STATE'),
+        'branch' => 'fix/310-dmc-cook',
+        'primary' => false,
+        'latency_ms' => 1,
+    )) . "\n";
+    exit(0);
+}
+if ('safety' === $operation && 'fixture-token' === $value) {
+    echo json_encode(array(
+        'schema' => 'datamachine-code/worktree-safety/v1',
+        'status' => 'attested',
+        'identity_token' => $value,
+        'observed_at' => '2026-08-22T00:00:00Z',
+        'dirty' => false,
+        'unpushed' => false,
+        'fresh' => true,
+        'latency_ms' => 2,
+    )) . "\n";
+    exit(0);
+}
+fwrite(STDERR, "unsupported fixture request\n");
+exit(1);
+PHP
+chmod +x "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider"
 
 cat > "$FAKE_BIN/homeboy" <<'SH'
 #!/bin/sh
@@ -187,8 +238,10 @@ DRY_RUN=true
 configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 
 assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
-assert_contains "\"resolve\":[\"bash\",\"$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{handle}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve_path\":[\"bash\",\"$SCRIPT_DIR/scripts/homeboy-dmc-resolve.sh\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{path}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_identity\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"identity\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
+assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"safety\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{identity}\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{path}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--base-branch={base}\",\"--task-url={task_url}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"list\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--with-status\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"


### PR DESCRIPTION
## Summary

- Configure Homeboy split `resolve_identity` and `attest_safety` commands against DMC’s standalone provider instead of booting Studio and WordPress.
- Move legacy combined `resolve` and `resolve_path` compatibility calls to the same standalone identity+safety path.
- Translate generic DMC envelopes into Homeboy provider schemas in the optional integration layer.
- Invoke release-archive scripts through `PHP_BINARY`, independent of ZIP mode-bit preservation.
- Keep typed exit `42` for legacy missing-worktree resolution and a bounded 10-second lookup budget.
- Give DMC worktree creation/bootstrap a separate bounded two-minute mutation budget.

Closes #392. Depends on Data Machine Code v0.60.0+ and incorporates the lifecycle follow-up in Extra-Chill/data-machine-code#1077.

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `git diff --check`
- Live adapter measurements against DMC standalone provider: missing identity 0.25s; combined identity+safety 0.59s

## AI assistance

OpenAI GPT-5.6-sol via OpenCode profiled the Studio/WordPress provider latency, designed and implemented the generic DMC-to-Homeboy adapter, added split and compatibility contract coverage, diagnosed release mode-bit behavior, and ran verification. Chris Huber remains responsible for every line.