### PR TITLE
Embed local OpenCode subagent graph sources

### DIFF
--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -108,7 +108,7 @@ sys.stdout.buffer.write(value)
     local reader_code reader_payload slug_payload reader_error
     reader_payload="$(base64 < "$graph_helper" | tr -d '\n')"
     slug_payload="$(printf '%s' "$AGENT_SLUG" | base64 | tr -d '\n')"
-    reader_code="\$args=array(base64_decode('$slug_payload'));eval('?>'.base64_decode('$reader_payload'));"
+    reader_code="\$args=array(base64_decode('$slug_payload'),'embedded');eval('?>'.base64_decode('$reader_payload'));"
     reader_error="$(mktemp)" || { OPENCODE_SUBAGENT_PROJECTION_FAILURE=temporary_file; warn "Could not prepare OpenCode subagent graph diagnostics"; return 1; }
     agent_json="$(wp_cmd eval "$reader_code" 2>"$reader_error")" || {
       cat "$reader_error" >&2

--- a/tests/opencode-subagents-reader.php
+++ b/tests/opencode-subagents-reader.php
@@ -21,9 +21,11 @@ $root = realpath( $root );
 mkdir( $root . '/writer/skills/writer', 0777, true );
 mkdir( $root . '/writer/references/writer', 0777, true );
 mkdir( $root . '/writer/contexts', 0777, true );
+mkdir( $root . '/shared', 0777, true );
 file_put_contents( $root . '/coordinator/SOUL.md', "# Coordinator\n" );
 file_put_contents( $root . '/writer/SOUL.md', "# Writer\n" );
 file_put_contents( $root . '/writer/contexts/chat.md', "# Nested context\n" );
+file_put_contents( $root . '/shared/SITE.md', "# Shared site context\n" );
 file_put_contents( $root . '/writer/skills/writer/SKILL.md', "---\nname: writer\n---\n" );
 file_put_contents( $root . '/writer/references/writer/context.md', "reference\x00bytes" );
 $outside = $root . '/outside.md';
@@ -54,6 +56,7 @@ function wp_get_ability( string $slug ): object {
 			$files     = array( array( 'filename' => 'SOUL.md', 'layer' => 'agent', 'path' => $directory . '/SOUL.md' ) );
 			if ( 2 === $input['agent_id'] ) {
 				$files[] = array( 'filename' => 'contexts/chat.md', 'layer' => 'agent', 'path' => $directory . '/contexts/chat.md' );
+				$files[] = array( 'filename' => 'SITE.md', 'layer' => 'shared', 'path' => $GLOBALS['root'] . '/shared/SITE.md' );
 			}
 			return array( 'success' => true, 'files' => $files );
 		}
@@ -142,6 +145,7 @@ if ( $embedded ) {
 		false === strpos( $encoded, '"tool_policy":{}' ) ||
 		"---\nname: writer\n---\n" !== base64_decode( $graph['nodes'][1]['sources']['skills']['writer/SKILL.md'], true ) ||
 		"# Nested context\n" !== base64_decode( $graph['nodes'][1]['sources']['instructions']['contexts/chat.md'], true ) ||
+		"# Shared site context\n" !== base64_decode( $graph['nodes'][1]['sources']['instructions']['SITE.md'], true ) ||
 		false !== strpos( wp_json_encode( $graph ), $root ) ) {
 		fwrite( STDERR, "FAIL: embedded reader did not return self-contained artifact content\n" );
 		exit( 1 );

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -32,6 +32,7 @@ import json, sys
 graph = json.load(open(sys.argv[1]))
 assert graph['coordinator'] == 'coordinator'
 assert graph['nodes'][0]['slug'] == 'coordinator'
+assert graph['source_mode'] == 'embedded'
 PY
       cat "$TMP/graph.json"
       ;;


### PR DESCRIPTION
## Summary

- request embedded graph output from the local WP-CLI reader path, matching external WordPress projection
- preserve shared injectable memory that lives outside a child agent identity root
- prove the generated local reader payload is self-contained before projection

Closes #430.

## Verification

- `bash tests/opencode-subagents.sh`
- `bash -n lib/opencode-subagents.sh`
- `php -l tests/opencode-subagents-reader.php`
- `git diff --check`

`bash tests/verify.sh` has an unrelated pre-existing healthy-fixture failure that reproduces unchanged on `main`.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the local/remote transport mismatch, implemented the embedded local reader contract, added layered-memory regression coverage, and ran verification. Chris Huber directed the work and is responsible for the change.