### PR TITLE
Defer Data Machine composition to chat lifecycle

### DIFF
--- a/bridges/kimaki/plugins/dm-agent-sync.ts
+++ b/bridges/kimaki/plugins/dm-agent-sync.ts
@@ -1,100 +1,74 @@
-// dm-agent-sync.ts — OpenCode plugin that refreshes Data Machine memory.
+// dm-agent-sync.ts — refresh Data Machine memory for OpenCode chat sessions.
 //
-// On session start it:
-//   1. Recomposes Data Machine's composable memory files (e.g. AGENTS.md) so
-//      they match live WordPress state before OpenCode reads them.
-//   2. Derives OpenCode's top-level `instructions` list from Data Machine's
-//      registered injectable memory files, instead of relying on a static,
-//      hand-maintained list in opencode.json that silently drifts whenever a
-//      new memory file is registered in Data Machine.
-//
-// Agent identity stays in Data Machine's channel/session binding and OpenCode's
-// top-level instructions instead of mutating config.agent.* prompts.
-//
-// Layer note: Data Machine is agnostic to how its memory files are consumed —
-// `datamachine memory injectable-files` returns generic resolved paths and
-// knows nothing about OpenCode. The OpenCode-specific knowledge (writing those
-// paths into config.instructions) lives here, in the integration layer.
-//
-// How to use:
-//   Add to opencode.json:  "plugin": ["path/to/dm-agent-sync.ts"]
-//   Or place in .opencode/plugins/ in the project root.
+// Setup and upgrade synchronize Data Machine's injectable file registry into
+// OpenCode's static `instructions` array. This plugin recomposes those files
+// before a session's first chat message, when OpenCode has not yet built the
+// model prompt. Config-only commands therefore never start WordPress.
 
-/**
- * External dependencies
- */
+import { spawn } from "node:child_process";
 import type { Plugin } from "@opencode-ai/plugin";
 
-interface InjectableFile {
-  filename: string;
-  layer: string;
-  path: string;
-  priority: number;
-}
+type WpCli = string;
 
