### PR TITLE
fix: resolve DMC provider from source contract

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -95,6 +95,7 @@ homeboy_dmc_wp_flags() {
 
 homeboy_dmc_command_json() {
   local action="$1"
+  local provider="${2:-}"
   local wp_argv=()
   local wp_flags=()
   local value
@@ -109,16 +110,16 @@ homeboy_dmc_command_json() {
 
   case "$action" in
     resolve_identity)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" identity "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{handle}'
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" identity "$provider" "$DM_WORKSPACE_DIR" '{handle}'
       ;;
     attest_safety)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" safety "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{identity}'
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" safety "$provider" "$DM_WORKSPACE_DIR" '{identity}'
       ;;
     resolve)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{handle}'
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$provider" "$DM_WORKSPACE_DIR" '{handle}'
       ;;
     resolve_path)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{path}'
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$provider" "$DM_WORKSPACE_DIR" '{path}'
       ;;
     ensure)
       # Homeboy owns each fanout worktree lifecycle. DMC verifies this complete
@@ -126,7 +127,7 @@ homeboy_dmc_command_json() {
       homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree add '{repo}' '{head}' '--from={base}' '--task-url={task_url}' '--reuse-policy=isolated' '--purpose={purpose}' '--owner-run-ref={owner_run_ref}' '--cleanup-policy={cleanup_policy}' --format=json "${wp_flags[@]}"
       ;;
     converge)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" converge "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{identity}' '{base}'
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" converge "$provider" "$DM_WORKSPACE_DIR" '{identity}' '{base}'
       ;;
     plan)
       # Project DMC's digest-addressed allocation decision into Homeboy's
