### PR TITLE
Fix frequent evaluation of bounded log policies

### DIFF
--- a/lib/systems-capabilities.sh
+++ b/lib/systems-capabilities.sh
@@ -6,6 +6,7 @@ SYSTEMS_CAPABILITIES_BIN_DIR="${SYSTEMS_CAPABILITIES_BIN_DIR:-/usr/local/bin}"
 SYSTEMS_CAPABILITIES_LIB_DIR="${SYSTEMS_CAPABILITIES_LIB_DIR:-/usr/local/lib/wp-coding-agents}"
 SYSTEMS_CAPABILITIES_JOURNALD_FILE="${SYSTEMS_CAPABILITIES_JOURNALD_FILE:-/etc/systemd/journald.conf.d/wp-coding-agents.conf}"
 SYSTEMS_CAPABILITIES_LOGROTATE_DIR="${SYSTEMS_CAPABILITIES_LOGROTATE_DIR:-/etc/logrotate.d}"
+SYSTEMS_CAPABILITIES_SYSTEMD_DIR="${SYSTEMS_CAPABILITIES_SYSTEMD_DIR:-/etc/systemd/system}"
 SYSTEMS_CAPABILITIES_SUDOERS_DIR="${SYSTEMS_CAPABILITIES_SUDOERS_DIR:-/etc/sudoers.d}"
 
 systems_capabilities_profile_name() { printf '%s' "$(basename "$SITE_PATH")"; }
@@ -18,6 +19,7 @@ systems_capabilities_profile_key() {
 }
 systems_capabilities_profile_file() { printf '%s/%s.json' "$SYSTEMS_CAPABILITIES_PROFILE_ROOT" "$(systems_capabilities_profile_key)"; }
 systems_capabilities_logrotate_file() { printf '%s/wp-coding-agents-%s-debug-log' "$SYSTEMS_CAPABILITIES_LOGROTATE_DIR" "$(systems_capabilities_profile_key)"; }
