### PR TITLE
Fix copied DMC release digest verification

### DIFF
--- a/lib/dmc-managed-release.sh
+++ b/lib/dmc-managed-release.sh
@@ -22,12 +22,14 @@ dmc_managed_release_sha256() {
   fi
 }
 
-# Print a tab-separated release tuple: version, archive URL, checksum URL.
+# Print a tab-separated release tuple: version, archive URL, archive name,
+# evidence type, expected digest or checksum URL.
 dmc_managed_release_resolve() {
   local release_json="$1"
   DMC_RELEASE_JSON="$release_json" DMC_RELEASE_ASSET="${DMC_MANAGED_RELEASE_ASSET:-}" python3 <<'PY'
 import json
 import os
+import re
 import sys
 
 data = json.loads(os.environ['DMC_RELEASE_JSON'])
@@ -43,11 +45,25 @@ if archive is None and len(archives) == 1:
     archive = archives[0]
 if archive is None:
     raise SystemExit('release must publish exactly one ZIP asset (or set DMC_MANAGED_RELEASE_ASSET)')
-name = str(archive['name'])
+name = archive.get('name')
+archive_url = archive.get('browser_download_url')
+if not isinstance(name, str) or re.search(r'[\t\r\n]', name):
+    raise SystemExit('release ZIP asset name is invalid')
+if not isinstance(archive_url, str) or not re.fullmatch(r'https://[^\t\r\n]+', archive_url):
+    raise SystemExit('release ZIP download URL is invalid')
+digest = archive.get('digest')
+if digest is not None:
+    if not re.fullmatch(r'sha256:[0-9a-fA-F]{64}', str(digest)):
+        raise SystemExit('release ZIP digest must be sha256 followed by 64 hexadecimal characters')
+    print('\t'.join((version, archive_url, name, 'github_digest', str(digest)[7:].lower())))
+    raise SystemExit(0)
 checksums = [asset for asset in assets if str(asset.get('name', '')).lower() in (name.lower() + '.sha256', name.lower() + '.sha256sum', 'sha256sums', 'sha256sums.txt')]
 if len(checksums) != 1:
     raise SystemExit('release must publish one SHA-256 checksum asset for the ZIP')
-print('\t'.join((version, str(archive['browser_download_url']), str(checksums[0]['browser_download_url']))))
+checksum_url = checksums[0].get('browser_download_url')
+if not isinstance(checksum_url, str) or not re.fullmatch(r'https://[^\t\r\n]+', checksum_url):
+    raise SystemExit('release checksum download URL is invalid')
+print('\t'.join((version, archive_url, name, 'checksum_sidecar', checksum_url)))
 PY
 }
 
