### PR TITLE
Allow bounded DMC worktree planning

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -145,7 +145,7 @@ homeboy_dmc_command_json() {
 
 homeboy_dmc_worktree_provider_json() {
   local provider="$1"
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":60000,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
     "$(homeboy_dmc_command_json resolve_identity "$provider")" \
     "$(homeboy_dmc_command_json attest_safety "$provider")" \
     "$(homeboy_dmc_command_json resolve "$provider")" \

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -62,8 +62,8 @@ expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", sys.argv[5], sys.argv[4], "{handle}"]
 expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", sys.argv[5], sys.argv[4], "{identity}"]
 expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", sys.argv[5], sys.argv[4], "{identity}", "{base}"]
-if provider.get("lookup_timeout_ms") != 10000:
-    raise SystemExit("FAIL: standalone DMC lookups must retain a bounded timeout")
+if provider.get("lookup_timeout_ms") != 60000:
+    raise SystemExit("FAIL: standalone DMC planning must have a realistic bounded timeout")
 if provider.get("mutation_timeout_ms") != 120000:
     raise SystemExit("FAIL: DMC mutation timeout must accommodate worktree creation and bootstrap")
 if commands.get("resolve_not_found_exit_codes") != [42]:


### PR DESCRIPTION
## Summary

- raise the generated DMC provider lookup budget from 10 to 60 seconds
- retain a bounded timeout below the existing 120-second mutation budget
- update provider contract coverage

Closes #428

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced and measured the DMC planning timeout, implemented the bounded provider adjustment, and ran the listed verification. Chris Huber directed and reviewed the work and is responsible for this pull request.