### PR TITLE
fix: expose DMC provider convergence

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -125,6 +125,9 @@ homeboy_dmc_command_json() {
       # contract on creation and on owner-identical retries.
       homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree add '{repo}' '{head}' '--from={base}' '--task-url={task_url}' '--reuse-policy=isolated' '--purpose={purpose}' '--owner-run-ref={owner_run_ref}' '--cleanup-policy={cleanup_policy}' --format=json "${wp_flags[@]}"
       ;;
+    converge)
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" converge "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{identity}' '{base}'
+      ;;
     cleanup_preview)
       homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --dry-run --format=json "${wp_flags[@]}"
       ;;
@@ -135,12 +138,13 @@ homeboy_dmc_command_json() {
 }
 
 homeboy_dmc_worktree_provider_json() {
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"mutation_timeout_ms":120000,"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"mutation_timeout_ms":120000,"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
     "$(homeboy_dmc_command_json resolve_identity)" \
     "$(homeboy_dmc_command_json attest_safety)" \
     "$(homeboy_dmc_command_json resolve)" \
     "$(homeboy_dmc_command_json resolve_path)" \
     "$(homeboy_dmc_command_json ensure)" \
+    "$(homeboy_dmc_command_json converge)" \
     "$(homeboy_dmc_command_json cleanup_preview)" \
     "$(homeboy_dmc_command_json cleanup_apply)"
 }

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -6,14 +6,19 @@ $operation = (string) ( $argv[1] ?? '' );
 $provider  = (string) ( $argv[2] ?? '' );
 $workspace = (string) ( $argv[3] ?? '' );
 $value     = (string) ( $argv[4] ?? '' );
+$base      = (string) ( $argv[5] ?? '' );
 
