### PR TITLE
feat(upgrade): manage copied DMC releases

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -236,6 +236,8 @@ jobs:
           - datamachine-worker
           - detect-php-version
           - detect-site-domain
+          - dmc-managed-release
+          - dmc-managed-release-integration
           - external-wordpress-runtime
           - dm-workspace-discovery
           - homeboy-codebox-canary

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -77,7 +77,13 @@ upgrade_data_machine_plugins() {
   # silently reinstalls and reactivates it, because update_plugin_to_latest_tag
   # activates — which is exactly why hand-deactivating DMC never stuck.
   if source_policy_workspace_enabled; then
-    update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+    local dmc_plugin_dir="$SITE_PATH/wp-content/plugins/data-machine-code"
+    if [ -d "$dmc_plugin_dir/.git" ] || [ ! -d "$dmc_plugin_dir" ]; then
+      # Preserve setup's git-checkout contract, including first installation.
+      update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+    else
+      update_data_machine_code_copied_release
+    fi
   else
     log "  Skipping Data Machine Code (source mode: ${SOURCE_MODE:-owned})"
   fi

--- a/lib/dmc-managed-release-integration.sh
+++ b/lib/dmc-managed-release-integration.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+dmc_managed_release_integration_sync() {
+  local file="$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-dmc-managed-release.php"
+  local template="$SCRIPT_DIR/templates/wp-coding-agents-dmc-managed-release.php"
+  [ -f "$template" ] || { warn "Missing DMC managed-release integration template"; return 1; }
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would sync DMC managed-release/runtime-doctor integration to $file"
+    return 0
+  fi
+  mkdir -p "${file%/*}"
+  local rendered
+  rendered="$(WP_CODING_AGENTS_UPGRADE_SCRIPT="$SCRIPT_DIR/upgrade.sh" python3 - "$template" <<'PY'
+import os
+import pathlib
+import sys
+
+value = os.environ['WP_CODING_AGENTS_UPGRADE_SCRIPT'].replace('\\', '\\\\').replace("'", "\\'").replace('\n', '\\n').replace('\r', '\\r')
+print(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8').replace('@WP_CODING_AGENTS_UPGRADE_SCRIPT@', value), end='')
+PY
+)"
+  if [ ! -f "$file" ] || ! printf '%s\n' "$rendered" | cmp -s - "$file"; then
+    printf '%s\n' "$rendered" > "$file"
+    UPDATED_ITEMS+=("DMC managed-release/runtime-doctor integration")
+  fi
+  service_file_normalize_perms "$file"
+}

--- a/lib/dmc-managed-release.sh
+++ b/lib/dmc-managed-release.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# Official release updater for copied Data Machine Code deployments.
+
+DMC_MANAGED_RELEASE_REPO="${DMC_MANAGED_RELEASE_REPO:-Extra-Chill/data-machine-code}"
+DMC_MANAGED_RELEASE_API="${DMC_MANAGED_RELEASE_API:-https://api.github.com/repos/${DMC_MANAGED_RELEASE_REPO}/releases/latest}"
+
+dmc_managed_release_plugin_dir() {
+  printf '%s/wp-content/plugins/data-machine-code' "$SITE_PATH"
+}
+
+dmc_managed_release_header_version() {
+  local file="$1/data-machine-code.php"
+  [ -f "$file" ] || return 1
+  grep -m1 -E '^[[:space:]]*\*?[[:space:]]*Version:' "$file" | sed -E 's/.*Version:[[:space:]]*([^[:space:]]+).*/\1/'
+}
+
+dmc_managed_release_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# Print a tab-separated release tuple: version, archive URL, checksum URL.
+dmc_managed_release_resolve() {
+  local release_json="$1"
+  DMC_RELEASE_JSON="$release_json" DMC_RELEASE_ASSET="${DMC_MANAGED_RELEASE_ASSET:-}" python3 <<'PY'
+import json
+import os
+import sys
+
+data = json.loads(os.environ['DMC_RELEASE_JSON'])
+tag = str(data.get('tag_name', ''))
+if not __import__('re').fullmatch(r'v?\d+\.\d+(?:\.\d+){0,2}', tag):
+    raise SystemExit('release tag must be a stable semantic version')
+version = tag.lstrip('v')
+assets = data.get('assets', [])
+requested = os.environ['DMC_RELEASE_ASSET']
+archives = [asset for asset in assets if str(asset.get('name', '')).endswith('.zip')]
+archive = next((asset for asset in archives if asset.get('name') == requested), None) if requested else None
+if archive is None and len(archives) == 1:
+    archive = archives[0]
+if archive is None:
+    raise SystemExit('release must publish exactly one ZIP asset (or set DMC_MANAGED_RELEASE_ASSET)')
+name = str(archive['name'])
+checksums = [asset for asset in assets if str(asset.get('name', '')).lower() in (name.lower() + '.sha256', name.lower() + '.sha256sum', 'sha256sums', 'sha256sums.txt')]
+if len(checksums) != 1:
+    raise SystemExit('release must publish one SHA-256 checksum asset for the ZIP')
+print('\t'.join((version, str(archive['browser_download_url']), str(checksums[0]['browser_download_url']))))
+PY
+}
+
+dmc_managed_release_expected_sha256() {
+  local checksum_file="$1" archive_name="$2"
+  awk -v name="$archive_name" 'tolower($NF) == tolower(name) || NF == 1 { print $1; exit }' "$checksum_file" | tr '[:upper:]' '[:lower:]'
+}
+
+dmc_managed_release_provenance_file() {
+  printf '%s/.wp-coding-agents-release-current/.wp-coding-agents-managed-release.json' "$(dmc_managed_release_plugin_dir)"
+}
+
+dmc_managed_release_active() {
+  wp_cmd plugin is-active data-machine-code >/dev/null 2>&1
+}
+
+dmc_managed_release_release_root() {
+  printf '%s/.wp-coding-agents-releases' "$(dmc_managed_release_plugin_dir)"
+}
+
+# Restore a complete prior release after an interrupted symlink switch. The
+# root loader also uses this fallback, so DMC remains loadable before recovery.
+dmc_managed_release_recover() {
+  local plugin_dir="$1" releases current previous
+  releases="$plugin_dir/.wp-coding-agents-releases"
+  current="$plugin_dir/.wp-coding-agents-release-current"
+  previous="$plugin_dir/.wp-coding-agents-release-previous"
+  [ -e "$current/data-machine-code.php" ] || [ -e "$previous/data-machine-code.php" ] || return 0
+  if [ ! -e "$current/data-machine-code.php" ] && [ -e "$previous/data-machine-code.php" ]; then
+    mv "$previous" "$current" || return 1
+    log "Recovered Data Machine Code release pointer after an interrupted update"
+  fi
+}
+
+dmc_managed_release_loader() {
+  local version="$1"
+  cat <<PHP
+<?php
+/**
+ * Plugin Name: Data Machine Code
+ * Version: $version
+ */
+
+\$root = __DIR__;
+\$current = \$root . '/.wp-coding-agents-release-current/data-machine-code.php';
+\$previous = \$root . '/.wp-coding-agents-release-previous/data-machine-code.php';
+if ( is_readable( \$current ) ) {
+	require \$current;
+} elseif ( is_readable( \$previous ) ) {
+	require \$previous;
+}
+PHP
+}
+
+dmc_managed_release_status() {
+  local plugin_dir current
+  plugin_dir="$(dmc_managed_release_plugin_dir)"
+  current="$(dmc_managed_release_header_version "$plugin_dir" 2>/dev/null || true)"
+  if [ ! -d "$plugin_dir" ] || [ -d "$plugin_dir/.git" ]; then
+    printf '{"deployment":"%s","installed_version":"%s"}\n' "$( [ -d "$plugin_dir/.git" ] && printf git_checkout || printf missing )" "$current"
+    return 0
+  fi
+
+  local release tuple version archive_url checksum_url
+  if ! release="$(curl -fsSL "$DMC_MANAGED_RELEASE_API")" || ! tuple="$(dmc_managed_release_resolve "$release")"; then
+    printf '{"deployment":"copied_deploy","installed_version":"%s","state":"resolution_failed"}\n' "$current"
+    return 1
+  fi
+  IFS=$'\t' read -r version archive_url checksum_url <<< "$tuple"
+  printf '{"deployment":"copied_deploy","installed_version":"%s","latest_version":"%s","archive_url":"%s","checksum_url":"%s"}\n' "$current" "$version" "$archive_url" "$checksum_url"
+}
+
+update_data_machine_code_copied_release() {
+  local plugin_dir
+  plugin_dir="$(dmc_managed_release_plugin_dir)"
+  [ -d "$plugin_dir" ] || return 0
+  [ ! -d "$plugin_dir/.git" ] || return 0
+  dmc_managed_release_recover "$plugin_dir" || { warn "Could not recover interrupted Data Machine Code release update"; return 0; }
+
+  local current release tuple target archive_url checksum_url
+  current="$(dmc_managed_release_header_version "$plugin_dir" 2>/dev/null || true)"
+  if ! release="$(curl -fsSL "$DMC_MANAGED_RELEASE_API")" || ! tuple="$(dmc_managed_release_resolve "$release")"; then
+    warn "Could not resolve the official Data Machine Code release — copied install unchanged"
+    return 0
+  fi
+  IFS=$'\t' read -r target archive_url checksum_url <<< "$tuple"
+
+  if [ "$current" = "$target" ]; then
+    log "Data Machine Code copied install already at official release $target"
+    return 0
+  fi
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Download and SHA-256 verify official Data Machine Code $target"
+    echo -e "${BLUE}[dry-run]${NC} Stage and atomically deploy only $plugin_dir ($current → $target)"
+    return 0
+  fi
+
+  local staging archive checksum expected actual extracted candidate staged releases release_dir legacy_dir legacy_name next current previous loader_tmp was_active
+  staging="$(mktemp -d)" || { warn "Could not create Data Machine Code release staging directory"; return 0; }
+  trap 'rm -rf "$staging"' RETURN
+  archive="$staging/release.zip"
+  checksum="$staging/release.sha256"
+  if ! curl -fsSL "$archive_url" -o "$archive" || ! curl -fsSL "$checksum_url" -o "$checksum"; then
+    warn "Could not download official Data Machine Code release $target — copied install unchanged"
+    return 0
+  fi
+  expected="$(dmc_managed_release_expected_sha256 "$checksum" "$(basename "$archive_url")")"
+  actual="$(dmc_managed_release_sha256 "$archive")"
+  if ! [[ "$expected" =~ ^[a-f0-9]{64}$ ]] || [ "$actual" != "$expected" ]; then
+    warn "Official Data Machine Code release $target failed published SHA-256 verification — copied install unchanged"
+    return 0
+  fi
+  extracted="$staging/extracted"
+  mkdir -p "$extracted"
+  if ! unzip -q "$archive" -d "$extracted"; then
+    warn "Could not extract verified Data Machine Code release $target — copied install unchanged"
+    return 0
+  fi
+  candidate="$extracted"
+  [ -f "$candidate/data-machine-code.php" ] || candidate="$(dirname "$(command find "$extracted" -mindepth 2 -maxdepth 2 -name data-machine-code.php -print -quit)")"
+  if [ ! -f "$candidate/data-machine-code.php" ] || [ "$(dmc_managed_release_header_version "$candidate" 2>/dev/null || true)" != "$target" ]; then
+    warn "Verified Data Machine Code release $target has no matching plugin entrypoint — copied install unchanged"
+    return 0
+  fi
+  releases="$(dmc_managed_release_release_root)"
+  current="$plugin_dir/.wp-coding-agents-release-current"
+  previous="$plugin_dir/.wp-coding-agents-release-previous"
+  # First conversion keeps a complete copy of the running copied deployment
+  # behind current before replacing its entrypoint with the stable loader.
+  # The release directory is excluded so copying into a child never recurses.
+  if [ ! -e "$current/data-machine-code.php" ]; then
+    legacy_dir="$staging/legacy"
+    legacy_name="legacy-${TIMESTAMP:-$(date +%s)}"
+    if ! rsync -a --exclude='.wp-coding-agents-releases' --exclude='.wp-coding-agents-release-current' --exclude='.wp-coding-agents-release-previous' --exclude='.wp-coding-agents-release-next' "$plugin_dir/" "$legacy_dir/"; then
+      warn "Could not preserve the current Data Machine Code release before deployment"
+      return 0
+    fi
+    mkdir -p "$releases"
+    if ! mv "$legacy_dir" "$releases/$legacy_name" || ! ln -s ".wp-coding-agents-releases/$legacy_name" "$current"; then
+      warn "Could not prepare Data Machine Code interruption recovery"
+      return 0
+    fi
+  fi
+  release_dir="$releases/$target-$actual"
+  mkdir -p "$releases"
+  if [ ! -d "$release_dir" ]; then
+    staged="$releases/.staging-$target-${TIMESTAMP:-$(date +%s)}"
+    cp -a "$candidate" "$staged"
+    printf '{"repository":"%s","version":"%s","sha256":"%s","archive_url":"%s"}\n' "$DMC_MANAGED_RELEASE_REPO" "$target" "$actual" "$archive_url" > "$staged/.wp-coding-agents-managed-release.json"
+    mv "$staged" "$release_dir" || { warn "Could not stage Data Machine Code $target — copied install unchanged"; return 0; }
+  fi
+  next="$plugin_dir/.wp-coding-agents-release-next"
+  ln -s ".wp-coding-agents-releases/$(basename "$release_dir")" "$next" || { warn "Could not prepare Data Machine Code $target release pointer"; return 0; }
+  # Keep activation state exactly as found. Inactive plugins are deployable but
+  # must not become active as a side effect of an updater run.
+  was_active=false
+  dmc_managed_release_active && was_active=true
+  loader_tmp="$plugin_dir/.wp-coding-agents-loader-${TIMESTAMP:-$(date +%s)}.php"
+  dmc_managed_release_loader "$target" > "$loader_tmp"
+  mv "$loader_tmp" "$plugin_dir/data-machine-code.php" || { rm -f "$next"; warn "Could not install Data Machine Code release loader"; return 0; }
+  # There is always a loader-visible target: before current is replaced it sees
+  # current; between the two renames it falls back to previous; afterward it
+  # sees the new current. A later invocation restores previous -> current.
+  [ ! -e "$current" ] || mv "$current" "$previous"
+  if ! mv "$next" "$current"; then
+    dmc_managed_release_recover "$plugin_dir" || true
+    warn "Could not switch Data Machine Code $target release pointer — prior release retained"
+    return 0
+  fi
+  if [ "$was_active" = true ] && { ! activate_plugin data-machine-code || ! dmc_managed_release_active; }; then
+    rm -f "$current"
+    dmc_managed_release_recover "$plugin_dir" || true
+    warn "Data Machine Code $target activation verification failed — prior release restored"
+    return 0
+  fi
+  if [ "$(dmc_managed_release_header_version "$plugin_dir" 2>/dev/null || true)" != "$target" ] || ! grep -Fq "\"sha256\":\"$actual\"" "$(dmc_managed_release_provenance_file)"; then
+    rm -f "$current"
+    dmc_managed_release_recover "$plugin_dir" || true
+    warn "Data Machine Code $target version/provenance verification failed — prior release restored"
+    return 0
+  fi
+  fix_ownership "$plugin_dir"
+  UPDATED_ITEMS+=("data-machine-code $target (official copied release)")
+}

--- a/templates/wp-coding-agents-dmc-managed-release.php
+++ b/templates/wp-coding-agents-dmc-managed-release.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Plugin Name: wp-coding-agents - DMC managed release
+ * Description: Connects copied Data Machine Code deployments to the wp-coding-agents official-release updater.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+function wp_coding_agents_dmc_upgrade_command(): string {
+	return escapeshellarg( '@WP_CODING_AGENTS_UPGRADE_SCRIPT@' ) . ' --plugins-only --wp-path ' . escapeshellarg( ABSPATH );
+}
+
+function wp_coding_agents_dmc_release_status(): array {
+	$raw = shell_exec( wp_coding_agents_dmc_upgrade_command() . ' --dmc-managed-release-status 2>/dev/null' );
+	$status = is_string( $raw ) ? json_decode( $raw, true ) : null;
+	return is_array( $status ) ? $status : array();
+}
+
+function wp_coding_agents_dmc_read_version(): string {
+	$file = WP_PLUGIN_DIR . '/data-machine-code/data-machine-code.php';
+	$body = is_readable( $file ) ? (string) file_get_contents( $file ) : '';
+	return preg_match( '/^\s*\*\s*Version:\s*(.+)$/mi', $body, $matches ) ? trim( $matches[1] ) : '';
+}
+
+add_filter( 'datamachine_code_managed_release_channel', static function( array $channel ): array {
+	$status = wp_coding_agents_dmc_release_status();
+	if ( 'copied_deploy' !== ( $status['deployment'] ?? '' ) || empty( $status['latest_version'] ) ) {
+		return $channel;
+	}
+	return array(
+		'id' => 'wp-coding-agents-official-release',
+		'latest_version' => (string) $status['latest_version'],
+		'action' => array( 'type' => 'command', 'command' => wp_coding_agents_dmc_upgrade_command(), 'authorize_callback' => true ),
+		'converge' => static function(): array { return array( 'success' => 0 === (int) shell_exec( wp_coding_agents_dmc_upgrade_command() . ' >/dev/null 2>&1; echo $?' ) ); },
+		'read_installed_version' => 'wp_coding_agents_dmc_read_version',
+		'verify' => static function( string $version ) use ( $status ): array {
+			$provenance = WP_PLUGIN_DIR . '/data-machine-code/.wp-coding-agents-release-current/.wp-coding-agents-managed-release.json';
+			$record = is_readable( $provenance ) ? json_decode( (string) file_get_contents( $provenance ), true ) : null;
+			return is_array( $record ) && $version === ( $record['version'] ?? '' ) && $version === ( $status['latest_version'] ?? '' ) ? array( 'state' => 'verified' ) : array( 'state' => 'unverified' );
+		},
+	);
+} );
+
+add_filter( 'datamachine_code_runtime_source_doctor_config', static function( array $config ): array {
+	$config['command_contract'] = array( 'command' => 'datamachine-code runtime release', 'flag' => '--apply' );
+	return $config;
+} );

--- a/tests/dmc-managed-release-integration.sh
+++ b/tests/dmc-managed-release-integration.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Regression coverage for the wp-coding-agents-owned DMC integration contract.
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$ROOT_DIR/templates/wp-coding-agents-dmc-managed-release.php"
+
+require_source() {
+  grep -Fq -- "$1" "$TEMPLATE" || { echo "FAIL: missing $2" >&2; exit 1; }
+}
+
+require_source "datamachine_code_managed_release_channel" "managed release channel filter"
+require_source "--dmc-managed-release-status" "shared updater status endpoint"
+require_source "--plugins-only" "shared updater convergence command"
+require_source "datamachine_code_runtime_source_doctor_config" "runtime doctor integration filter"
+require_source "datamachine-code runtime release" "runtime doctor release command contract"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SITE_PATH="$TMP/site"
+SPECIAL_SCRIPT_DIR="$TMP/with & | ' special"
+mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$SPECIAL_SCRIPT_DIR/templates"
+cp "$TEMPLATE" "$SPECIAL_SCRIPT_DIR/templates/wp-coding-agents-dmc-managed-release.php"
+SCRIPT_DIR="$SPECIAL_SCRIPT_DIR"
+DRY_RUN=false
+UPDATED_ITEMS=()
+warn() { echo "FAIL: $*" >&2; exit 1; }
+service_file_normalize_perms() { :; }
+# shellcheck disable=SC1091
+source "$ROOT_DIR/lib/dmc-managed-release-integration.sh"
+dmc_managed_release_integration_sync
+rendered_script="${SPECIAL_SCRIPT_DIR//\'/\\\'}/upgrade.sh"
+grep -Fq "$rendered_script" "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-dmc-managed-release.php" || { echo "FAIL: special-character script path was not rendered safely" >&2; exit 1; }
+php -l "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-dmc-managed-release.php" >/dev/null || { echo "FAIL: rendered special-character path produced invalid PHP" >&2; exit 1; }
+
+echo "dmc-managed-release-integration tests passed"

--- a/tests/dmc-managed-release.sh
+++ b/tests/dmc-managed-release.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Deterministic coverage for copied DMC official-release updates.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/dmc-managed-release.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SITE_PATH="$TMP/site"
+TIMESTAMP="test"
+DRY_RUN=false
+INSTALL_DATA_MACHINE=true
+BLUE=""; NC=""
+declare -a UPDATED_ITEMS=()
+LOG=""
+log() { LOG="$LOG$*\n"; }
+warn() { LOG="$LOG$*\n"; }
+fix_ownership() { :; }
+ACTIVATIONS=0
+ACTIVE=true
+activate_plugin() { ACTIVATIONS=$((ACTIVATIONS + 1)); ACTIVE=true; }
+wp_cmd() { [ "$ACTIVE" = true ] && [ "$1 $2 $3" = "plugin is-active data-machine-code" ]; }
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+PLUGIN="$SITE_PATH/wp-content/plugins/data-machine-code"
+mkdir -p "$PLUGIN"
+printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN" "$TMP/release/data-machine-code"
+printf '<?php\n/*\n * Version: 2.0.0\n */\n' > "$TMP/release/data-machine-code/data-machine-code.php"
+(cd "$TMP/release" && zip -qr "$TMP/dmc.zip" data-machine-code)
+SHA="$(shasum -a 256 "$TMP/dmc.zip" | awk '{print $1}')"
+printf '%s  dmc.zip\n' "$SHA" > "$TMP/dmc.zip.sha256"
+cat > "$FAKE_BIN/curl" <<'SH'
+#!/bin/bash
+set -eu
+if [[ "$*" == *"releases/latest"* ]]; then
+  printf '%s' "$DMC_TEST_RELEASE_JSON"
+elif [[ "$*" == *"dmc.zip.sha256"* ]]; then cp "$DMC_TEST_CHECKSUM" "${@: -1}"
+elif [[ "$*" == *"dmc.zip"* ]]; then cp "$DMC_TEST_ARCHIVE" "${@: -1}"
+else exit 1
+fi
+SH
+chmod +x "$FAKE_BIN/curl"
+export PATH="$FAKE_BIN:$PATH" DMC_TEST_ARCHIVE="$TMP/dmc.zip" DMC_TEST_CHECKSUM="$TMP/dmc.zip.sha256"
+DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip"},{"name":"dmc.zip.sha256","browser_download_url":"https://release/dmc.zip.sha256"}]}'
+export DMC_TEST_RELEASE_JSON
+DMC_MANAGED_RELEASE_API="https://test/releases/latest"
+
+# copied + dry-run: resolves the channel but leaves the deployment untouched.
+DRY_RUN=true
+before="$(shasum -a 256 "$PLUGIN/data-machine-code.php")"
+out="$(update_data_machine_code_copied_release)"
+case "$out" in *"SHA-256 verify"*) : ;; *) fail "dry-run did not describe checksum verification";; esac
+[ "$before" = "$(shasum -a 256 "$PLUGIN/data-machine-code.php")" ] || fail "dry-run mutated copied plugin"
+
+# current copied install: no download/deploy and no update record.
+DRY_RUN=false
+printf '<?php\n/*\n * Version: 2.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+UPDATED_ITEMS=(); LOG=""
+update_data_machine_code_copied_release
+case "$LOG" in *"already at official release 2.0.0"*) : ;; *) fail "current copied install was not recognized";; esac
+[ "${#UPDATED_ITEMS[@]}" -eq 0 ] || fail "current copied install recorded an update"
+
+# checksum failure: preserve the old deployment.
+printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+printf '0%.0s' {1..64} > "$TMP/dmc.zip.sha256"
+printf '  dmc.zip\n' >> "$TMP/dmc.zip.sha256"
+LOG=""
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "checksum failure replaced deployment"
+case "$LOG" in *"SHA-256 verification"*) : ;; *) fail "checksum failure was not reported";; esac
+printf '%s  dmc.zip\n' "$SHA" > "$TMP/dmc.zip.sha256"
+
+# copied deployment: stage, preserve a fallback, activate, and record provenance.
+mkdir -p "$PLUGIN/obsolete"
+UPDATED_ITEMS=()
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "2.0.0" ] || fail "copied release did not deploy target version"
+[ -f "$(dmc_managed_release_provenance_file)" ] || fail "copied release provenance missing"
+[ -f "$PLUGIN/.wp-coding-agents-release-current/data-machine-code.php" ] || fail "copied release current pointer missing"
+[ ! -e "$PLUGIN/.wp-coding-agents-release-current/obsolete" ] || fail "copied release included stale files"
+[ "${#UPDATED_ITEMS[@]}" -eq 1 ] || fail "copied release was not recorded"
+
+# An inactive plugin remains inactive; deployment does not call activation.
+rm -rf "$PLUGIN"
+mkdir -p "$PLUGIN"
+printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+ACTIVE=false; ACTIVATIONS=0; UPDATED_ITEMS=()
+update_data_machine_code_copied_release
+[ "$ACTIVE" = false ] || fail "inactive plugin became active"
+[ "$ACTIVATIONS" -eq 0 ] || fail "inactive plugin activation was attempted"
+
+# Simulate interruption after current -> previous. Recovery restores a complete
+# release pointer before the next deployment attempt.
+mv "$PLUGIN/.wp-coding-agents-release-current" "$PLUGIN/.wp-coding-agents-release-previous"
+dmc_managed_release_recover "$PLUGIN"
+[ -f "$PLUGIN/.wp-coding-agents-release-current/data-machine-code.php" ] || fail "interrupted update recovery left no runnable release"
+
+# Malformed tags are rejected before download/deployment.
+rm -rf "$PLUGIN"
+mkdir -p "$PLUGIN"
+printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+DMC_TEST_RELEASE_JSON='{"tag_name":"release-latest","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip"},{"name":"dmc.zip.sha256","browser_download_url":"https://release/dmc.zip.sha256"}]}'
+LOG=""
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "malformed tag replaced deployment"
+case "$LOG" in *"Could not resolve"*) : ;; *) fail "malformed tag was not rejected";; esac
+DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip"},{"name":"dmc.zip.sha256","browser_download_url":"https://release/dmc.zip.sha256"}]}'
+
+# Channel status uses the same resolver and exposes the official target.
+status="$(dmc_managed_release_status)"
+case "$status" in *'"deployment":"copied_deploy"'*'"latest_version":"2.0.0"'*) : ;; *) fail "copied channel status incorrect: $status";; esac
+
+# git checkout: preserve the existing tagged-release path, never resolve assets.
+mkdir -p "$PLUGIN/.git"
+LOG=""
+update_data_machine_code_copied_release
+[ -z "$LOG" ] || fail "git checkout entered copied-release updater"
+
+# The channel helper distinguishes copied installs from git installs.
+status="$(dmc_managed_release_status)"
+case "$status" in *'"deployment":"git_checkout"'*) : ;; *) fail "git channel status incorrect: $status";; esac
+
+echo "dmc-managed-release tests passed"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents systems-capabilities; do
+for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine dmc-managed-release dmc-managed-release-integration carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents systems-capabilities; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -104,6 +104,7 @@ WITH_AI_GATEWAY=false
 WITH_CLAUDE_CODE_AUTH=true
 ROTATE_AI_GATEWAY_TOKEN=false
 SHOW_HELP=false
