### PR TITLE
fix: bootstrap colocated OpenCode subagent graph

### DIFF
--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -100,7 +100,11 @@ sys.stdout.buffer.write(value)
       return 1
     }
   else
-    agent_json="$(wp_cmd eval-file "$graph_helper" -- "$AGENT_SLUG" 2>/dev/null)" || {
+    local reader_code reader_payload slug_payload
+    reader_payload="$(base64 < "$graph_helper" | tr -d '\n')"
+    slug_payload="$(printf '%s' "$AGENT_SLUG" | base64 | tr -d '\n')"
+    reader_code="\$args=array(base64_decode('$slug_payload'));eval('?>'.base64_decode('$reader_payload'));"
+    agent_json="$(wp_cmd eval "$reader_code" 2>/dev/null)" || {
       warn "Could not read the Agents API subagent graph for coordinator '$AGENT_SLUG'"
       return 1
     }

--- a/tests/opencode-subagents-reader.php
+++ b/tests/opencode-subagents-reader.php
@@ -60,6 +60,32 @@ function wp_get_ability( string $slug ): object {
 	};
 }
 
+$payload = $argv[1] ?? '';
+if ( '--payload' === $payload ) {
+	$reader_code = $argv[2] ?? '';
+	if ( ! is_string( $reader_code ) || '' === $reader_code ) {
+		fwrite( STDERR, "FAIL: missing generated reader payload\n" );
+		exit( 1 );
+	}
+
+	ob_start();
+	try {
+		eval( $reader_code );
+	} catch ( Throwable $error ) {
+		ob_end_clean();
+		throw $error;
+	}
+	$encoded = ob_get_clean();
+	$graph   = json_decode( $encoded, true, 512, JSON_THROW_ON_ERROR );
+	if ( 'coordinator' !== ( $graph['coordinator'] ?? null ) || 'coordinator' !== ( $graph['nodes'][0]['slug'] ?? null ) ) {
+		fwrite( STDERR, "FAIL: generated reader payload did not resolve the coordinator graph\n" );
+		exit( 1 );
+	}
+
+	echo $encoded;
+	exit( 0 );
+}
+
 $embedded = isset( $argv[1] ) && '--embedded' === $argv[1];
 $scenario = $argv[2] ?? '';
 if ( 'outside' === $scenario ) {

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -21,7 +21,17 @@ warn() { printf '%s\n' "$*" >&2; }
 FAILED=0
 assert() { if "$@"; then printf '  ok   %s\n' "$*"; else printf '  FAIL %s\n' "$*"; FAILED=$((FAILED + 1)); fi; }
 assert_python() { local name="$1"; shift; if python3 - "$@"; then printf '  ok   %s\n' "$name"; else printf '  FAIL %s\n' "$name"; FAILED=$((FAILED + 1)); fi; }
-wp_cmd() { [ "$1" = eval ] && [ "$#" -eq 2 ] || return 1; cat "$TMP/graph.json"; }
+wp_cmd() {
+  [ "$1" = eval ] && [ "$#" -eq 2 ] || return 1
+  php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --payload "$2" > "$TMP/colocated-payload-graph.json"
+  python3 - "$TMP/colocated-payload-graph.json" <<'PY'
+import json, sys
+graph = json.load(open(sys.argv[1]))
+assert graph['coordinator'] == 'coordinator'
+assert graph['nodes'][0]['slug'] == 'coordinator'
+PY
+  cat "$TMP/graph.json"
+}
 
 php "$SCRIPT_DIR/tests/opencode-subagents-reader.php"
 php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --embedded

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -21,7 +21,7 @@ warn() { printf '%s\n' "$*" >&2; }
 FAILED=0
 assert() { if "$@"; then printf '  ok   %s\n' "$*"; else printf '  FAIL %s\n' "$*"; FAILED=$((FAILED + 1)); fi; }
 assert_python() { local name="$1"; shift; if python3 - "$@"; then printf '  ok   %s\n' "$name"; else printf '  FAIL %s\n' "$name"; FAILED=$((FAILED + 1)); fi; }
-wp_cmd() { [ "$1" = eval-file ] && [ "$2" = "$SCRIPT_DIR/lib/read-opencode-subagent-graph.php" ] && [ "$3" = -- ] && [ "$4" = "$AGENT_SLUG" ]; cat "$TMP/graph.json"; }
+wp_cmd() { [ "$1" = eval ] && [ "$#" -eq 2 ] || return 1; cat "$TMP/graph.json"; }
 
 php "$SCRIPT_DIR/tests/opencode-subagents-reader.php"
 php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --embedded


### PR DESCRIPTION
Closes #413

## Summary

- Run the colocated subagent graph reader through post-bootstrap `wp eval`, matching the existing external transport.
- Keep the reader payload and coordinator slug argv-safe through base64 encoding.
- Require `eval` in the colocated projection regression fixture.

## Verification

- `bash tests/opencode-subagents.sh`
- `bash tests/ci-coverage.sh`
- `bash -n lib/opencode-subagents.sh`
- `bash -n tests/opencode-subagents.sh`
- `php -l lib/read-opencode-subagent-graph.php`
- `php -l tests/opencode-subagents-reader.php`
- Serialized reader payload against the configured local WordPress runtime resolves `intelligence-chubes4`.

## AI assistance

OpenAI `openai/gpt-5.6-terra` via OpenCode was used to reproduce the WP-CLI evaluation-scope mismatch, implement the small transport fix, and run the listed verification. Chris Huber reviewed the change and remains responsible for it.