### PR TITLE
feat: provision managed VPS systems capabilities

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -251,6 +251,7 @@ jobs:
           - opencode-claude-auth-refresh-hardening
           - owned-source-discovery
           - source-reconcile
+          - systems-capabilities
           - verify
           - path-helpers
           - post-upgrade-restore

--- a/lib/systems-capabilities.sh
+++ b/lib/systems-capabilities.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Durable, opt-in host policy for managed VPS installs.
+
+SYSTEMS_CAPABILITIES_PROFILE_ROOT="${SYSTEMS_CAPABILITIES_PROFILE_ROOT:-/etc/wp-coding-agents/systems-capabilities}"
+SYSTEMS_CAPABILITIES_BIN_DIR="${SYSTEMS_CAPABILITIES_BIN_DIR:-/usr/local/bin}"
+SYSTEMS_CAPABILITIES_LIB_DIR="${SYSTEMS_CAPABILITIES_LIB_DIR:-/usr/local/lib/wp-coding-agents}"
+SYSTEMS_CAPABILITIES_JOURNALD_FILE="${SYSTEMS_CAPABILITIES_JOURNALD_FILE:-/etc/systemd/journald.conf.d/wp-coding-agents.conf}"
+SYSTEMS_CAPABILITIES_LOGROTATE_DIR="${SYSTEMS_CAPABILITIES_LOGROTATE_DIR:-/etc/logrotate.d}"
+SYSTEMS_CAPABILITIES_SUDOERS_DIR="${SYSTEMS_CAPABILITIES_SUDOERS_DIR:-/etc/sudoers.d}"
+
+systems_capabilities_profile_name() { printf '%s' "$(basename "$SITE_PATH")"; }
+systems_capabilities_profile_key() {
+  local name canonical digest
+  name="$(systems_capabilities_profile_name | tr -c 'A-Za-z0-9_-' '-')"
+  canonical="$(cd "$SITE_PATH" 2>/dev/null && pwd -P || printf '%s' "$SITE_PATH")"
+  digest="$(printf '%s' "$canonical" | sha256sum | cut -c1-12)"
+  printf '%s-%s' "$name" "$digest"
+}
+systems_capabilities_profile_file() { printf '%s/%s.json' "$SYSTEMS_CAPABILITIES_PROFILE_ROOT" "$(systems_capabilities_profile_key)"; }
+systems_capabilities_logrotate_file() { printf '%s/wp-coding-agents-%s-debug-log' "$SYSTEMS_CAPABILITIES_LOGROTATE_DIR" "$(systems_capabilities_profile_key)"; }
+systems_capabilities_sudoers_file() { printf '%s/wp-coding-agents-dmc-process-inspect-%s' "$SYSTEMS_CAPABILITIES_SUDOERS_DIR" "$(systems_capabilities_profile_key)"; }
+
+systems_capabilities_workspace_roots() {
+  local roots="${SYSTEMS_CAPABILITIES_WORKSPACE_ROOTS:-${DM_WORKSPACE_DIR:-}}"
+  printf '%s' "$roots" | tr ':' '\n' | sed '/^$/d'
+}
+
+systems_capabilities_enabled() { [ "${SYSTEMS_CAPABILITIES_PROFILE:-}" = "managed-vps" ]; }
+
+systems_capabilities_validate_profile() {
+  case "${SYSTEMS_CAPABILITIES_PROFILE:-}" in
+    ""|managed-vps) ;;
+    *) error "Unknown systems capability profile: $SYSTEMS_CAPABILITIES_PROFILE (supported: managed-vps)" ;;
+  esac
+  if [ "${SYSTEMS_CAPABILITIES_PROFILE:-}" = "managed-vps" ] && [ "${LOCAL_MODE:-false}" = true ]; then
+    error "The managed-vps systems capability profile requires a colocated VPS install"
+  fi
+}
+
+systems_capabilities_resolve_profile() {
+  [ -n "${SYSTEMS_CAPABILITIES_PROFILE:-}" ] && return 0
+  if [ -f "$(systems_capabilities_profile_file)" ] && \
+    grep -q '"profile":"managed-vps"' "$(systems_capabilities_profile_file)" 2>/dev/null; then
+    SYSTEMS_CAPABILITIES_PROFILE="managed-vps"
+  fi
+}
+
+systems_capabilities_profile_content() {
+  local log="$SITE_PATH/wp-content/debug.log" roots_json adapter
+  roots_json="$(systems_capabilities_workspace_roots | python3 -c 'import json,sys; print(json.dumps([line.rstrip("\n") for line in sys.stdin if line.strip()]))')"
+  adapter="$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect"
+  python3 -c 'import json,sys; print(json.dumps({"profile":"managed-vps","debug_log":sys.argv[1],"workspace_roots":json.loads(sys.argv[2]),"process_inspection":{"adapter":sys.argv[3],"invocation":"printf candidate-path | sudo -n " + sys.argv[3] + " " + sys.argv[4],"stdin":"one absolute candidate path","output":"JSON process references"}}, separators=(",",":")))' "$log" "$roots_json" "$adapter" "$(systems_capabilities_profile_file)"
+}
+
+systems_capabilities_logrotate_content() {
+  cat <<EOF
+$SITE_PATH/wp-content/debug.log {
+    daily
+    maxsize 100M
+    rotate 7
+    compress
+    missingok
+    notifempty
+    copytruncate
+    su www-data www-data
+    create 0640 www-data www-data
+}
+EOF
+}
+
+systems_capabilities_journald_content() {
+  cat <<'EOF'
+[Journal]
+SystemMaxUse=1G
+EOF
+}
+
+systems_capabilities_sudoers_content() {
+  printf '%s ALL=(root) NOPASSWD: %s %s\n' "$SERVICE_USER" "$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect" "$(systems_capabilities_profile_file)"
+}
+
+systems_capabilities_process_probe_argv() {
+  python3 -c 'import json,sys; print(json.dumps(["sudo", "-n", sys.argv[1], sys.argv[2]]))' "$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect" "$(systems_capabilities_profile_file)"
+}
+
+systems_capabilities_configure_dmc() {
+  local argv
+  argv="$(systems_capabilities_process_probe_argv)"
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would configure DMC external process-path provider: $argv"
+    return 0
+  fi
+  if ! (cd "$SITE_PATH" && wp_run_as_service_user option update datamachine_code_external_process_path_probe_argv "$argv" --format=json >/dev/null); then
+    error "Failed to configure DMC external process-path provider"
+  fi
+}
+
+systems_capabilities_write_exact() {
+  local file="$1" content="$2" mode="$3" group="${4:-root}"
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would install managed systems capability artifact: $file"
+    return 0
+  fi
+  mkdir -p "$(dirname "$file")"
+  printf '%s' "$content" > "$file"
+  chown "root:$group" "$file"
+  chmod "$mode" "$file"
+}
+
+systems_capabilities_install_sudoers() {
+  local file="$1" content="$2" tmp
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would validate and install managed sudoers policy: $file"
+    return 0
+  fi
+  mkdir -p "$(dirname "$file")"
+  tmp="$(mktemp "${file}.XXXXXX")"
+  printf '%s' "$content" > "$tmp"
+  if ! visudo -cf "$tmp" >/dev/null; then
+    rm -f "$tmp"
+    error "Generated systems capability sudoers policy is invalid: $file"
+  fi
+  chown root:root "$tmp"
+  chmod 0440 "$tmp"
+  mv "$tmp" "$file"
+}
+
+systems_capabilities_drift() {
+  local file="$1" content="$2" mode="${3#0}" group="${4:-root}"
+  [ -f "$file" ] && [ "$(cat "$file")" = "$content" ] && \
+    [ "$(stat -c '%U:%G:%a' "$file" 2>/dev/null || true)" = "root:$group:$mode" ]
+}
+
+systems_capabilities_report_root_repair() {
+  printf '{"status":"root_repair_required","profile":"managed-vps","repair_command":"sudo ./upgrade.sh --systems-capabilities managed-vps --wp-path %s"}\n' "$SITE_PATH"
+}
+
+systems_capabilities_status() {
+  local profile logrotate adapter sudoers journal
+  profile="$(systems_capabilities_profile_file)"
+  logrotate="$(systems_capabilities_logrotate_file)"
+  adapter="$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect"
+  sudoers="$(systems_capabilities_sudoers_file)"
+  journal="$SYSTEMS_CAPABILITIES_JOURNALD_FILE"
+  local missing=()
+  systems_capabilities_drift "$profile" "$(systems_capabilities_profile_content)" 0640 "$SERVICE_USER" || missing+=(profile)
+  systems_capabilities_drift "$logrotate" "$(systems_capabilities_logrotate_content)" 0644 || missing+=(logrotate)
+  systems_capabilities_drift "$journal" "$(systems_capabilities_journald_content)" 0644 || missing+=(journald)
+  systems_capabilities_drift "$adapter" "$(cat "$SCRIPT_DIR/scripts/dmc-process-inspect.py")" 0755 || missing+=(adapter)
+  systems_capabilities_drift "$sudoers" "$(systems_capabilities_sudoers_content)" 0440 || missing+=(sudoers)
+  if [ ${#missing[@]} -eq 0 ]; then
+    printf '{"status":"healthy","profile":"managed-vps"}\n'
+  else
+    printf '{"status":"drift","profile":"managed-vps","missing_or_drifted":['
+    printf '"%s",' "${missing[@]}" | sed 's/,$//'
+    printf ']}\n'
+    return 1
+  fi
+}
+
+systems_capabilities_apply() {
+  systems_capabilities_validate_profile
+  [ "$LOCAL_MODE" = false ] || return 0
+  systems_capabilities_enabled || return 0
+  if [ "$DRY_RUN" = true ]; then
+    log "Dry-run: provisioning managed VPS systems capabilities..."
+    systems_capabilities_write_exact "$(systems_capabilities_profile_file)" "$(systems_capabilities_profile_content)" 0640 "$SERVICE_USER"
+    systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_JOURNALD_FILE" "$(systems_capabilities_journald_content)" 0644
+    systems_capabilities_write_exact "$(systems_capabilities_logrotate_file)" "$(systems_capabilities_logrotate_content)" 0644
+    systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect" "$(cat "$SCRIPT_DIR/scripts/dmc-process-inspect.py")" 0755
+    systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_BIN_DIR/wp-coding-agents-systems-capabilities" "$(cat "$SCRIPT_DIR/scripts/systems-capabilities-status.py")" 0755
+    systems_capabilities_install_sudoers "$(systems_capabilities_sudoers_file)" "$(systems_capabilities_sudoers_content)"
+    systems_capabilities_configure_dmc
+    return 0
+  fi
+  if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+    systems_capabilities_report_root_repair
+    return 0
+  fi
+  log "Provisioning managed VPS systems capabilities..."
+  local journald_changed=false
+  systems_capabilities_drift "$SYSTEMS_CAPABILITIES_JOURNALD_FILE" "$(systems_capabilities_journald_content)" 0644 || journald_changed=true
+  systems_capabilities_write_exact "$(systems_capabilities_profile_file)" "$(systems_capabilities_profile_content)" 0640 "$SERVICE_USER"
+  systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_JOURNALD_FILE" "$(systems_capabilities_journald_content)" 0644
+  systems_capabilities_write_exact "$(systems_capabilities_logrotate_file)" "$(systems_capabilities_logrotate_content)" 0644
+  systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect" "$(cat "$SCRIPT_DIR/scripts/dmc-process-inspect.py")" 0755
+  systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_BIN_DIR/wp-coding-agents-systems-capabilities" "$(cat "$SCRIPT_DIR/scripts/systems-capabilities-status.py")" 0755
+  systems_capabilities_install_sudoers "$(systems_capabilities_sudoers_file)" "$(systems_capabilities_sudoers_content)"
+  systems_capabilities_configure_dmc
+  if [ "$journald_changed" = true ]; then
+    systemctl restart systemd-journald
+  fi
+  systems_capabilities_status
+}

--- a/operator-entrypoints/wp-coding-agents-setup/interview.md
+++ b/operator-entrypoints/wp-coding-agents-setup/interview.md
@@ -61,7 +61,10 @@ Collect the facts needed to install wp-coding-agents. Do not build commands, run
    - Skills install skip.
 
 7. **Agent identity**
-   Ask for the agent slug and display name only when the user wants to override defaults. Defaults come from the site domain or blog name.
+    Ask for the agent slug and display name only when the user wants to override defaults. Defaults come from the site domain or blog name.
+
+8. **Systems capabilities**
+   For a dedicated VPS whose agent is expected to perform bounded host maintenance, ask whether to provision the `managed-vps` systems capability profile. Record `none` for local, external-runtime, and operator-managed hosts.
 
 ## Output Shape
 
@@ -104,6 +107,9 @@ Return the profile as JSON in this shape so the compiler script can map it deter
   "agent": {
     "slug": "",
     "name": ""
+  },
+  "systems_capabilities": {
+    "profile": "none | managed-vps"
   },
   "notes": []
 }

--- a/scripts/compile-setup-profile.mjs
+++ b/scripts/compile-setup-profile.mjs
@@ -112,6 +112,7 @@ function compile(profile) {
   const installTarget = profile.install_target
   const target = profile.target ?? {}
   const overlays = profile.overlays ?? {}
+  const systemsCapabilities = profile.systems_capabilities ?? {}
   const agent = profile.agent ?? {}
 
   if (!installTarget) {
@@ -187,6 +188,13 @@ function compile(profile) {
   if (overlays.root === false) addFlag(command, "--non-root")
   if (agent.slug) addFlag(command, "--agent-slug", agent.slug)
   if (agent.name) addFlag(command, "--agent-name", agent.name)
+  if (systemsCapabilities.profile && systemsCapabilities.profile !== "none") {
+    if (systemsCapabilities.profile !== "managed-vps") throw new Error(`Unknown systems capability profile: ${systemsCapabilities.profile}`)
+    if (!["fresh-vps", "existing-vps", "migration"].includes(installTarget)) {
+      throw new Error("The managed-vps systems capability profile requires a colocated VPS install")
+    }
+    addFlag(command, "--systems-capabilities", systemsCapabilities.profile)
+  }
 
   if (runtime.selection === "multiple" && runtime.requested.length > 1) {
     const runtimeOnlyEnv = {}
@@ -233,6 +241,7 @@ function compile(profile) {
       overlays: Object.entries(overlays)
         .filter(([, value]) => value === true)
         .map(([key]) => key),
+      systems_capabilities: systemsCapabilities.profile || "none",
     },
     commands: {
       dry_run: formatCommand(env, command, true),

--- a/scripts/dmc-process-inspect.py
+++ b/scripts/dmc-process-inspect.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Root-owned DMC process inspection adapter. It accepts only one path on stdin."""
+import json
+import os
+import stat
+import sys
+import syslog
+from pathlib import Path
+
+def fail(message):
+    print(json.dumps({"status": "rejected", "error": message}))
+    raise SystemExit(2)
+
+if len(sys.argv) != 2:
+    fail("exactly one capability profile is required")
+CONFIG_ROOT = Path("/etc/wp-coding-agents/systems-capabilities")
+requested_config = Path(sys.argv[1])
+if os.geteuid() == 0:
+    try:
+        if requested_config.parent != CONFIG_ROOT or requested_config.suffix != ".json":
+            fail("capability profile is outside the managed configuration root")
+        config_stat = requested_config.stat()
+        if config_stat.st_uid != 0 or config_stat.st_mode & 0o022:
+            fail("capability profile ownership or mode is unsafe")
+    except OSError:
+        fail("capability profile is unavailable")
+CONFIG = requested_config
+candidate = sys.stdin.readline().strip()
+if not candidate or sys.stdin.read().strip():
+    fail("exactly one candidate path is required on stdin")
+try:
+    config = json.loads(Path(CONFIG).read_text())
+    roots = [Path(root).resolve() for root in config["workspace_roots"]]
+    path = Path(candidate).resolve(strict=True)
+except (OSError, ValueError, KeyError, json.JSONDecodeError):
+    fail("candidate or configured workspace roots are invalid")
+if not roots:
+    fail("no configured DMC workspace roots are available")
+if not any(path != root and root in path.parents for root in roots):
+    fail("candidate path is outside configured DMC workspace roots")
+
+if not Path("/proc").is_dir():
+    print(json.dumps({"status": "unavailable", "error": "process inspection requires Linux /proc"}))
+    raise SystemExit(3)
+
+O_PATH = getattr(os, "O_PATH", os.O_RDONLY)
+DIRECTORY_FLAGS = O_PATH | os.O_DIRECTORY
+candidate_identity = (path.stat().st_dev, path.stat().st_ino)
+
+def process_still_exists(entry):
+    return entry.is_dir()
+
+def process_is_zombie(entry):
+    try:
+        fields = (entry / "stat").read_text().split()
+        return len(fields) > 2 and fields[2] == "Z"
+    except OSError:
+        return not process_still_exists(entry)
+
+def directory_is_within_candidate(directory_fd):
+    current = os.dup(directory_fd)
+    try:
+        for _ in range(512):
+            current_stat = os.fstat(current)
+            if (current_stat.st_dev, current_stat.st_ino) == candidate_identity:
+                return True
+            parent = os.open("..", DIRECTORY_FLAGS, dir_fd=current)
+            parent_stat = os.fstat(parent)
+            if (parent_stat.st_dev, parent_stat.st_ino) == (current_stat.st_dev, current_stat.st_ino):
+                os.close(parent)
+                return False
+            os.close(current)
+            current = parent
+        raise OSError("directory ancestry exceeded safety bound")
+    finally:
+        os.close(current)
+
+def reference_is_within_candidate(entry, reference):
+    reference_stat = reference.stat()
+    if stat.S_ISDIR(reference_stat.st_mode):
+        directory_fd = os.open(reference, DIRECTORY_FLAGS)
+    else:
+        target = os.readlink(reference)
+        if not target.startswith("/"):
+            return False
+        target = target.removesuffix(" (deleted)")
+        parent = os.path.dirname(target)
+        directory_fd = os.open(str(entry / "root") + parent, DIRECTORY_FLAGS)
+    try:
+        return directory_is_within_candidate(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+processes = []
+incomplete = []
+for entry in Path("/proc").iterdir():
+    if not entry.name.isdigit():
+        continue
+    pid = entry.name
+    matches = []
+    try:
+        command = (entry / "comm").read_text().strip()
+    except OSError:
+        command = ""
+    try:
+        if reference_is_within_candidate(entry, entry / "cwd"):
+            matches.append("cwd")
+    except (FileNotFoundError, ProcessLookupError):
+        if process_still_exists(entry) and not process_is_zombie(entry):
+            incomplete.append({"pid": int(pid), "resource": "cwd"})
+    except (OSError, PermissionError):
+        if process_still_exists(entry) and not process_is_zombie(entry):
+            incomplete.append({"pid": int(pid), "resource": "cwd"})
+    try:
+        fd_entries = list((entry / "fd").iterdir())
+    except (FileNotFoundError, ProcessLookupError):
+        fd_entries = []
+        if process_still_exists(entry) and not process_is_zombie(entry):
+            incomplete.append({"pid": int(pid), "resource": "fd"})
+    except (OSError, PermissionError):
+        fd_entries = []
+        if process_still_exists(entry) and not process_is_zombie(entry):
+            incomplete.append({"pid": int(pid), "resource": "fd"})
+    for fd in fd_entries:
+        try:
+            if reference_is_within_candidate(entry, fd):
+                matches.append("open_file")
+                break
+        except (FileNotFoundError, ProcessLookupError):
+            continue
+        except (OSError, PermissionError):
+            if fd.exists() and process_still_exists(entry) and not process_is_zombie(entry):
+                incomplete.append({"pid": int(pid), "resource": "fd"})
+                break
+    if matches:
+        for match_type in sorted(set(matches)):
+            processes.append({"pid": int(pid), "command": command, "match_type": match_type, "path": str(path)})
+
+if incomplete:
+    syslog.openlog("wp-coding-agents-dmc-process-inspect", syslog.LOG_PID, syslog.LOG_AUTHPRIV)
+    syslog.syslog(syslog.LOG_WARNING, "incomplete process inspection candidate=%s unreadable=%d" % (path, len(incomplete)))
+    print(json.dumps({"status": "unavailable", "path": str(path), "error": "process inspection was incomplete", "unreadable_count": len(incomplete)}))
+    raise SystemExit(3)
+
+syslog.openlog("wp-coding-agents-dmc-process-inspect", syslog.LOG_PID, syslog.LOG_AUTHPRIV)
+syslog.syslog(syslog.LOG_INFO, "inspected configured DMC workspace candidate=%s matches=%d" % (path, len(processes)))
+print(json.dumps({"status": "available", "path": str(path), "processes": processes}, sort_keys=True))

--- a/scripts/systems-capabilities-status.py
+++ b/scripts/systems-capabilities-status.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Read-only discovery and audit surface for managed systems capabilities."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PROFILE_ROOT = Path("/etc/wp-coding-agents/systems-capabilities")
+
+def status():
+    profiles = []
+    for file in sorted(PROFILE_ROOT.glob("*.json")):
+        try:
+            profiles.append(json.loads(file.read_text()))
+        except (OSError, json.JSONDecodeError):
+            profiles.append({"profile_file": str(file), "status": "invalid"})
+    print(json.dumps({"profiles": profiles, "audit_command": "wp-coding-agents-systems-capabilities audit"}, sort_keys=True))
+
+def audit():
+    try:
+        result = subprocess.run(["journalctl", "-t", "wp-coding-agents-dmc-process-inspect", "--no-pager", "-o", "short-iso"], text=True, capture_output=True)
+    except OSError as error:
+        print(json.dumps({"status": "unavailable", "entries": [], "error": str(error)}))
+        return
+    print(json.dumps({"status": "ok" if result.returncode == 0 else "unavailable", "entries": result.stdout.splitlines()}))
+
+if len(sys.argv) != 2 or sys.argv[1] not in ("status", "audit"):
+    raise SystemExit("Usage: wp-coding-agents-systems-capabilities <status|audit>")
+{"status": status, "audit": audit}[sys.argv[1]]()

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect source-policy owned-source-discovery wordpress external-wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance opencode-subagents; do
+for lib in common detect source-policy owned-source-discovery wordpress external-wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance opencode-subagents systems-capabilities; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -256,6 +256,10 @@ while [[ $# -gt 0 ]]; do
       SOURCE_LOG_PATHS_EXPLICIT=true
       shift 2
       ;;
+    --systems-capabilities)
+      SYSTEMS_CAPABILITIES_PROFILE="$2"
+      shift 2
+      ;;
     --agent-slug)
       AGENT_SLUG="$2"
       AGENT_SLUG_EXPLICIT=true
@@ -289,6 +293,8 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+systems_capabilities_validate_profile
 
 if [ "$SHOW_HELP" = true ]; then
   cat << HELP
@@ -361,6 +367,9 @@ OPTIONS:
   --multisite        Convert to WordPress Multisite (subdirectory by default)
   --subdomain        Use subdomain multisite (requires wildcard DNS; use with --multisite)
   --no-skills        Skip installing the wp-coding-agents upgrade skill
+  --systems-capabilities managed-vps
+                      Opt in to root-managed journald, debug-log rotation, and
+                      DMC process-inspection capabilities on a VPS.
   --with-homeboy     Create/update a Homeboy project and install/verify the
                       WordPress Homeboy extension
   --with-ai-gateway  Opt in to WP AI Gateway setup for OpenCode runtimes.
@@ -586,6 +595,7 @@ runtime_install
 runtime_discover_dm_paths
 external_wordpress_project_context
 discover_dm_workspace_dir
+systems_capabilities_apply
 runtime_generate_config
 ai_gateway_configure_opencode
 runtime_install_hooks

--- a/tests/setup-profile-compiler.mjs
+++ b/tests/setup-profile-compiler.mjs
@@ -33,6 +33,36 @@ function compile(profile) {
   assert.ok(plan.verification.overlays.includes("verify-external-wordpress-transport"))
 }
 
+{
+  const plan = compile({
+    install_target: "existing-vps",
+    target: { wordpress_path: "/var/www/example.com" },
+    runtime: { selection: "opencode" },
+    chat_bridge: { selection: "kimaki" },
+    overlays: {},
+    systems_capabilities: { profile: "managed-vps" },
+    agent: {},
+  })
+  assert.match(plan.commands.apply, /--systems-capabilities managed-vps/)
+  assert.equal(plan.summary.systems_capabilities, "managed-vps")
+}
+
+{
+  const result = spawnSync("node", ["scripts/compile-setup-profile.mjs"], {
+    input: JSON.stringify({
+      install_target: "local",
+      target: { wordpress_path: "/tmp/site" },
+      runtime: { selection: "opencode" },
+      chat_bridge: { selection: "none" },
+      overlays: {},
+      systems_capabilities: { profile: "managed-vps" },
+    }),
+    encoding: "utf8",
+  })
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /requires a colocated VPS install/)
+}
+
 for (const selection of ["auto", "codex", "claude-code", "multiple"]) {
   const result = spawnSync("node", ["scripts/compile-setup-profile.mjs"], {
     input: JSON.stringify({

--- a/tests/systems-capabilities.sh
+++ b/tests/systems-capabilities.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Managed VPS systems-capability profile and its fixed DMC inspection boundary.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+ok() { echo "  ok   $1"; }
+fail() { echo "  FAIL $1"; failures=$((failures + 1)); }
+
+source lib/common.sh
+wp_run_as_service_user() { return 0; }
+source lib/systems-capabilities.sh
+SITE_PATH="$TMP/site"
+DM_WORKSPACE_DIR="$TMP/workspace"
+SERVICE_USER=opencode
+DRY_RUN=true
+LOCAL_MODE=false
+SYSTEMS_CAPABILITIES_PROFILE=managed-vps
+SYSTEMS_CAPABILITIES_PROFILE_ROOT="$TMP/profiles"
+SYSTEMS_CAPABILITIES_LIB_DIR="$TMP/lib"
+SYSTEMS_CAPABILITIES_BIN_DIR="$TMP/bin"
+SYSTEMS_CAPABILITIES_JOURNALD_FILE="$TMP/journald.conf"
+SYSTEMS_CAPABILITIES_LOGROTATE_DIR="$TMP/logrotate"
+SYSTEMS_CAPABILITIES_SUDOERS_DIR="$TMP/sudoers"
+mkdir -p "$SITE_PATH/wp-content" "$DM_WORKSPACE_DIR/repo"
+
+echo "systems capability policy is exact and bounded"
+[ "$(systems_capabilities_journald_content)" = $'[Journal]\nSystemMaxUse=1G' ] && ok "journald cap is 1G" || fail "journald cap changed"
+policy="$(systems_capabilities_logrotate_content)"
+for directive in daily 'maxsize 100M' 'rotate 7' compress copytruncate 'su www-data www-data' 'create 0640 www-data www-data'; do
+  case "$policy" in *"$directive"*) ;; *) fail "logrotate policy misses $directive" ;; esac
+done
+[ "$(systems_capabilities_sudoers_content)" = "opencode ALL=(root) NOPASSWD: $SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect $(systems_capabilities_profile_file)" ] && ok "sudo rule binds the adapter to one profile" || fail "sudo rule is not exact"
+SITE_PATH="$TMP/example.com"
+case "$(basename "$(systems_capabilities_sudoers_file)")" in *.*) fail "sudoers filename contains an ignored dot" ;; *) ok "sudoers filename is include-safe" ;; esac
+first_key="$(systems_capabilities_profile_key)"
+SITE_PATH="$TMP/other/example.com"
+mkdir -p "$SITE_PATH"
+[ "$first_key" != "$(systems_capabilities_profile_key)" ] && ok "same-basename sites have collision-resistant keys" || fail "site profile keys collide"
+SITE_PATH="$TMP/site"
+case "$(systems_capabilities_profile_content)" in *'"invocation":"printf candidate-path | sudo -n '* ) ok "discovery records DMC's fixed stdin sudo contract" ;; *) fail "DMC invocation contract missing" ;; esac
+
+echo "adapter rejects ambient paths and reports only configured workspace processes"
+printf '{"workspace_roots":["%s"]}\n' "$DM_WORKSPACE_DIR" > "$TMP/profile.json"
+if [ -d /proc ] && [ "$(id -u)" -ne 0 ]; then
+  (cd "$DM_WORKSPACE_DIR/repo" && sleep 20) & sleeper=$!
+  trap 'kill "$sleeper" 2>/dev/null || true; rm -rf "$TMP"' EXIT
+  out="$(printf '%s\n' "$DM_WORKSPACE_DIR/repo" | python3 scripts/dmc-process-inspect.py "$TMP/profile.json")"
+  case "$out" in *'"status": "available"'* ) ;; *) fail "adapter did not return DMC's available status" ;; esac
+  case "$out" in *"\"pid\": $sleeper"*|*"\"pid\":$sleeper"*) ok "configured workspace process is visible" ;; *) fail "adapter did not report workspace process" ;; esac
+  case "$out" in *'"path": "'"$DM_WORKSPACE_DIR/repo"'"'* ) ok "adapter returns candidate-scoped process paths" ;; *) fail "adapter process evidence does not match DMC contract" ;; esac
+else
+  ok "live adapter evidence is exercised by the root VPS acceptance test"
+fi
+if printf '%s\n' "$TMP/outside" | python3 scripts/dmc-process-inspect.py "$TMP/profile.json" >/dev/null 2>&1; then
+  fail "adapter accepted a path outside configured roots"
+else
+  ok "outside path is rejected"
+fi
+if python3 scripts/dmc-process-inspect.py "$TMP/profile.json" --path "$DM_WORKSPACE_DIR/repo" >/dev/null 2>&1; then
+  fail "adapter accepted argv"
+else
+  ok "adapter rejects arbitrary command-style argv"
+fi
+
+echo "non-root repair is explicit and dry-run does not write"
+repair="$(systems_capabilities_report_root_repair)"
+case "$repair" in *root_repair_required*'--systems-capabilities managed-vps'*) ok "root repair is actionable" ;; *) fail "root repair contract missing" ;; esac
+systems_capabilities_apply > "$TMP/dry-run.out"
+[ ! -e "$SYSTEMS_CAPABILITIES_JOURNALD_FILE" ] && ok "dry-run leaves host policy untouched" || fail "dry-run wrote policy"
+
+if [ "$failures" -eq 0 ]; then
+  echo "systems-capabilities: all assertions passed"
+else
+  exit 1
+fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents; do
+for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents systems-capabilities; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -163,6 +163,8 @@ while [[ $# -gt 0 ]]; do
     --owned-source|--managed-source) OWNED_SOURCES="${OWNED_SOURCES}${OWNED_SOURCES:+ }$2"; OWNED_SOURCES_EXPLICIT=true; shift 2 ;;
     --owned-writable|--managed-writable) OWNED_WRITABLE="${OWNED_WRITABLE}${OWNED_WRITABLE:+ }$2"; OWNED_WRITABLE_EXPLICIT=true; shift 2 ;;
     --log-path) SOURCE_LOG_PATHS="${SOURCE_LOG_PATHS}${SOURCE_LOG_PATHS:+ }$2"; SOURCE_LOG_PATHS_EXPLICIT=true; shift 2 ;;
+    --systems-capabilities) SYSTEMS_CAPABILITIES_PROFILE="$2"; shift 2 ;;
+    --systems-capabilities-only) SYSTEMS_CAPABILITIES_ONLY=true; shift ;;
     --runtime)       RUNTIME="$2"; shift 2 ;;
     --wp-path)       EXISTING_WP="$2"; shift 2 ;;
     --agent-slug)    AGENT_SLUG="$2"; AGENT_SLUG_EXPLICIT=true; shift 2 ;;
@@ -179,6 +181,8 @@ while [[ $# -gt 0 ]]; do
     *)               shift ;;
   esac
 done
+
+systems_capabilities_validate_profile
 
 if [ "$SHOW_HELP" = true ]; then
   cat << HELP
@@ -207,6 +211,12 @@ USAGE:
                                 only adds missing managed entries, never
                                 removes user-added plugins.
   ./upgrade.sh --runtime <name> Force runtime (auto-detected otherwise)
+  ./upgrade.sh --systems-capabilities managed-vps
+                                 Provision or repair the opt-in managed VPS
+                                 systems-capability profile.
+  ./upgrade.sh --systems-capabilities managed-vps --systems-capabilities-only
+                                 Repair only the managed VPS host capability
+                                 profile and its DMC provider configuration.
   ./upgrade.sh --source-mode <name>
                                Where code changes land: workspace | owned
                                (default: the mode recorded at setup time).
@@ -407,6 +417,7 @@ owned_discovery_record_exclusions
 source_policy_record_owned_sources
 source_policy_record_writable_paths
 source_policy_record_log_paths
+systems_capabilities_resolve_profile
 
 # Detect chat bridge from installed services / installed binaries via the
 # bridges/_dispatch.sh registry walk. See bridge_detect_local /
@@ -482,6 +493,13 @@ echo ""
 
 # Track what was touched for the summary
 UPDATED_ITEMS=()
+
+if [ "${SYSTEMS_CAPABILITIES_ONLY:-false}" = true ]; then
+  [ -n "${SYSTEMS_CAPABILITIES_PROFILE:-}" ] || error "--systems-capabilities-only requires --systems-capabilities <profile>"
+  discover_dm_workspace_dir
+  systems_capabilities_apply
+  exit 0
+fi
 
 # Service identity migration (#93). Runs before any phase that renders a unit or
 # writes into the service home, so everything downstream sees the new identity.
@@ -1412,6 +1430,7 @@ sync_cli_transport_runtime
 update_ai_gateway
 sync_chat_bridge_config
 discover_dm_workspace_dir
+systems_capabilities_apply
 check_opencode_json_drift
 ai_gateway_configure_opencode
 sync_skills


### PR DESCRIPTION
## Summary

- add an opt-in `managed-vps` systems-capability profile to setup and upgrade
- install native journald and WordPress debug-log retention policies
- provision a collision-resistant, profile-bound DMC process inspector with an exact sudo rule
- expose read-only capability status/audit and repair drift through upgrade

## Verification

- `bash tests/systems-capabilities.sh`
- `node tests/setup-profile-compiler.mjs`
- `bash tests/ci-coverage.sh`
- shell and Python syntax checks
- live non-root acceptance: exact sudo invocation, outside-path rejection, argv rejection, active-process evidence, journald cap, and logrotate debug validation

Closes #396.

---

AI assistance: OpenAI gpt-5.6-sol via OpenCode implemented and security-reviewed the capability profile, tests, and live acceptance workflow. Chris Huber reviewed the changes and is responsible for every line.