+systems_capabilities_logrotate_timer_file() { printf '%s/logrotate.timer.d/wp-coding-agents.conf' "$SYSTEMS_CAPABILITIES_SYSTEMD_DIR"; }
 systems_capabilities_sudoers_file() { printf '%s/wp-coding-agents-dmc-process-inspect-%s' "$SYSTEMS_CAPABILITIES_SUDOERS_DIR" "$(systems_capabilities_profile_key)"; }
 
 systems_capabilities_workspace_roots() {
@@ -46,10 +48,12 @@ systems_capabilities_resolve_profile() {
 }
 
 systems_capabilities_profile_content() {
-  local log="$SITE_PATH/wp-content/debug.log" roots_json adapter
+  local log="$SITE_PATH/wp-content/debug.log" roots_json adapter logrotate timer_dropin
   roots_json="$(systems_capabilities_workspace_roots | python3 -c 'import json,sys; print(json.dumps([line.rstrip("\n") for line in sys.stdin if line.strip()]))')"
   adapter="$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect"
-  python3 -c 'import json,sys; print(json.dumps({"profile":"managed-vps","debug_log":sys.argv[1],"workspace_roots":json.loads(sys.argv[2]),"process_inspection":{"adapter":sys.argv[3],"invocation":"printf candidate-path | sudo -n " + sys.argv[3] + " " + sys.argv[4],"stdin":"one absolute candidate path","output":"JSON process references"}}, separators=(",",":")))' "$log" "$roots_json" "$adapter" "$(systems_capabilities_profile_file)"
+  logrotate="$(systems_capabilities_logrotate_file)"
+  timer_dropin="$(systems_capabilities_logrotate_timer_file)"
+  python3 -c 'import json,sys; print(json.dumps({"profile":"managed-vps","debug_log":sys.argv[1],"workspace_roots":json.loads(sys.argv[2]),"logrotate":{"config":sys.argv[5],"timer":"logrotate.timer","timer_dropin":sys.argv[6],"schedule":"*:0/5"},"process_inspection":{"adapter":sys.argv[3],"invocation":"printf candidate-path | sudo -n " + sys.argv[3] + " " + sys.argv[4],"stdin":"one absolute candidate path","output":"JSON process references"}}, separators=(",",":")))' "$log" "$roots_json" "$adapter" "$(systems_capabilities_profile_file)" "$logrotate" "$timer_dropin"
 }
 
 systems_capabilities_logrotate_content() {
@@ -72,6 +76,17 @@ systems_capabilities_journald_content() {
   cat <<'EOF'
 [Journal]
 SystemMaxUse=1G
+EOF
+}
+
+systems_capabilities_logrotate_timer_content() {
+  cat <<'EOF'
+[Timer]
+OnCalendar=
+OnCalendar=*:0/5
+AccuracySec=1min
+RandomizedDelaySec=0
+Persistent=true
 EOF
 }
 
@@ -136,15 +151,17 @@ systems_capabilities_report_root_repair() {
 }
 
 systems_capabilities_status() {
-  local profile logrotate adapter sudoers journal
+  local profile logrotate logrotate_timer adapter sudoers journal
   profile="$(systems_capabilities_profile_file)"
   logrotate="$(systems_capabilities_logrotate_file)"
+  logrotate_timer="$(systems_capabilities_logrotate_timer_file)"
   adapter="$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect"
   sudoers="$(systems_capabilities_sudoers_file)"
   journal="$SYSTEMS_CAPABILITIES_JOURNALD_FILE"
   local missing=()
   systems_capabilities_drift "$profile" "$(systems_capabilities_profile_content)" 0640 "$SERVICE_USER" || missing+=(profile)
   systems_capabilities_drift "$logrotate" "$(systems_capabilities_logrotate_content)" 0644 || missing+=(logrotate)
+  systems_capabilities_drift "$logrotate_timer" "$(systems_capabilities_logrotate_timer_content)" 0644 || missing+=(logrotate_timer)
   systems_capabilities_drift "$journal" "$(systems_capabilities_journald_content)" 0644 || missing+=(journald)
   systems_capabilities_drift "$adapter" "$(cat "$SCRIPT_DIR/scripts/dmc-process-inspect.py")" 0755 || missing+=(adapter)
   systems_capabilities_drift "$sudoers" "$(systems_capabilities_sudoers_content)" 0440 || missing+=(sudoers)
@@ -167,6 +184,7 @@ systems_capabilities_apply() {
     systems_capabilities_write_exact "$(systems_capabilities_profile_file)" "$(systems_capabilities_profile_content)" 0640 "$SERVICE_USER"
     systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_JOURNALD_FILE" "$(systems_capabilities_journald_content)" 0644
     systems_capabilities_write_exact "$(systems_capabilities_logrotate_file)" "$(systems_capabilities_logrotate_content)" 0644
+    systems_capabilities_write_exact "$(systems_capabilities_logrotate_timer_file)" "$(systems_capabilities_logrotate_timer_content)" 0644
     systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect" "$(cat "$SCRIPT_DIR/scripts/dmc-process-inspect.py")" 0755
     systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_BIN_DIR/wp-coding-agents-systems-capabilities" "$(cat "$SCRIPT_DIR/scripts/systems-capabilities-status.py")" 0755
     systems_capabilities_install_sudoers "$(systems_capabilities_sudoers_file)" "$(systems_capabilities_sudoers_content)"
@@ -178,17 +196,26 @@ systems_capabilities_apply() {
     return 0
   fi
   log "Provisioning managed VPS systems capabilities..."
-  local journald_changed=false
+  local journald_changed=false logrotate_timer_changed=false
   systems_capabilities_drift "$SYSTEMS_CAPABILITIES_JOURNALD_FILE" "$(systems_capabilities_journald_content)" 0644 || journald_changed=true
+  systems_capabilities_drift "$(systems_capabilities_logrotate_timer_file)" "$(systems_capabilities_logrotate_timer_content)" 0644 || logrotate_timer_changed=true
   systems_capabilities_write_exact "$(systems_capabilities_profile_file)" "$(systems_capabilities_profile_content)" 0640 "$SERVICE_USER"
   systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_JOURNALD_FILE" "$(systems_capabilities_journald_content)" 0644
   systems_capabilities_write_exact "$(systems_capabilities_logrotate_file)" "$(systems_capabilities_logrotate_content)" 0644
+  systems_capabilities_write_exact "$(systems_capabilities_logrotate_timer_file)" "$(systems_capabilities_logrotate_timer_content)" 0644
   systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect" "$(cat "$SCRIPT_DIR/scripts/dmc-process-inspect.py")" 0755
   systems_capabilities_write_exact "$SYSTEMS_CAPABILITIES_BIN_DIR/wp-coding-agents-systems-capabilities" "$(cat "$SCRIPT_DIR/scripts/systems-capabilities-status.py")" 0755
   systems_capabilities_install_sudoers "$(systems_capabilities_sudoers_file)" "$(systems_capabilities_sudoers_content)"
   systems_capabilities_configure_dmc
   if [ "$journald_changed" = true ]; then
     systemctl restart systemd-journald
+  fi
+  if [ "$logrotate_timer_changed" = true ]; then
+    systemctl daemon-reload
+  fi
+  systemctl enable --now logrotate.timer
+  if [ "$logrotate_timer_changed" = true ]; then
+    systemctl restart logrotate.timer
   fi
   systems_capabilities_status
 }

--- a/tests/systems-capabilities.sh
+++ b/tests/systems-capabilities.sh
@@ -12,7 +12,7 @@ ok() { echo "  ok   $1"; }
 fail() { echo "  FAIL $1"; failures=$((failures + 1)); }
 
 source lib/common.sh
-wp_run_as_service_user() { return 0; }
+wp_run_as_service_user() { printf '%s\n' "$*" > "$TMP/wp-call"; }
 source lib/systems-capabilities.sh
 SITE_PATH="$TMP/site"
 DM_WORKSPACE_DIR="$TMP/workspace"
@@ -25,6 +25,7 @@ SYSTEMS_CAPABILITIES_LIB_DIR="$TMP/lib"
 SYSTEMS_CAPABILITIES_BIN_DIR="$TMP/bin"
 SYSTEMS_CAPABILITIES_JOURNALD_FILE="$TMP/journald.conf"
 SYSTEMS_CAPABILITIES_LOGROTATE_DIR="$TMP/logrotate"
+SYSTEMS_CAPABILITIES_SYSTEMD_DIR="$TMP/systemd"
 SYSTEMS_CAPABILITIES_SUDOERS_DIR="$TMP/sudoers"
 mkdir -p "$SITE_PATH/wp-content" "$DM_WORKSPACE_DIR/repo"
 
@@ -34,6 +35,11 @@ policy="$(systems_capabilities_logrotate_content)"
 for directive in daily 'maxsize 100M' 'rotate 7' compress copytruncate 'su www-data www-data' 'create 0640 www-data www-data'; do
   case "$policy" in *"$directive"*) ;; *) fail "logrotate policy misses $directive" ;; esac
 done
+timer="$(systems_capabilities_logrotate_timer_content)"
+for directive in 'OnCalendar=' 'OnCalendar=*:0/5' 'AccuracySec=1min' 'RandomizedDelaySec=0' 'Persistent=true'; do
+  case "$timer" in *"$directive"*) ;; *) fail "logrotate timer misses $directive" ;; esac
+done
+[ "$(systems_capabilities_logrotate_timer_file)" = "$SYSTEMS_CAPABILITIES_SYSTEMD_DIR/logrotate.timer.d/wp-coding-agents.conf" ] && ok "logrotate cadence extends the owner timer" || fail "logrotate timer path is not fixed"
 [ "$(systems_capabilities_sudoers_content)" = "opencode ALL=(root) NOPASSWD: $SYSTEMS_CAPABILITIES_LIB_DIR/dmc-process-inspect $(systems_capabilities_profile_file)" ] && ok "sudo rule binds the adapter to one profile" || fail "sudo rule is not exact"
 SITE_PATH="$TMP/example.com"
 case "$(basename "$(systems_capabilities_sudoers_file)")" in *.*) fail "sudoers filename contains an ignored dot" ;; *) ok "sudoers filename is include-safe" ;; esac
