### PR TITLE
fix: preserve DMC tracker evidence in resolve

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -115,10 +115,10 @@ homeboy_dmc_command_json() {
       homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" safety "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{identity}'
       ;;
     resolve)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{handle}'
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{handle}' "${wp_argv[@]}" datamachine-code workspace worktree get '{handle}' --format=json "${wp_flags[@]}"
       ;;
     resolve_path)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{path}'
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$DM_WORKSPACE_DIR" '{path}' "${wp_argv[@]}" datamachine-code workspace worktree get '{path}' --format=json "${wp_flags[@]}"
       ;;
     ensure)
       # Homeboy owns each fanout worktree lifecycle. DMC verifies this complete
@@ -143,7 +143,7 @@ homeboy_dmc_command_json() {
 }
 
 homeboy_dmc_worktree_provider_json() {
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"mutation_timeout_ms":120000,"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
     "$(homeboy_dmc_command_json resolve_identity)" \
     "$(homeboy_dmc_command_json attest_safety)" \
     "$(homeboy_dmc_command_json resolve)" \

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -21,6 +21,13 @@ if ( 'plan' === $operation ) {
 	fclose($pipes[2]);
 	$status = proc_close($process);
 	if ( 0 !== $status ) {
+		$evidence = trim($stdout . "\n" . $stderr);
+		if ( preg_match('/Disposition:\s*(unsafe|owner(?:ship)?[ _-]conflict)/i', $evidence, $matches) ) {
+			$normalized = strtolower(str_replace(array( ' ', '-' ), '_', $matches[1]));
+			$disposition = in_array($normalized, array( 'owner_conflict', 'ownership_conflict' ), true) ? 'owner_conflict' : 'unsafe';
+			fwrite(STDERR, 'DMC worktree plan disposition: ' . $disposition . "\n");
+			exit($status > 0 && $status < 256 ? $status : 1);
+		}
 		fwrite(STDERR, 'DMC worktree plan failed: ' . trim($stderr) . "\n");
 		exit($status > 0 && $status < 256 ? $status : 1);
 	}
@@ -36,7 +43,7 @@ if ( 'plan' === $operation ) {
 	}
 	$disposition = (string) ( $plan['disposition'] ?? '' );
 	if ( ! in_array($disposition, array( 'create', 'exact_reuse', 'adoptable' ), true) ) {
-		fwrite(STDERR, 'DMC worktree plan refused the requested destination: ' . ( $disposition ?: 'unknown' ) . "\n");
+		fwrite(STDERR, 'DMC worktree plan disposition: ' . ( $disposition ?: 'unknown' ) . "\n");
 		exit(1);
 	}
 	$handle = $plan['handle'] ?? null;
@@ -60,6 +67,30 @@ if ( ! in_array($operation, array( 'identity', 'safety', 'resolve', 'converge' )
 	fwrite(STDERR, "Usage: homeboy-dmc-provider.php <identity|safety|resolve|converge> <dmc-provider> <workspace-root> <handle|path|identity-token> [base-sha]\n");
 	exit(2);
 }
+
+/** @return array<string,mixed> */
+$read_inventory = static function ( array $command ) use ( $value ): array {
+	if ( array() === $command ) {
+		throw new RuntimeException('DMC aggregate inventory command is required for resolve.');
+	}
+	$process = proc_open($command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
+	if ( ! is_resource($process) ) {
+		throw new RuntimeException('Could not start the DMC aggregate inventory command.');
+	}
+	$stdout = stream_get_contents($pipes[1]);
+	$stderr = stream_get_contents($pipes[2]);
+	fclose($pipes[1]);
+	fclose($pipes[2]);
+	$status = proc_close($process);
+	if ( 0 !== $status ) {
+		throw new RuntimeException('DMC aggregate inventory failed: ' . trim($stderr), $status);
+	}
+	$inventory = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+	if ( ! is_array($inventory) || 1 !== count($inventory) || ! is_array($inventory[0] ?? null) ) {
+		throw new RuntimeException('DMC aggregate inventory did not return one typed worktree record.');
+	}
+	return $inventory[0];
+};
 
 $run_provider = static function ( string $provider_operation, string $provider_value, string $provider_base = '' ) use ( $provider, $workspace ): array {
 	$command = array( PHP_BINARY, $provider, $provider_operation, $workspace, $provider_value );
@@ -132,6 +163,7 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 	} else {
 		try {
 			$safety = $run_provider('safety', (string) ( $payload['token'] ?? '' ));
+			$inventory = $read_inventory(array_slice($argv, 5));
 		} catch (Throwable $error) {
 			fwrite(STDERR, $error->getMessage() . "\n");
 			exit($error->getCode() > 0 && $error->getCode() < 256 ? $error->getCode() : 1);
@@ -140,11 +172,32 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 			fwrite(STDERR, "DMC worktree provider returned an unsupported safety envelope.\n");
 			exit(1);
 		}
+		$task_url = $inventory['task_full']['task_url'] ?? null;
+		$owner_site = $inventory['owner_full']['site'] ?? null;
+		$owner_agent = $inventory['owner_full']['agent'] ?? null;
+		$lineage_task_url = $inventory['metadata']['origin_task']['task_url'] ?? null;
+		$lineage_site = $inventory['metadata']['origin_site'] ?? null;
+		$lineage_agent = $inventory['metadata']['origin_agent'] ?? null;
+		if (
+			! is_string($task_url) || '' === $task_url
+			|| ! is_string($owner_site) || '' === $owner_site
+			|| ! is_string($owner_agent) || '' === $owner_agent
+			|| $payload['handle'] !== ( $inventory['handle'] ?? null )
+			|| $payload['path'] !== ( $inventory['path'] ?? null )
+			|| $payload['branch'] !== ( $inventory['branch'] ?? null )
+			|| $task_url !== $lineage_task_url
+			|| $owner_site !== $lineage_site
+			|| $owner_agent !== $lineage_agent
+		) {
+			fwrite(STDERR, "DMC aggregate inventory does not prove tracker ownership for the standalone identity.\n");
+			exit(1);
+		}
 		$result = array(
 			array(
 				'handle'  => $payload['handle'] ?? '',
 				'path'    => $payload['path'] ?? '',
 				'branch'  => $payload['branch'] ?? '',
+				'task_url' => $task_url,
 				'safety'  => array(
 					'dirty'    => $safety['dirty'] ?? true,
 					'unpushed' => $safety['unpushed'] ?? true,

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -55,8 +55,8 @@ if not lines:
 _, payload = lines[-1].split("|", 1)
 provider = json.loads(payload)
 commands = provider["commands"]
-expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}"]
-expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{path}"]
+expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{handle}", "--format=json", f"--path={sys.argv[3]}"]
+expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{path}", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{path}", "--format=json", f"--path={sys.argv[3]}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", f"{sys.argv[3]}/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider", sys.argv[4], "{handle}"]
@@ -68,6 +68,9 @@ if provider.get("mutation_timeout_ms") != 120000:
     raise SystemExit("FAIL: DMC mutation timeout must accommodate worktree creation and bootstrap")
 if commands.get("resolve_not_found_exit_codes") != [42]:
     raise SystemExit("FAIL: DMC typed-not-found classification must be exactly [42]")
+mapping = provider.get("list_result_mapping")
+if mapping != {"items": "$", "handle": "$.handle", "path": "$.path", "branch": "$.branch", "task_url": "$.task_url", "dirty": "$.safety.dirty", "unpushed": "$.safety.unpushed", "primary": "$.safety.primary"}:
+    raise SystemExit(f"FAIL: DMC resolve mapping must explicitly project tracker ownership: {mapping!r}")
 if commands.get("resolve") != expected_resolve:
     raise SystemExit(f"FAIL: DMC resolve adapter mapping mismatch: {commands.get('resolve')!r}")
 if commands.get("resolve_path") != expected_resolve_path:
@@ -82,7 +85,7 @@ if commands.get("attest_safety") != expected_safety:
     raise SystemExit(f"FAIL: DMC standalone safety mapping mismatch: {commands.get('attest_safety')!r}")
 if commands.get("converge") != expected_converge:
     raise SystemExit(f"FAIL: DMC convergence mapping must bind the opaque identity and pinned base: {commands.get('converge')!r}")
-if "list" in commands or "list_result_mapping" in provider:
+if "list" in commands:
     raise SystemExit("FAIL: DMC provider must not advertise unsupported generic list capability")
 PY
 }
@@ -168,6 +171,41 @@ for disposition in ("exact_reuse", "capacity_blocked", "owner_conflict"):
     elif result.returncode == 0 or f"{disposition}" not in result.stderr:
         raise SystemExit(f"FAIL: {disposition} was not an exact plan refusal: {result!r}")
 
+for disposition in ("unsafe", "ownership conflict"):
+    env = os.environ.copy()
+    env["DMC_PLAN_TEXT_DISPOSITION"] = disposition
+    result = subprocess.run([part.format(**intent) for part in commands["plan"]], text=True, capture_output=True, env=env)
+    normalized = "owner_conflict" if disposition == "ownership conflict" else disposition
+    if result.returncode == 0 or f"DMC worktree plan disposition: {normalized}" not in result.stderr:
+        raise SystemExit(f"FAIL: textual {disposition} evidence was collapsed: {result!r}")
+
+PY
+}
+
+assert_resolution_contract() {
+  python3 - "$1" "$DMC_STATE" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+_, payload = open(sys.argv[1], encoding="utf-8").read().strip().split("|", 1)
+commands = json.loads(payload)["commands"]
+intent = {"handle": "fixture@fix-310-dmc-cook", "path": sys.argv[2]}
+
+def run(mode=""):
+    env = os.environ.copy()
+    env["DMC_INVENTORY_MODE"] = mode
+    return subprocess.run([part.format(**intent) for part in commands["resolve"]], text=True, capture_output=True, env=env)
+
+resolved = run()
+expected = [{"handle": intent["handle"], "path": intent["path"], "branch": "fix/310-dmc-cook", "task_url": "https://github.com/Extra-Chill/wp-coding-agents/issues/419", "safety": {"dirty": False, "unpushed": False, "primary": False}}]
+if resolved.returncode or json.loads(resolved.stdout) != expected:
+    raise SystemExit(f"FAIL: resolve did not join typed tracker inventory to exact identity: {resolved!r}")
+for mode in ("missing_task", "mismatched_identity", "conflicting_lineage"):
+    result = run(mode)
+    if result.returncode == 0 or "does not prove tracker ownership" not in result.stderr:
+        raise SystemExit(f"FAIL: {mode} inventory evidence must fail closed: {result!r}")
 PY
 }
 
@@ -254,7 +292,20 @@ if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree get" ]; then
     exit 1
   fi
   if [ -f "$DMC_STATE" ]; then
-    printf '[{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook","safety":{"dirty":false,"unpushed":false,"primary":false}}]\n' "$DMC_STATE"
+    case "${DMC_INVENTORY_MODE:-}" in
+      missing_task)
+        printf '[{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook","owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Home Page","origin_agent":"intelligence-chubes4","origin_task":{}}}]\n' "$DMC_STATE"
+        ;;
+      mismatched_identity)
+        printf '[{"handle":"other@worktree","path":"%s","branch":"fix/310-dmc-cook","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"},"owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Home Page","origin_agent":"intelligence-chubes4","origin_task":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"}}}]\n' "$DMC_STATE"
+        ;;
+      conflicting_lineage)
+        printf '[{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"},"owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Other Site","origin_agent":"intelligence-chubes4","origin_task":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"}}}]\n' "$DMC_STATE"
+        ;;
+      *)
+        printf '[{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"},"owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Home Page","origin_agent":"intelligence-chubes4","origin_task":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"}}}]\n' "$DMC_STATE"
+        ;;
+    esac
     exit 0
   fi
   printf '{"success":false,"error":{"code":"worktree_not_found"}}\n'