@@ -111,13 +127,21 @@ dmc_managed_release_status() {
     return 0
   fi
 
-  local release tuple version archive_url checksum_url
+  local release tuple version archive_url archive_name evidence_type evidence extra
   if ! release="$(curl -fsSL "$DMC_MANAGED_RELEASE_API")" || ! tuple="$(dmc_managed_release_resolve "$release")"; then
     printf '{"deployment":"copied_deploy","installed_version":"%s","state":"resolution_failed"}\n' "$current"
     return 1
   fi
-  IFS=$'\t' read -r version archive_url checksum_url <<< "$tuple"
-  printf '{"deployment":"copied_deploy","installed_version":"%s","latest_version":"%s","archive_url":"%s","checksum_url":"%s"}\n' "$current" "$version" "$archive_url" "$checksum_url"
+  IFS=$'\t' read -r version archive_url archive_name evidence_type evidence extra <<< "$tuple"
+  if [ -n "$extra" ] || [ -z "$version" ] || [ -z "$archive_url" ] || [ -z "$archive_name" ] || [ -z "$evidence_type" ] || [ -z "$evidence" ]; then
+    printf '{"deployment":"copied_deploy","installed_version":"%s","state":"resolution_failed"}\n' "$current"
+    return 1
+  fi
+  if [ "$evidence_type" = github_digest ]; then
+    printf '{"deployment":"copied_deploy","installed_version":"%s","latest_version":"%s","archive_url":"%s","expected_sha256":"%s"}\n' "$current" "$version" "$archive_url" "$evidence"
+  else
+    printf '{"deployment":"copied_deploy","installed_version":"%s","latest_version":"%s","archive_url":"%s","checksum_url":"%s"}\n' "$current" "$version" "$archive_url" "$evidence"
+  fi
 }
 
 update_data_machine_code_copied_release() {
@@ -125,22 +149,32 @@ update_data_machine_code_copied_release() {
   plugin_dir="$(dmc_managed_release_plugin_dir)"
   [ -d "$plugin_dir" ] || return 0
   [ ! -d "$plugin_dir/.git" ] || return 0
-  dmc_managed_release_recover "$plugin_dir" || { warn "Could not recover interrupted Data Machine Code release update"; return 0; }
 
-  local current release tuple target archive_url checksum_url
+  local current release tuple target archive_url archive_name evidence_type evidence extra
   current="$(dmc_managed_release_header_version "$plugin_dir" 2>/dev/null || true)"
   if ! release="$(curl -fsSL "$DMC_MANAGED_RELEASE_API")" || ! tuple="$(dmc_managed_release_resolve "$release")"; then
     warn "Could not resolve the official Data Machine Code release — copied install unchanged"
     return 0
   fi
-  IFS=$'\t' read -r target archive_url checksum_url <<< "$tuple"
+  IFS=$'\t' read -r target archive_url archive_name evidence_type evidence extra <<< "$tuple"
+  if [ -n "$extra" ] || [ -z "$target" ] || [ -z "$archive_url" ] || [ -z "$archive_name" ] || [ -z "$evidence_type" ] || [ -z "$evidence" ]; then
+    warn "Could not resolve the official Data Machine Code release — copied install unchanged"
+    return 0
+  fi
 
   if [ "$current" = "$target" ]; then
+    if [ "${DRY_RUN:-false}" != true ]; then
+      dmc_managed_release_recover "$plugin_dir" || { warn "Could not recover interrupted Data Machine Code release update"; return 0; }
+    fi
     log "Data Machine Code copied install already at official release $target"
     return 0
   fi
   if [ "${DRY_RUN:-false}" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} Download and SHA-256 verify official Data Machine Code $target"
+    if [ "$evidence_type" = github_digest ]; then
+      echo -e "${BLUE}[dry-run]${NC} Download and SHA-256 verify official Data Machine Code $target against $evidence"
+    else
+      echo -e "${BLUE}[dry-run]${NC} Download and SHA-256 verify official Data Machine Code $target using $evidence"
+    fi
     echo -e "${BLUE}[dry-run]${NC} Stage and atomically deploy only $plugin_dir ($current → $target)"
     return 0
   fi
@@ -149,17 +183,26 @@ update_data_machine_code_copied_release() {
   staging="$(mktemp -d)" || { warn "Could not create Data Machine Code release staging directory"; return 0; }
   trap 'rm -rf "$staging"' RETURN
   archive="$staging/release.zip"
-  checksum="$staging/release.sha256"
-  if ! curl -fsSL "$archive_url" -o "$archive" || ! curl -fsSL "$checksum_url" -o "$checksum"; then
+  if ! curl -fsSL "$archive_url" -o "$archive"; then
     warn "Could not download official Data Machine Code release $target — copied install unchanged"
     return 0
   fi
-  expected="$(dmc_managed_release_expected_sha256 "$checksum" "$(basename "$archive_url")")"
+  if [ "$evidence_type" = github_digest ]; then
+    expected="$evidence"
+  else
+    checksum="$staging/release.sha256"
+    if ! curl -fsSL "$evidence" -o "$checksum"; then
+      warn "Could not download official Data Machine Code release $target — copied install unchanged"
+      return 0
+    fi
+    expected="$(dmc_managed_release_expected_sha256 "$checksum" "$archive_name")"
+  fi
   actual="$(dmc_managed_release_sha256 "$archive")"
   if ! [[ "$expected" =~ ^[a-f0-9]{64}$ ]] || [ "$actual" != "$expected" ]; then
     warn "Official Data Machine Code release $target failed published SHA-256 verification — copied install unchanged"
     return 0
   fi
+  dmc_managed_release_recover "$plugin_dir" || { warn "Could not recover interrupted Data Machine Code release update"; return 0; }
   extracted="$staging/extracted"
   mkdir -p "$extracted"
   if ! unzip -q "$archive" -d "$extracted"; then

--- a/tests/dmc-managed-release.sh
+++ b/tests/dmc-managed-release.sh
@@ -33,6 +33,7 @@ mkdir -p "$FAKE_BIN" "$TMP/release/data-machine-code"
 printf '<?php\n/*\n * Version: 2.0.0\n */\n' > "$TMP/release/data-machine-code/data-machine-code.php"
 (cd "$TMP/release" && zip -qr "$TMP/dmc.zip" data-machine-code)
 SHA="$(shasum -a 256 "$TMP/dmc.zip" | awk '{print $1}')"
+SHA_UPPER="$(printf '%s' "$SHA" | tr '[:lower:]' '[:upper:]')"
 printf '%s  dmc.zip\n' "$SHA" > "$TMP/dmc.zip.sha256"
 cat > "$FAKE_BIN/curl" <<'SH'
 #!/bin/bash
@@ -46,7 +47,7 @@ fi
 SH
 chmod +x "$FAKE_BIN/curl"
 export PATH="$FAKE_BIN:$PATH" DMC_TEST_ARCHIVE="$TMP/dmc.zip" DMC_TEST_CHECKSUM="$TMP/dmc.zip.sha256"
-DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip"},{"name":"dmc.zip.sha256","browser_download_url":"https://release/dmc.zip.sha256"}]}'
+DMC_TEST_RELEASE_JSON="{\"tag_name\":\"v2.0.0\",\"assets\":[{\"name\":\"dmc.zip\",\"browser_download_url\":\"https://release/dmc.zip\",\"digest\":\"sha256:$SHA_UPPER\"}]}"
 export DMC_TEST_RELEASE_JSON
 DMC_MANAGED_RELEASE_API="https://test/releases/latest"
 
@@ -55,6 +56,7 @@ DRY_RUN=true
 before="$(shasum -a 256 "$PLUGIN/data-machine-code.php")"
 out="$(update_data_machine_code_copied_release)"
 case "$out" in *"SHA-256 verify"*) : ;; *) fail "dry-run did not describe checksum verification";; esac
+case "$out" in *"$SHA"*) : ;; *) fail "dry-run did not carry the normalized GitHub digest";; esac
 [ "$before" = "$(shasum -a 256 "$PLUGIN/data-machine-code.php")" ] || fail "dry-run mutated copied plugin"
 
 # current copied install: no download/deploy and no update record.