@@ -43,6 +49,14 @@ mkdir -p "$SITE_PATH"
 [ "$first_key" != "$(systems_capabilities_profile_key)" ] && ok "same-basename sites have collision-resistant keys" || fail "site profile keys collide"
 SITE_PATH="$TMP/site"
 case "$(systems_capabilities_profile_content)" in *'"invocation":"printf candidate-path | sudo -n '* ) ok "discovery records DMC's fixed stdin sudo contract" ;; *) fail "DMC invocation contract missing" ;; esac
+case "$(systems_capabilities_profile_content)" in *'"timer":"logrotate.timer"'*'"schedule":"*:0/5"'* ) ok "discovery records frequent owner-policy evaluation" ;; *) fail "logrotate timer contract missing" ;; esac
+
+echo "DMC consumer wiring uses the fixed adapter contract"
+DRY_RUN=false
+systems_capabilities_configure_dmc
+expected_argv="$(systems_capabilities_process_probe_argv)"
+[ "$(cat "$TMP/wp-call")" = "option update datamachine_code_external_process_path_probe_argv $expected_argv --format=json" ] && ok "DMC option receives the fixed probe argv" || fail "DMC option wiring drifted"
+DRY_RUN=true
 
 echo "adapter rejects ambient paths and reports only configured workspace processes"
 printf '{"workspace_roots":["%s"]}\n' "$DM_WORKSPACE_DIR" > "$TMP/profile.json"


### PR DESCRIPTION
## Summary
- evaluate root-owned logrotate policies every five minutes through a systemd drop-in for the stock `logrotate.timer`
- preserve owner-defined size and retention rules rather than adding service-specific maintenance code
- expose the schedule in the managed systems-capability profile and detect drop-in drift
- verify that setup wires DMC to the fixed external process-inspection adapter

## Live Evidence
The managed VPS reached 99% root usage because MariaDB generated 45.8 GB of slow-query logs between daily logrotate evaluations. Its existing `maxsize 500M` rule was correct but only evaluated by the stock daily timer. Truncating the two oversized logs reclaimed 45,791,247,477 bytes and restored root usage to 70%. Frequent evaluation makes the existing size bound operational during future bursts.

## Tests
- `bash tests/systems-capabilities.sh`
- `bash -n **/*.sh`
- `bash tests/ci-coverage.sh`
- `node tests/setup-profile-compiler.mjs`
- `git diff --check`

The Homeboy review umbrella was not started because local resource admission reported load 95 across 18 CPUs; its focused underlying checks above passed.

Fixes #396

AI assistance: OpenAI gpt-5.6-sol via OpenCode was used to diagnose the live storage growth, implement the generic timer policy, and add regression coverage. Chris Huber is responsible for every line.