### PR TITLE
Discover DMC workspace before Homeboy configuration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -574,7 +574,6 @@ if [ "$RUNTIME_ONLY" != true ]; then
     sync_carried_plugins
     install_extra_plugins
     setup_homeboy_project
-    configure_homeboy_dmc_worktree_provider
     setup_nginx
     setup_ssl
     setup_service_permissions
@@ -595,6 +594,9 @@ runtime_install
 runtime_discover_dm_paths
 external_wordpress_project_context
 discover_dm_workspace_dir
+if [ "$RUNTIME_ONLY" != true ] && [ "$EXTERNAL_WORDPRESS" != true ]; then
+  configure_homeboy_dmc_worktree_provider
+fi
 systems_capabilities_apply
 runtime_generate_config
 ai_gateway_configure_opencode

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -11,6 +11,15 @@ source "$SCRIPT_DIR/lib/wordpress.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/homeboy.sh"
 
+for entrypoint in setup.sh upgrade.sh; do
+  discover_line=$(grep -n '^discover_dm_workspace_dir$' "$SCRIPT_DIR/$entrypoint" | tail -1 | cut -d: -f1)
+  configure_line=$(grep -n '^\(  \)\?configure_homeboy_dmc_worktree_provider\(_phase\)\?$' "$SCRIPT_DIR/$entrypoint" | tail -1 | cut -d: -f1)
+  if [ -z "$discover_line" ] || [ -z "$configure_line" ] || [ "$discover_line" -ge "$configure_line" ]; then
+    echo "FAIL: $entrypoint must discover the authoritative DMC workspace before configuring Homeboy" >&2
+    exit 1
+  fi
+done
+
 TMP="$(mktemp -d)"
 ORIGINAL_PATH="$PATH"
 trap 'rm -rf "$TMP"' EXIT

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1446,11 +1446,11 @@ _print_verify_block() {
 # ============================================================================
 
 update_data_machine_plugins
+discover_dm_workspace_dir
 configure_homeboy_dmc_worktree_provider_phase
 sync_cli_transport_runtime
 update_ai_gateway
 sync_chat_bridge_config
-discover_dm_workspace_dir
 systems_capabilities_apply
 check_opencode_json_drift
 ai_gateway_configure_opencode


### PR DESCRIPTION
## Summary

- discover the authoritative Data Machine Code workspace before rendering Homeboy provider commands during setup and upgrade
- retain existing setup phase guards while moving provider configuration after discovery
- cover entrypoint ordering alongside the existing provider and discovery contracts

Closes #431.

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `bash tests/dm-workspace-discovery.sh`
- `bash -n setup.sh upgrade.sh`
- `git diff --check`

`bash tests/verify.sh` has an unrelated pre-existing healthy-fixture failure that reproduces unchanged on `main`.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the post-create provider ownership failure, proved the authoritative workspace-root correction, implemented setup/upgrade ordering, and ran verification. Chris Huber directed the work and is responsible for the change.