@@ -65,15 +67,15 @@ update_data_machine_code_copied_release
 case "$LOG" in *"already at official release 2.0.0"*) : ;; *) fail "current copied install was not recognized";; esac
 [ "${#UPDATED_ITEMS[@]}" -eq 0 ] || fail "current copied install recorded an update"
 
-# checksum failure: preserve the old deployment.
+# GitHub digest mismatch: preserve the old deployment.
 printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
-printf '0%.0s' {1..64} > "$TMP/dmc.zip.sha256"
-printf '  dmc.zip\n' >> "$TMP/dmc.zip.sha256"
+DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip","digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}]}'
 LOG=""
 update_data_machine_code_copied_release
-[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "checksum failure replaced deployment"
-case "$LOG" in *"SHA-256 verification"*) : ;; *) fail "checksum failure was not reported";; esac
-printf '%s  dmc.zip\n' "$SHA" > "$TMP/dmc.zip.sha256"
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "GitHub digest mismatch replaced deployment"
+[ ! -e "$PLUGIN/.wp-coding-agents-release-current" ] || fail "GitHub digest mismatch mutated release pointers"
+case "$LOG" in *"SHA-256 verification"*) : ;; *) fail "GitHub digest mismatch was not reported";; esac
+DMC_TEST_RELEASE_JSON="{\"tag_name\":\"v2.0.0\",\"assets\":[{\"name\":\"dmc.zip\",\"browser_download_url\":\"https://release/dmc.zip\",\"digest\":\"sha256:$SHA_UPPER\"}]}"
 
 # copied deployment: stage, preserve a fallback, activate, and record provenance.
 mkdir -p "$PLUGIN/obsolete"
@@ -84,6 +86,30 @@ update_data_machine_code_copied_release
 [ -f "$PLUGIN/.wp-coding-agents-release-current/data-machine-code.php" ] || fail "copied release current pointer missing"
 [ ! -e "$PLUGIN/.wp-coding-agents-release-current/obsolete" ] || fail "copied release included stale files"
 [ "${#UPDATED_ITEMS[@]}" -eq 1 ] || fail "copied release was not recorded"
+
+# Legacy checksum sidecars remain accepted and verified before deployment.
+rm -rf "$PLUGIN"
+mkdir -p "$PLUGIN"
+printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip?download=1"},{"name":"dmc.zip.sha256","browser_download_url":"https://release/dmc.zip.sha256"}]}'
+DRY_RUN=true
+out="$(update_data_machine_code_copied_release)"
+case "$out" in *"https://release/dmc.zip.sha256"*) : ;; *) fail "legacy dry-run did not carry the checksum sidecar URL";; esac
+status="$(dmc_managed_release_status)"
+case "$status" in *'"checksum_url":"https://release/dmc.zip.sha256"'*) : ;; *) fail "legacy channel status omitted the checksum sidecar URL";; esac
+DRY_RUN=false
+printf '%064d  dmc.zip\n' 0 > "$TMP/dmc.zip.sha256"
+LOG=""
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "legacy checksum mismatch replaced deployment"
+[ ! -e "$PLUGIN/.wp-coding-agents-release-current" ] || fail "legacy checksum mismatch mutated release pointers"
+case "$LOG" in *"SHA-256 verification"*) : ;; *) fail "legacy checksum mismatch was not reported";; esac
+printf '%s  dmc.zip\n' "$SHA" > "$TMP/dmc.zip.sha256"
+UPDATED_ITEMS=()
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "2.0.0" ] || fail "legacy checksum sidecar did not deploy target version"
+[ "${#UPDATED_ITEMS[@]}" -eq 1 ] || fail "legacy checksum sidecar release was not recorded"
+DMC_TEST_RELEASE_JSON="{\"tag_name\":\"v2.0.0\",\"assets\":[{\"name\":\"dmc.zip\",\"browser_download_url\":\"https://release/dmc.zip\",\"digest\":\"sha256:$SHA_UPPER\"}]}"
 
 # An inactive plugin remains inactive; deployment does not call activation.
 rm -rf "$PLUGIN"