-if ( ! in_array($operation, array( 'identity', 'safety', 'resolve' ), true) || '' === $provider || '' === $workspace || '' === $value ) {
-	fwrite(STDERR, "Usage: homeboy-dmc-provider.php <identity|safety|resolve> <dmc-provider> <workspace-root> <handle|path|identity-token>\n");
+if ( ! in_array($operation, array( 'identity', 'safety', 'resolve', 'converge' ), true) || '' === $provider || '' === $workspace || '' === $value || ( 'converge' === $operation && '' === $base ) ) {
+	fwrite(STDERR, "Usage: homeboy-dmc-provider.php <identity|safety|resolve|converge> <dmc-provider> <workspace-root> <handle|path|identity-token> [base-sha]\n");
 	exit(2);
 }
 
-$run_provider = static function ( string $provider_operation, string $provider_value ) use ( $provider, $workspace ): array {
-	$process = proc_open(array( PHP_BINARY, $provider, $provider_operation, $workspace, $provider_value ), array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
+$run_provider = static function ( string $provider_operation, string $provider_value, string $provider_base = '' ) use ( $provider, $workspace ): array {
+	$command = array( PHP_BINARY, $provider, $provider_operation, $workspace, $provider_value );
+	if ( '' !== $provider_base ) {
+		$command[] = $provider_base;
+	}
+	$process = proc_open($command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
 	if ( ! is_resource($process) ) {
 		throw new RuntimeException('Could not start the DMC worktree provider.');
 	}
@@ -34,7 +39,7 @@ $run_provider = static function ( string $provider_operation, string $provider_v
 
 try {
 	$identity_input = 'resolve' === $operation && str_starts_with($value, '/') ? basename($value) : $value;
-	$payload        = $run_provider('resolve' === $operation ? 'identity' : $operation, $identity_input);
+	$payload        = $run_provider('resolve' === $operation ? 'identity' : $operation, $identity_input, 'converge' === $operation ? $base : '');
 } catch (Throwable $error) {
 	fwrite(STDERR, $error->getMessage() . "\n");
 	exit($error->getCode() > 0 && $error->getCode() < 256 ? $error->getCode() : 1);
@@ -64,6 +69,12 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 		'fresh'          => $payload['fresh'] ?? false,
 		'latency_ms'     => $payload['latency_ms'] ?? 0,
 		'budget_ms'      => 0,
+	);
+} elseif ( 'converge' === $operation && 'datamachine-code/worktree-convergence/v1' === ( $payload['schema'] ?? null ) && 'converged' === ( $payload['status'] ?? null ) && $value === ( $payload['identity_token'] ?? null ) && $base === ( $payload['base_sha'] ?? null ) ) {
+	$result = array(
+		'schema'         => 'homeboy/worktree-provider-convergence/v1',
+		'identity_token' => $value,
+		'base_sha'       => $base,
 	);
 } elseif ( 'resolve' === $operation && in_array((string) ( $payload['status'] ?? '' ), array( 'not_owned', 'not_found' ), true) ) {
 	$result = array( 'success' => false, 'error' => array( 'code' => 'worktree_not_found', 'message' => 'DMC does not own the requested worktree.' ) );

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -58,6 +58,7 @@ expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}"]
 expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{identity}"]
+expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{identity}", "{base}"]
 if provider.get("lookup_timeout_ms") != 10000:
     raise SystemExit("FAIL: standalone DMC lookups must retain a bounded timeout")
 if provider.get("mutation_timeout_ms") != 120000:
@@ -74,8 +75,43 @@ if commands.get("resolve_identity") != expected_identity:
     raise SystemExit(f"FAIL: DMC standalone identity mapping mismatch: {commands.get('resolve_identity')!r}")
 if commands.get("attest_safety") != expected_safety:
     raise SystemExit(f"FAIL: DMC standalone safety mapping mismatch: {commands.get('attest_safety')!r}")
+if commands.get("converge") != expected_converge:
+    raise SystemExit(f"FAIL: DMC convergence mapping must bind the opaque identity and pinned base: {commands.get('converge')!r}")
 if "list" in commands or "list_result_mapping" in provider:
     raise SystemExit("FAIL: DMC provider must not advertise unsupported generic list capability")
+PY
+}
+
+assert_convergence_contract() {
+  python3 - "$1" "$DMC_PROVIDER_LOG" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+line = open(sys.argv[1], encoding="utf-8").read().strip()
+_, payload = line.split("|", 1)
+command = json.loads(payload)["commands"]["converge"]
+identity = "fixture-token"
+base = "0123456789012345678901234567890123456789"
+
+def run(mode):
+    env = os.environ.copy()
+    env["DMC_CONVERGENCE_MODE"] = mode
+    return subprocess.run([part.replace("{identity}", identity).replace("{base}", base) for part in command], text=True, capture_output=True, env=env)
+
+success = run("success")
+expected = {"schema": "homeboy/worktree-provider-convergence/v1", "identity_token": identity, "base_sha": base}
+if success.returncode or json.loads(success.stdout) != expected:
+    raise SystemExit(f"FAIL: DMC convergence success did not preserve exact Homeboy evidence: {success!r}")
+for mode in ("mismatched", "stale", "refused"):
+    result = run(mode)
+    if result.returncode == 0 or result.stdout:
+        raise SystemExit(f"FAIL: DMC {mode} convergence response must fail closed: {result!r}")
+
+log = open(sys.argv[2], encoding="utf-8").read()
+if f"converge|{identity}|{base}" not in log:
+    raise SystemExit("FAIL: DMC converge did not receive the opaque identity and pinned base")
 PY
 }
 
@@ -119,7 +155,8 @@ cat > "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider
 <?php
 $operation = $argv[1] ?? '';
 $value = $argv[3] ?? '';
-file_put_contents(getenv('DMC_PROVIDER_LOG'), $operation . "|" . $value . "\n", FILE_APPEND);
+$base = $argv[4] ?? '';
+file_put_contents(getenv('DMC_PROVIDER_LOG'), $operation . "|" . $value . ('' === $base ? '' : "|" . $base) . "\n", FILE_APPEND);
 if ('identity' === $operation) {
     if (!file_exists(getenv('DMC_STATE'))) {
         echo json_encode(array('schema' => 'datamachine-code/worktree-identity/v1', 'status' => 'not_owned', 'ownership' => 'not_owned')) . "\n";
@@ -149,6 +186,25 @@ if ('safety' === $operation && 'fixture-token' === $value) {
         'latency_ms' => 2,
     )) . "\n";
     exit(0);
+}
+if ('converge' === $operation && 'fixture-token' === $value) {
+    $mode = getenv('DMC_CONVERGENCE_MODE');
+    if ('success' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'converged', 'identity_token' => $value, 'base_sha' => $base)) . "\n";
+        exit(0);
+    }
+    if ('mismatched' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'converged', 'identity_token' => 'other-token', 'base_sha' => $base)) . "\n";
+        exit(0);
+    }
+    if ('stale' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'stale', 'identity_token' => $value, 'base_sha' => $base)) . "\n";
+        exit(0);
+    }
+    if ('refused' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'refused', 'identity_token' => $value, 'base_sha' => $base)) . "\n";
+        exit(0);
+    }
 }
 fwrite(STDERR, "unsupported fixture request\n");
 exit(1);
@@ -215,6 +271,7 @@ configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
 assert_contains "\"resolve_identity\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"identity\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
 assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"safety\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{identity}\"]" "$TMP/dry-run.log"
+assert_contains "\"converge\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"converge\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{identity}\",\"{base}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{path}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
@@ -237,6 +294,7 @@ assert_not_contains 'workspace worktree list' "$STUDIO_LOG"
 assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
+assert_convergence_contract "$HOMEBOY_CONFIG_LOG"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
 
 HOMEBOY_MODE="disabled"


### PR DESCRIPTION
Closes #408.

Adds the generated DMC `commands.converge` mapping with token and pinned-base placeholders. The adapter invokes DMC standalone convergence, accepts only a converged DMC envelope bound to those exact inputs, and emits the exact Homeboy convergence evidence schema.

Tests:
- `bash tests/homeboy-dmc-provider.sh`
- `./verify.sh` (no WordPress install found; exited successfully)

AI assistance: OpenAI GPT-5.6 Sol via OpenCode was used to diagnose, implement, and verify this change. Chris Huber remains responsible.