-const dmAgentSync: Plugin = async ({ $ }) => {
+const DEFAULT_COMPOSE_TIMEOUT_MS = 10_000;
+const OUTPUT_LIMIT = 16 * 1024;
+
+const dmAgentSync: Plugin = async () => {
+  let sessionConfig: { wpCli: WpCli; sitePath: string; agentSlug: string } | undefined;
+  const synchronizedSessions = new Map<string, Promise<void>>();
+
   return {
     config: async (input) => {
       if (process.env.EXTERNAL_WORDPRESS === "true") {
-        // Portable profiles project remote memory during setup. Replacing the
-        // configured local paths with WordPress-host paths would make every
-        // instruction unreachable from this runtime.
-        return;
-      }
-      const wpCli = await resolveWpCli($);
-      if (!wpCli) {
         return;
       }
 
-      const sitePath = getSitePath();
-      const agentSlug = getAgentSlug(input);
-
-      // Refresh composable files before the session reads them.
-      // DM SectionRegistry callbacks render live state (configured sources,
-      // skills, config). DM's own invalidation hooks cover state changes
-      // that happen inside a WordPress request, but cron jobs, direct DB
-      // edits, or other external processes would leave AGENTS.md stale.
-      // Running compose here guarantees the file matches live state at the
-      // moment OpenCode loads the session prompt.
-      const composeResult = await runDatamachineCommand($, wpCli, sitePath, agentSlug, "compose");
-      if (composeResult.exitCode !== 0) {
-        // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
-        console.warn(`[dm-agent-sync] memory compose failed (exit ${composeResult.exitCode}): ${await shellOutputText(composeResult)}`);
+      // Config runs for every CLI command. Capture only local state here;
+      // invoking WordPress belongs to the real chat lifecycle below.
+      sessionConfig = {
+        wpCli: process.env.DATAMACHINE_WP_CMD || process.env.WP_CMD || "wp",
+        sitePath: getSitePath(),
+        agentSlug: getAgentSlug(input),
+      };
+    },
+    "chat.message": async ({ sessionID }) => {
+      if (!sessionConfig) {
         return;
       }
-      // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
-      console.warn("[dm-agent-sync] recomposed Data Machine memory");
 
-      // Derive the instructions list from DM's registered injectable memory
-      // files so it stays in sync with the registry. If DM is too old to
-      // provide the command, or it returns nothing usable, leave whatever
-      // static list opencode.json already has untouched (graceful no-op).
-      await syncInstructions(input, sitePath, $, wpCli, agentSlug);
+      let sync = synchronizedSessions.get(sessionID);
+      if (!sync) {
+        sync = composeMemory(sessionConfig.wpCli, sessionConfig.sitePath, sessionConfig.agentSlug);
+        synchronizedSessions.set(sessionID, sync);
+      }
+      await sync;
     },
   };
 };
 
-type WpCli = string;
+async function composeMemory(wpCli: WpCli, sitePath: string, agentSlug: string): Promise<void> {
+  const startedAt = Date.now();
+  const result = await runBoundedCommand(datamachineCommand(wpCli, sitePath, agentSlug), getComposeTimeoutMs());
+  const durationMs = Date.now() - startedAt;
 
-async function resolveWpCli($: any): Promise<WpCli | null> {
-  const configured = process.env.DATAMACHINE_WP_CMD || process.env.WP_CMD || "";
-  if (configured) {
-    return configured;
+  if (result.timedOut) {
+    // Existing composed files remain the fallback. A WordPress outage must not
+    // prevent OpenCode from accepting a chat message.
+    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+    console.warn(`[dm-agent-sync] memory compose timed out after ${durationMs}ms; using existing memory files`);
+    return;
   }
-
-  const wpAvailable = await $`command -v wp`.quiet().nothrow();
-  if (wpAvailable.exitCode === 0) {
-    return "wp";
+  if (result.exitCode !== 0) {
+    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+    console.warn(`[dm-agent-sync] memory compose failed (exit ${result.exitCode}) after ${durationMs}ms: ${result.output}`);
+    return;
   }
-
-  return null;
+  // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
+  console.warn(`[dm-agent-sync] recomposed Data Machine memory in ${durationMs}ms`);
 }
 
-async function runDatamachineCommand($: any, wpCli: WpCli, sitePath: string, agentSlug: string, command: "compose" | "injectable-files"): Promise<any> {
-  const args = ["datamachine", "memory", command];
-  if (command === "injectable-files") {
-    args.push("--format=json");
-  }
+function datamachineCommand(wpCli: WpCli, sitePath: string, agentSlug: string): string {
+  const args = ["datamachine", "memory", "compose"];
   if (agentSlug) {
     args.push(`--agent=${agentSlug}`);
   }
@@ -102,63 +76,53 @@ async function runDatamachineCommand($: any, wpCli: WpCli, sitePath: string, age
     args.push(`--path=${sitePath}`);
   }
   args.push("--allow-root");
-
-  // Do not start a login shell here. Service-user profiles are unrelated user
-  // state and may contain interactive, stale, or failing initialization.
-  return $`sh -c ${[wpCli, ...args.map(shellQuote)].join(" ")}`.quiet().nothrow();
+  return [wpCli, ...args.map(shellQuote)].join(" ");
 }
 
-/**
- * Replace config.instructions with the absolute paths Data Machine reports as
- * injectable for the active agent. Only existing files are included (DM already
- * filters to on-disk files), so a registered-but-not-yet-written file like a
- * freshly added briefing won't break session load.
- */
-async function syncInstructions(
-  input: { instructions?: string[] },
-  sitePath: string,
-  $: any,
-  wpCli: WpCli,
-  agentSlug: string,
-): Promise<void> {
-  if (!agentSlug) {
-    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
-    console.warn("[dm-agent-sync] agent slug unavailable; leaving instructions unchanged");
-    return;
-  }
+function runBoundedCommand(command: string, timeoutMs: number): Promise<{ exitCode: number; output: string; timedOut: boolean }> {
+  return new Promise((resolve) => {
+    const child = spawn("sh", ["-c", command], { detached: process.platform !== "win32", stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    let settled = false;
+    const finish = (exitCode: number, timedOut: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ exitCode, output, timedOut });
+    };
+    const terminate = () => {
+      if (child.pid && process.platform !== "win32") {
+        try {
+          process.kill(-child.pid, "SIGTERM");
+          return;
+        } catch {
+          // The process may have already exited; fall through to child.kill().
+        }
+      }
+      child.kill("SIGTERM");
+    };
+    const timeout = setTimeout(() => {
+      terminate();
+      finish(1, true);
+    }, timeoutMs);
+    const append = (chunk: Buffer) => {
+      output += chunk.toString();
+      if (output.length > OUTPUT_LIMIT) {
+        output = output.slice(0, OUTPUT_LIMIT);
+        terminate();
+        finish(1, false);
+      }
+    };
+    child.stdout.on("data", append);
+    child.stderr.on("data", append);
+    child.on("error", () => finish(1, false));
+    child.on("close", (code) => finish(code ?? 1, false));
+  });
+}
 
-  const result = await runDatamachineCommand($, wpCli, sitePath, agentSlug, "injectable-files");
-
-  if (result.exitCode !== 0) {
-    // DM predates the command, or the call failed — keep the existing list.
-    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
-    console.warn(`[dm-agent-sync] injectable-files unavailable (exit ${result.exitCode}); leaving instructions unchanged`);
-    return;
-  }
-
-  const raw = await shellOutputText(result);
-  let files: InjectableFile[];
-  try {
-    files = JSON.parse(raw);
-  } catch {
-    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
-    console.warn("[dm-agent-sync] could not parse injectable-files output; leaving instructions unchanged");
-    return;
-  }
-
-  const paths = Array.isArray(files)
-    ? files.map((f) => f?.path).filter((p): p is string => typeof p === "string" && p.length > 0)
-    : [];
-
-  if (paths.length === 0) {
-    // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
-    console.warn("[dm-agent-sync] injectable-files returned no paths; leaving instructions unchanged");
-    return;
-  }
-
-  input.instructions = paths;
-  // eslint-disable-next-line no-console -- intentional operational log to the OpenCode session console
-  console.warn(`[dm-agent-sync] synced ${paths.length} instruction file(s) from Data Machine`);
+function getComposeTimeoutMs(): number {
+  const configured = Number(process.env.DATAMACHINE_COMPOSE_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_COMPOSE_TIMEOUT_MS;
 }
 
 function getSitePath(): string {
@@ -178,19 +142,11 @@ function getAgentSlug(input: { instructions?: string[] }): string {
       return match[1];
     }
   }
-
   return "";
 }
 
 function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-async function shellOutputText(output: any): Promise<string> {
-  if (typeof output.text === "function") {
-    return output.text();
-  }
-  return [output.stdout, output.stderr].filter(Boolean).join("\n");
+  return `'${value.replace(/'/g, `"'"'`)}'`;
 }
 
 export default dmAgentSync;

--- a/tests/dm-agent-sync.mjs
+++ b/tests/dm-agent-sync.mjs
@@ -1,148 +1,108 @@
-// tests/dm-agent-sync.mjs — unit smoke tests for the Kimaki DM memory sync plugin.
+// tests/dm-agent-sync.mjs — lifecycle tests for the Kimaki DM memory sync plugin.
 
 import assert from "node:assert/strict"
+import { access, mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import dmAgentSync from "../bridges/kimaki/plugins/dm-agent-sync.ts"
 
 const sitePath = "/tmp/datamachine-site"
-process.env.DATAMACHINE_SITE_PATH = sitePath
-delete process.env.DATAMACHINE_WP_CMD
-delete process.env.WP_CMD
-delete process.env.DATAMACHINE_AGENT_SLUG
-
-function output(stdout = "", exitCode = 0, stderr = "") {
-  return {
-    exitCode,
-    stdout,
-    stderr,
-    async text() {
-      return [stdout, stderr].filter(Boolean).join("\n")
-    },
-  }
-}
-
-function fakeShell(responses) {
-  return (strings, ...values) => {
-    const command = strings.reduce((acc, part, index) => acc + part + (values[index] ?? ""), "")
-    return {
-      quiet() {
-        return this
-      },
-      nothrow() {
-        for (const [pattern, result] of responses) {
-          if (pattern.test(command)) {
-            return Promise.resolve(result)
-          }
-        }
-        return Promise.resolve(output("", 1, `unexpected command: ${command}`))
-      },
-    }
-  }
-}
-
-async function runConfig(config, responses) {
-  const warnings = []
-  const originalWarn = console.warn
-  console.warn = (message) => warnings.push(String(message))
-  try {
-    const plugin = await dmAgentSync({ $: fakeShell(responses) })
-    await plugin.config(config)
-  } finally {
-    console.warn = originalWarn
-  }
-  return warnings
-}
 
 async function withEnv(env, callback) {
   const previous = {}
   for (const key of Object.keys(env)) {
     previous[key] = process.env[key]
-    if (env[key] === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = env[key]
-    }
+    if (env[key] === undefined) delete process.env[key]
+    else process.env[key] = env[key]
   }
-
   try {
     return await callback()
   } finally {
     for (const [key, value] of Object.entries(previous)) {
-      if (value === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = value
-      }
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
     }
   }
 }
 
-const commonResponses = [
-  [/^command -v wp$/, output("/usr/local/bin/wp")],
-  [/^sh -c wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
-]
-
-{
-  const config = {
-    model: "anthropic/claude-opus-4-7",
-    agent: {
-      build: { mode: "primary", model: "anthropic/claude-opus-4-7" },
-      plan: { mode: "primary", model: "anthropic/claude-opus-4-7" },
+async function loadPlugin(config = {}) {
+  const warnings = []
+  const originalWarn = console.warn
+  const plugin = await dmAgentSync({})
+  return {
+    async config() {
+      console.warn = (message) => warnings.push(String(message))
+      try {
+        await plugin.config(config)
+      } finally {
+        console.warn = originalWarn
+      }
     },
-  }
-  const warnings = await runConfig(config, commonResponses)
-  assert.equal(config.agent.build.prompt, undefined)
-  assert.equal(config.agent.plan.prompt, undefined)
-  assert.equal(config.agent.build.model, "anthropic/claude-opus-4-7")
-  assert.equal(config.agent.franklin, undefined)
-  assert.equal(config.agent.julia, undefined)
-  assert.ok(warnings.some((line) => line.includes("recomposed Data Machine memory")))
-}
-
-{
-  const config = {
-    agent: {
-      build: { mode: "primary", tools: { bash: true } },
-      plan: { mode: "primary" },
+    async chat(sessionID = "session-1") {
+      console.warn = (message) => warnings.push(String(message))
+      try {
+        await plugin["chat.message"]({ sessionID }, {})
+      } finally {
+        console.warn = originalWarn
+      }
     },
+    warnings,
   }
-  await runConfig(config, commonResponses)
-  assert.deepEqual(config.agent.build.tools, { bash: true })
-  assert.equal(config.agent.build.prompt, undefined)
-  assert.equal(config.agent.plan.prompt, undefined)
 }
 
-{
-  const config = {
-    agent: {
-      build: { prompt: "custom prompt" },
-    },
-  }
-  await runConfig(config, commonResponses)
-  assert.equal(config.agent.build.prompt, "custom prompt")
-  assert.equal(config.agent.plan, undefined)
-}
+await withEnv({
+  DATAMACHINE_SITE_PATH: sitePath,
+  DATAMACHINE_WP_CMD: "true",
+  DATAMACHINE_AGENT_SLUG: "intelligence-chubes4",
+  EXTERNAL_WORDPRESS: undefined,
+}, async () => {
+  const config = { instructions: ["/tmp/datamachine-site/agents/intelligence-chubes4/SOUL.md"] }
+  const run = await loadPlugin(config)
+  await run.config()
 
-{
-  const config = {}
-  const warnings = await runConfig(config, [
-    [/^command -v wp$/, output("/usr/local/bin/wp")],
-    [/^sh -c wp 'datamachine' 'memory' 'compose' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("", 1, "db down")],
-  ])
-  assert.ok(warnings.some((line) => line.includes("memory compose failed")))
-  assert.equal(config.agent, undefined)
-}
+  // Mirrors `opencode models`: config setup has no shell or WordPress work and
+  // leaves setup/upgrade-managed instruction paths untouched.
+  assert.deepEqual(config.instructions, ["/tmp/datamachine-site/agents/intelligence-chubes4/SOUL.md"])
+  assert.equal(run.warnings.length, 0)
 
-await withEnv({ DATAMACHINE_WP_CMD: "custom-wp", DATAMACHINE_AGENT_SLUG: "intelligence-chubes4" }, async () => {
-  const config = {}
-  const warnings = await runConfig(config, [
-    [/^sh -c custom-wp 'datamachine' 'memory' 'compose' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output("composed")],
-    [/^sh -c custom-wp 'datamachine' 'memory' 'injectable-files' '--format=json' '--agent=intelligence-chubes4' '--path=\/tmp\/datamachine-site' '--allow-root'$/, output(JSON.stringify([
-      { path: "/tmp/datamachine-site/AGENTS.md" },
-      { path: "/tmp/datamachine-site/MEMORY.md" },
-    ]))],
-  ])
-  assert.ok(warnings.some((line) => line.includes("recomposed Data Machine memory")))
-  assert.deepEqual(config.instructions, ["/tmp/datamachine-site/AGENTS.md", "/tmp/datamachine-site/MEMORY.md"])
+  await run.chat()
+  assert.ok(run.warnings.some((line) => line.includes("recomposed Data Machine memory in")))
+  const warningCount = run.warnings.length
+  await run.chat()
+  assert.equal(run.warnings.length, warningCount)
 })
 
-console.log("OK: dm-agent-sync recomposes DM memory without mutating OpenCode agents")
+await withEnv({
+  DATAMACHINE_SITE_PATH: sitePath,
+  DATAMACHINE_WP_CMD: "false",
+  DATAMACHINE_AGENT_SLUG: "intelligence-chubes4",
+}, async () => {
+  const run = await loadPlugin()
+  await run.config()
+  await run.chat()
+  assert.ok(run.warnings.some((line) => line.includes("memory compose failed")))
+})
+
+await withEnv({ EXTERNAL_WORDPRESS: "true", DATAMACHINE_WP_CMD: "false" }, async () => {
+  const run = await loadPlugin()
+  await run.config()
+  await run.chat()
+  assert.equal(run.warnings.length, 0)
+})
+
+await withEnv({ DATAMACHINE_COMPOSE_TIMEOUT_MS: "10" }, async () => {
+  const directory = await mkdtemp(join(tmpdir(), "dm-agent-sync-"))
+  const marker = join(directory, "compose-finished")
+  const run = await loadPlugin()
+  await withEnv({ DATAMACHINE_WP_CMD: `sh -c 'sleep 0.2; touch ${marker}'` }, async () => {
+    await run.config()
+    const startedAt = Date.now()
+    await run.chat()
+    assert.ok(Date.now() - startedAt < 150)
+  })
+  await new Promise((resolve) => setTimeout(resolve, 250))
+  await assert.rejects(access(marker))
+  assert.ok(run.warnings.some((line) => line.includes("memory compose timed out")))
+})
+
+console.log("OK: dm-agent-sync runs bounded WordPress composition only for the first chat message per session")


### PR DESCRIPTION
## Summary

- remove synchronous WordPress work from OpenCode config-only commands
- compose memory once per session at the awaited pre-prompt `chat.message` boundary
- bound composition with process-group termination, fallback, and duration telemetry

Closes #141.

## Verification

- `bun tests/dm-agent-sync.mjs`
- `bun --check bridges/kimaki/plugins/dm-agent-sync.ts`

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode general coding subagents implemented and reviewed the lifecycle narrowing, process timeout behavior, and focused tests. Chris Huber directed the work and remains responsible.