@@ -104,16 +130,38 @@ dmc_managed_release_recover "$PLUGIN"
 rm -rf "$PLUGIN"
 mkdir -p "$PLUGIN"
 printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+
+# Present-but-malformed GitHub evidence is rejected rather than downgraded.
+DMC_TEST_RELEASE_JSON="{\"tag_name\":\"v2.0.0\",\"assets\":[{\"name\":\"dmc.zip\",\"browser_download_url\":\"https://release/dmc.zip\",\"digest\":\"sha512:$SHA\"},{\"name\":\"dmc.zip.sha256\",\"browser_download_url\":\"https://release/dmc.zip.sha256\"}]}"
+LOG=""
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "malformed GitHub digest replaced deployment"
+case "$LOG" in *"Could not resolve"*) : ;; *) fail "malformed GitHub digest was not rejected";; esac
+
+# Releases without either recognized evidence form fail closed.
+DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip"}]}'
+LOG=""
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "missing digest evidence replaced deployment"
+case "$LOG" in *"Could not resolve"*) : ;; *) fail "missing digest evidence was not rejected";; esac
+
+# Tuple delimiters in release metadata are rejected before download/deployment.
+DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip\tinvalid","digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}]}'
+LOG=""
+update_data_machine_code_copied_release
+[ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "delimiter-bearing metadata replaced deployment"
+case "$LOG" in *"Could not resolve"*) : ;; *) fail "delimiter-bearing metadata was not rejected";; esac
+
 DMC_TEST_RELEASE_JSON='{"tag_name":"release-latest","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip"},{"name":"dmc.zip.sha256","browser_download_url":"https://release/dmc.zip.sha256"}]}'
 LOG=""
 update_data_machine_code_copied_release
 [ "$(dmc_managed_release_header_version "$PLUGIN")" = "1.0.0" ] || fail "malformed tag replaced deployment"
 case "$LOG" in *"Could not resolve"*) : ;; *) fail "malformed tag was not rejected";; esac
-DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip"},{"name":"dmc.zip.sha256","browser_download_url":"https://release/dmc.zip.sha256"}]}'
+DMC_TEST_RELEASE_JSON="{\"tag_name\":\"v2.0.0\",\"assets\":[{\"name\":\"dmc.zip\",\"browser_download_url\":\"https://release/dmc.zip\",\"digest\":\"sha256:$SHA_UPPER\"}]}"
 
-# Channel status uses the same resolver and exposes the official target.
+# Channel status uses the same resolver and exposes the deterministic digest.
 status="$(dmc_managed_release_status)"
-case "$status" in *'"deployment":"copied_deploy"'*'"latest_version":"2.0.0"'*) : ;; *) fail "copied channel status incorrect: $status";; esac
+case "$status" in *'"deployment":"copied_deploy"'*'"latest_version":"2.0.0"'*"\"expected_sha256\":\"$SHA\""*) : ;; *) fail "copied channel status incorrect: $status";; esac
 
 # git checkout: preserve the existing tagged-release path, never resolve assets.
 mkdir -p "$PLUGIN/.git"


### PR DESCRIPTION
## Summary

- verify copied DMC releases with GitHub's published `sha256:` asset digest
- preserve legacy checksum-sidecar verification
- validate tuple metadata and verify archive bytes before any deployment mutation

Closes #416.

## Verification

- `bash tests/dmc-managed-release.sh`
- `bash tests/dmc-managed-release-integration.sh`
- `bash -n lib/dmc-managed-release.sh upgrade.sh`
- real DMC v0.66.2 release payload resolution

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode general coding subagents implemented and independently reviewed the digest/sidecar paths, fixed delimiter and query-bearing URL findings, and ran focused verification. Chris Huber directed the work and remains responsible.