@@ -267,6 +318,10 @@ if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree plan" ]; then
     *) exit 2 ;;
   esac
   printf 'plan\n' >> "$DMC_ENSURE_LOG"
+  if [ -n "${DMC_PLAN_TEXT_DISPOSITION:-}" ]; then
+    printf 'Disposition: %s\n' "$DMC_PLAN_TEXT_DISPOSITION"
+    exit 9
+  fi
   printf '{"version":1,"digest":"fixture-plan-digest","handle":"blocks-engine@fix-406-dmc-provider-plan","path":"%s","branch":"fix/406-dmc-provider-plan","disposition":"%s"}\n' "$DMC_PLAN_PATH" "${DMC_PLAN_DISPOSITION:-create}"
   exit 0
 fi
@@ -307,13 +362,12 @@ assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\
 assert_contains "\"resolve_identity\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"identity\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
 assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"safety\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{identity}\"]" "$TMP/dry-run.log"
 assert_contains "\"converge\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"converge\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{identity}\",\"{base}\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{path}\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{handle}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{handle}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider\",\"$DM_WORKSPACE_DIR\",\"{path}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{path}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"plan\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"plan\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"plan\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_not_contains '"list":' "$TMP/dry-run.log"
-assert_not_contains '"list_result_mapping":' "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 if [ -f "$HOMEBOY_CONFIG_LOG" ]; then
@@ -331,6 +385,7 @@ assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
 assert_convergence_contract "$HOMEBOY_CONFIG_LOG"
+assert_resolution_contract "$HOMEBOY_CONFIG_LOG"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
 
 # The same generated set operation is used during upgrade, replacing stale


### PR DESCRIPTION
## Summary

- Join standalone DMC identity and safety to one exact persisted DMC `worktree get` inventory record before projecting tracker ownership.
- Require matching handle, path, branch, task URL, and persisted site/agent lineage; ambiguous, absent, and conflicting evidence fails closed.
- Configure explicit result mapping for the trusted `task_url`, and retain typed `unsafe` or `owner_conflict` plan disposition evidence from both JSON and textual DMC output.

## Tests

- `bash tests/homeboy-dmc-provider.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `bash tests/verify.sh` (fails in its existing healthy-install fixture before this provider path is exercised: it reports `FAIL` and exits nonzero)

Closes #419

## AI assistance

OpenAI `openai/gpt-5.6-terra` via OpenCode inspected the DMC inventory and Homeboy provider contracts, implemented the fail-closed adapter join, and ran focused regression coverage. Chris Huber remains responsible for review and decisions.