### PR TITLE
fix: scope DMC worktree inventory by repository

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -116,10 +116,10 @@ homeboy_dmc_command_json() {
       homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" safety "$provider" "$DM_WORKSPACE_DIR" '{identity}'
       ;;
     resolve)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$provider" "$DM_WORKSPACE_DIR" '{handle}' "${wp_argv[@]}" datamachine-code workspace worktree get '{handle}' --format=json "${wp_flags[@]}"
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$provider" "$DM_WORKSPACE_DIR" '{handle}' "${wp_argv[@]}" datamachine-code workspace worktree list '{repo}' --all --full --format=json "${wp_flags[@]}"
       ;;
     resolve_path)
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$provider" "$DM_WORKSPACE_DIR" '{path}' "${wp_argv[@]}" datamachine-code workspace worktree get '{path}' --format=json "${wp_flags[@]}"
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$provider" "$DM_WORKSPACE_DIR" '{path}' "${wp_argv[@]}" datamachine-code workspace worktree list '{repo}' --all --full --format=json "${wp_flags[@]}"
       ;;
     ensure)
       # Homeboy owns each fanout worktree lifecycle. DMC verifies this complete

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -69,10 +69,14 @@ if ( ! in_array($operation, array( 'identity', 'safety', 'resolve', 'converge' )
 }
 
 /** @return array<string,mixed> */
-$read_inventory = static function ( array $command ) use ( $value ): array {
+$read_inventory = static function ( array $command, string $repo = '' ): array {
 	if ( array() === $command ) {
 		throw new RuntimeException('DMC aggregate inventory command is required for resolve.');
 	}
+	if ( '' === $repo || 1 !== count(array_filter($command, static fn ( string $part ): bool => '{repo}' === $part))) {
+		throw new RuntimeException('DMC worktree list requires the repository resolved from identity.');
+	}
+	$command = array_map(static fn ( string $part ): string => '{repo}' === $part ? $repo : $part, $command);
 	$process = proc_open($command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
 	if ( ! is_resource($process) ) {
 		throw new RuntimeException('Could not start the DMC aggregate inventory command.');
@@ -163,7 +167,12 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 	} else {
 		try {
 			$safety = $run_provider('safety', (string) ( $payload['token'] ?? '' ));
-			$inventory = $read_inventory(array_slice($argv, 5));
+			$handle = (string) ( $payload['handle'] ?? '' );
+			$repo = strstr($handle, '@', true);
+			if ( false === $repo || '' === $repo ) {
+				throw new RuntimeException('DMC identity did not provide a repository-scoped handle.');
+			}
+			$inventory = $read_inventory(array_slice($argv, 5), $repo);
 		} catch (Throwable $error) {
 			fwrite(STDERR, $error->getMessage() . "\n");
 			exit($error->getCode() > 0 && $error->getCode() < 256 ? $error->getCode() : 1);

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -55,8 +55,8 @@ if not lines:
 _, payload = lines[-1].split("|", 1)
 provider = json.loads(payload)
 commands = provider["commands"]
-expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{handle}", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{handle}", "--format=json", f"--path={sys.argv[3]}"]
-expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{path}", "studio", "wp", "datamachine-code", "workspace", "worktree", "get", "{path}", "--format=json", f"--path={sys.argv[3]}"]
+expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{handle}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "{repo}", "--all", "--full", "--format=json", f"--path={sys.argv[3]}"]
+expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{path}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "{repo}", "--all", "--full", "--format=json", f"--path={sys.argv[3]}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", sys.argv[5], sys.argv[4], "{handle}"]
@@ -196,7 +196,7 @@ intent = {"handle": "fixture@fix-310-dmc-cook", "path": sys.argv[2]}
 def run(mode=""):
     env = os.environ.copy()
     env["DMC_INVENTORY_MODE"] = mode
-    return subprocess.run([part.format(**intent) for part in commands["resolve"]], text=True, capture_output=True, env=env)
+    return subprocess.run([part.replace("{handle}", intent["handle"]).replace("{path}", intent["path"]) for part in commands["resolve"]], text=True, capture_output=True, env=env)
 
 resolved = run()
 expected = [{"handle": intent["handle"], "path": intent["path"], "branch": "fix/310-dmc-cook", "task_url": "https://github.com/Extra-Chill/wp-coding-agents/issues/419", "safety": {"dirty": False, "unpushed": False, "primary": False}}]
@@ -288,11 +288,13 @@ chmod +x "$FAKE_BIN/homeboy"
 cat > "$FAKE_BIN/studio" <<'SH'
 #!/bin/sh
 printf '%s\n' "$*" >> "$STUDIO_LOG"
-if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree get" ]; then
-  if [ "$6" = "fixture@unrelated-exit-one" ]; then
-    printf '{"success":false,"error":{"code":"workspace_unavailable"}}\n'
-    exit 1
-  fi
+if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree list" ]; then
+  [ -n "$6" ] && [ "$6" != "--state" ] || exit 2
+  [ "$6" = "fixture" ] || exit 2
+  case "$*" in
+    *" --all --full --format=json"*) ;;
+    *) exit 2 ;;
+  esac
   if [ -f "$DMC_STATE" ]; then
     case "${DMC_INVENTORY_MODE:-}" in
       missing_task)
@@ -369,8 +371,8 @@ assert_contains "homeboy config set /worktree_providers/dmc '{\"enabled\":true,\
 assert_contains "\"resolve_identity\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"identity\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
 assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"safety\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{identity}\"]" "$TMP/dry-run.log"
 assert_contains "\"converge\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"converge\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{identity}\",\"{base}\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{handle}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{path}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"get\",\"{path}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"{repo}\",\"--all\",\"--full\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{path}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"{repo}\",\"--all\",\"--full\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"plan\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"plan\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"plan\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
@@ -387,12 +389,13 @@ DRY_RUN=false
 configure_homeboy_dmc_worktree_provider > "$TMP/apply.log"
 
 assert_contains 'identity|homeboy-readiness@probe' "$DMC_PROVIDER_LOG"
-assert_not_contains 'workspace worktree list' "$STUDIO_LOG"
+assert_not_contains 'workspace worktree get' "$STUDIO_LOG"
 assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
 assert_convergence_contract "$HOMEBOY_CONFIG_LOG"
 assert_resolution_contract "$HOMEBOY_CONFIG_LOG"
+assert_contains 'wp datamachine-code workspace worktree list fixture --all --full --format=json' "$STUDIO_LOG"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
 
 # A source checkout can expose the provider outside the historical installed-plugin path.


### PR DESCRIPTION
## Summary

- replace obsolete DMC `worktree get` resolution with the current repository-scoped `worktree list <repo> --all --full` contract
- derive repository scope from the typed DMC identity handle inside the integration-owned adapter
- make setup and upgrade rewrite stale Homeboy provider configuration without changing generic Homeboy or DMC layers
- update integration coverage to execute and assert the required repository positional and full inventory shape

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `bash -n lib/homeboy.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- `git diff --check`

The fix was produced through Homeboy Cook. Controller promotion could not complete because the installed provider configuration has the exact defect fixed by this PR, so the durable patch was reviewed and applied to the issue-owned DMC worktree before verification and publication.

Closes #401