@@ -143,21 +144,21 @@ homeboy_dmc_command_json() {
 }
 
 homeboy_dmc_worktree_provider_json() {
+  local provider="$1"
   printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"mutation_timeout_ms":120000,"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
-    "$(homeboy_dmc_command_json resolve_identity)" \
-    "$(homeboy_dmc_command_json attest_safety)" \
-    "$(homeboy_dmc_command_json resolve)" \
-    "$(homeboy_dmc_command_json resolve_path)" \
-    "$(homeboy_dmc_command_json ensure)" \
-    "$(homeboy_dmc_command_json converge)" \
-    "$(homeboy_dmc_command_json plan)" \
-    "$(homeboy_dmc_command_json cleanup_preview)" \
-    "$(homeboy_dmc_command_json cleanup_apply)"
+    "$(homeboy_dmc_command_json resolve_identity "$provider")" \
+    "$(homeboy_dmc_command_json attest_safety "$provider")" \
+    "$(homeboy_dmc_command_json resolve "$provider")" \
+    "$(homeboy_dmc_command_json resolve_path "$provider")" \
+    "$(homeboy_dmc_command_json ensure "$provider")" \
+    "$(homeboy_dmc_command_json converge "$provider")" \
+    "$(homeboy_dmc_command_json plan "$provider")" \
+    "$(homeboy_dmc_command_json cleanup_preview "$provider")" \
+    "$(homeboy_dmc_command_json cleanup_apply "$provider")"
 }
 
 homeboy_dmc_worktree_provider_ready() {
-  local provider response
-  provider="$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider"
+  local provider="$1" response
 
   [ -f "$provider" ] || return 1
   [ -d "${DM_WORKSPACE_DIR:-}" ] || return 1
@@ -176,6 +177,34 @@ except Exception:
 
 sys.exit(0 if payload.get("schema") == "datamachine-code/worktree-identity/v1" and payload.get("status") == "not_owned" and payload.get("ownership") == "not_owned" else 1)
 ' >/dev/null 2>&1
+}
+
+homeboy_dmc_worktree_provider_executable() {
+  local wp_argv=() wp_flags=() value response
+
+  while IFS= read -r value; do
+    wp_argv+=("$value")
+  done < <(homeboy_dmc_wp_argv)
+  while IFS= read -r value; do
+    wp_flags+=("$value")
+  done < <(homeboy_dmc_wp_flags)
+
+  response="$("${wp_argv[@]}" datamachine-code workspace worktree provider --format=json "${wp_flags[@]}" 2>/dev/null)" || return 1
+  printf '%s' "$response" | python3 -c '
+import json
+import os
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+executable = payload.get("executable")
+if payload.get("schema") != "datamachine-code/standalone-worktree-provider-command/v1" or not isinstance(executable, str) or not os.path.isfile(executable):
+    sys.exit(1)
+print(executable)
+'
 }
 
 homeboy_project_id() {
@@ -516,8 +545,12 @@ configure_homeboy_dmc_worktree_provider() {
     return 0
   fi
 
-  local provider_json
-  provider_json="$(homeboy_dmc_worktree_provider_json)"
+  local provider provider_json
+  provider="$(homeboy_dmc_worktree_provider_executable)" || {
+    homeboy_handle_failure "Data Machine Code standalone worktree provider source contract is unavailable; skipping Homeboy DMC worktree provider setup."
+    return 0
+  }
+  provider_json="$(homeboy_dmc_worktree_provider_json "$provider")"
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} homeboy config set /worktree_providers/dmc '$provider_json'"
@@ -525,7 +558,7 @@ configure_homeboy_dmc_worktree_provider() {
   fi
 
   if [ -n "${SITE_PATH:-}" ] && { [ -f "$SITE_PATH/wp-config.php" ] || [ -f "$SITE_PATH/wp-load.php" ]; }; then
-    if ! homeboy_dmc_worktree_provider_ready; then
+    if ! homeboy_dmc_worktree_provider_ready "$provider"; then
       homeboy_handle_failure "Data Machine Code standalone worktree provider is not available; skipping Homeboy DMC worktree provider setup."
       return 0
     fi

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -23,7 +23,7 @@ IS_STUDIO=true
 LOCAL_MODE=true
 HOMEBOY_MODE="auto"
 WITH_HOMEBOY=false
-mkdir -p "$SITE_PATH/wp-content/plugins/data-machine-code/bin" "$DM_WORKSPACE_DIR"
+mkdir -p "$SITE_PATH/wp-content/plugins/data-machine-code/bin" "$TMP/dmc-source/bin" "$DM_WORKSPACE_DIR"
 touch "$SITE_PATH/wp-config.php"
 
 assert_contains() {
@@ -45,7 +45,7 @@ assert_not_contains() {
 }
 
 assert_provider_contract() {
-  python3 - "$1" "$2" "$3" "$DM_WORKSPACE_DIR" <<'PY'
+  python3 - "$1" "$2" "$3" "$DM_WORKSPACE_DIR" "$DMC_PROVIDER_EXECUTABLE" <<'PY'
 import json
 import sys
 
@@ -55,13 +55,13 @@ if not lines:
 _, payload = lines[-1].split("|", 1)
 provider = json.loads(payload)
 commands = provider["commands"]
-expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}"]
-expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{path}"]
+expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{handle}"]
+expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{path}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
-expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}"]
-expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{identity}"]
-expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{identity}", "{base}"]
+expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", sys.argv[5], sys.argv[4], "{handle}"]
+expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", sys.argv[5], sys.argv[4], "{identity}"]
+expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", sys.argv[5], sys.argv[4], "{identity}", "{base}"]
 if provider.get("lookup_timeout_ms") != 10000:
     raise SystemExit("FAIL: standalone DMC lookups must retain a bounded timeout")
 if provider.get("mutation_timeout_ms") != 120000:
@@ -234,6 +234,8 @@ fwrite(STDERR, "unsupported fixture request\n");
 exit(1);
 PHP
 chmod +x "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider"
+cp "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$TMP/dmc-source/bin/dmc-worktree-provider"
+chmod +x "$TMP/dmc-source/bin/dmc-worktree-provider"
 
 cat > "$FAKE_BIN/homeboy" <<'SH'
 #!/bin/sh
@@ -259,6 +261,10 @@ if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree get" ]; then
   fi
   printf '{"success":false,"error":{"code":"worktree_not_found"}}\n'
   exit 1
+fi
+if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree provider" ]; then
+  printf '{"schema":"datamachine-code/standalone-worktree-provider-command/v1","executable":"%s"}\n' "$DMC_PROVIDER_EXECUTABLE"
+  exit 0
 fi
 if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree plan" ]; then
   [ "$6" = "blocks-engine" ] && [ "$7" = "fix/406-dmc-provider-plan" ] || exit 2
@@ -292,9 +298,10 @@ DMC_STATE="$TMP/dmc-state"
 DMC_ENSURE_LOG="$TMP/dmc-ensure.log"
 DMC_PLAN_PATH="$DM_WORKSPACE_DIR/blocks-engine@fix-406-dmc-provider-plan"
 DMC_PROVIDER_LOG="$TMP/dmc-provider.log"
+DMC_PROVIDER_EXECUTABLE="$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider"
 : > "$DMC_ENSURE_LOG"
 : > "$STUDIO_LOG"
-export HOMEBOY_CONFIG_LOG STUDIO_LOG DMC_STATE DMC_ENSURE_LOG DMC_PLAN_PATH DMC_PROVIDER_LOG
+export HOMEBOY_CONFIG_LOG STUDIO_LOG DMC_STATE DMC_ENSURE_LOG DMC_PLAN_PATH DMC_PROVIDER_LOG DMC_PROVIDER_EXECUTABLE
 
 # macOS ships Bash 3.2, which has no mapfile/readarray builtin. Disable it
 # when the test runs under newer Bash so this path stays portable.
@@ -304,11 +311,11 @@ DRY_RUN=true
 configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"
 
 assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$TMP/dry-run.log"
-assert_contains "\"resolve_identity\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"identity\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
-assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"safety\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{identity}\"]" "$TMP/dry-run.log"
-assert_contains "\"converge\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"converge\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{identity}\",\"{base}\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{path}\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_identity\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"identity\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
+assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"safety\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{identity}\"]" "$TMP/dry-run.log"
+assert_contains "\"converge\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"converge\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{identity}\",\"{base}\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{path}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"plan\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"plan\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"plan\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
@@ -332,6 +339,17 @@ assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
 assert_convergence_contract "$HOMEBOY_CONFIG_LOG"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
+
+# A source checkout can expose the provider outside the historical installed-plugin path.
+DMC_PROVIDER_EXECUTABLE="$TMP/dmc-source/bin/dmc-worktree-provider"
+export DMC_PROVIDER_EXECUTABLE
+rm -f "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider"
+rm -f "$DMC_STATE"
+: > "$HOMEBOY_CONFIG_LOG"
+configure_homeboy_dmc_worktree_provider > "$TMP/source-contract.log"
+assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
+assert_contains "$DMC_PROVIDER_EXECUTABLE" "$HOMEBOY_CONFIG_LOG"
+assert_not_contains "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$HOMEBOY_CONFIG_LOG"
 
 # The same generated set operation is used during upgrade, replacing stale
 # installed provider objects rather than retaining their missing plan command.


### PR DESCRIPTION
## Summary

Closes #412.

- resolve the DMC standalone provider once through DMC's typed source contract before readiness and configuration
- generate identity, safety, resolve, and convergence adapter commands from that executable
- preserve typed readiness and provider evidence
- cover installed-plugin and source-only provider layouts deterministically

Depends on Extra-Chill/data-machine-code#1169.

## Tests

- `bash tests/homeboy-dmc-provider.sh`
- `bash -n lib/homeboy.sh tests/homeboy-dmc-provider.sh`
- `git diff --check`

## AI assistance

OpenAI `openai/gpt-5.6-terra` via OpenCode inspected issue #412, related DMC and wp-coding-agents work, implemented the source-contract consumer, added deterministic layout coverage, and ran the listed checks. Chris Huber remains responsible for review and merge.