+DMC_MANAGED_RELEASE_STATUS=false
 SOURCE_MODE=""
 SOURCE_MODE_EXPLICIT=false
 OWNED_SOURCES=""
@@ -178,6 +179,7 @@ while [[ $# -gt 0 ]]; do
     --migrate-user)  MIGRATE_TARGET_USER="$2"; shift 2 ;;
     --migrate-extra) service_migration_add_extra_path "$2"; shift 2 ;;
     --help|-h)       SHOW_HELP=true; shift ;;
+    --dmc-managed-release-status) DMC_MANAGED_RELEASE_STATUS=true; shift ;;
     *)               shift ;;
   esac
 done
@@ -331,6 +333,15 @@ OPT-IN TOUCHES:
     authenticate with Claude Pro/Max OAuth. Use --no-claude-code-auth to skip.
 HELP
   exit 0
+fi
+
+# The DMC runtime integration invokes this narrow, read-only status endpoint to
+# inspect the same official-release channel used by --plugins-only.
+if [ "$DMC_MANAGED_RELEASE_STATUS" = true ]; then
+  SITE_PATH="${EXISTING_WP:-${SITE_PATH:-}}"
+  [ -n "$SITE_PATH" ] || error "--dmc-managed-release-status requires --wp-path <path>"
+  dmc_managed_release_status
+  exit $?
 fi
 
 if [ "$PLUGINS_ONLY" = true ] && [ "$SKIP_PLUGINS" = true ]; then
@@ -571,6 +582,7 @@ _run_filter_active() {
 update_data_machine_plugins() {
   _run_filter_active plugins || return 0
   upgrade_data_machine_plugins
+  dmc_managed_release_integration_sync
   sync_carried_plugins
   update_wp_codebox_plugin_subtree
 }


### PR DESCRIPTION
## Summary

- update copied DMC installs from verified official release assets while preserving activation state
- add interruption-safe release pointers, rollback, version/digest validation, and current/git no-op paths
- register wp-coding-agents-owned managed-release/runtime-doctor integration

Closes #404.

## Verification

- copied release and integration suites
- CI coverage, WP Codebox subtree, and OpenCode auth sync suites
- shell/PHP syntax and `git diff --check`

## AI assistance

GPT-5.6-sol via OpenCode coordinated direct coding and review subagents, implemented the managed updater, corrected deployment-safety findings, and ran verification. Chris Huber remains responsible for every line.