### PR TITLE
Fix DMC resolution in multi-worktree repositories

### DIFF
--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -69,11 +69,11 @@ if ( ! in_array($operation, array( 'identity', 'safety', 'resolve', 'converge' )
 }
 
 /** @return array<string,mixed> */
-$read_inventory = static function ( array $command, string $repo = '' ): array {
+$read_inventory = static function ( array $command, string $repo = '', string $handle = '' ): array {
 	if ( array() === $command ) {
 		throw new RuntimeException('DMC aggregate inventory command is required for resolve.');
 	}
-	if ( '' === $repo || 1 !== count(array_filter($command, static fn ( string $part ): bool => '{repo}' === $part))) {
+	if ( '' === $repo || '' === $handle || 1 !== count(array_filter($command, static fn ( string $part ): bool => '{repo}' === $part))) {
 		throw new RuntimeException('DMC worktree list requires the repository resolved from identity.');
 	}
 	$command = array_map(static fn ( string $part ): string => '{repo}' === $part ? $repo : $part, $command);
@@ -90,10 +90,14 @@ $read_inventory = static function ( array $command, string $repo = '' ): array {
 		throw new RuntimeException('DMC aggregate inventory failed: ' . trim($stderr), $status);
 	}
 	$inventory = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
-	if ( ! is_array($inventory) || 1 !== count($inventory) || ! is_array($inventory[0] ?? null) ) {
-		throw new RuntimeException('DMC aggregate inventory did not return one typed worktree record.');
+	if ( ! is_array($inventory) ) {
+		throw new RuntimeException('DMC aggregate inventory did not return typed worktree records.');
 	}
-	return $inventory[0];
+	$matches = array_values(array_filter($inventory, static fn ( mixed $record ): bool => is_array($record) && $handle === ( $record['handle'] ?? null )));
+	if ( 1 !== count($matches) ) {
+		throw new RuntimeException('DMC aggregate inventory did not return one matching typed worktree record.');
+	}
+	return $matches[0];
 };
 
 $run_provider = static function ( string $provider_operation, string $provider_value, string $provider_base = '' ) use ( $provider, $workspace ): array {
@@ -172,7 +176,7 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 			if ( false === $repo || '' === $repo ) {
 				throw new RuntimeException('DMC identity did not provide a repository-scoped handle.');
 			}
-			$inventory = $read_inventory(array_slice($argv, 5), $repo);
+			$inventory = $read_inventory(array_slice($argv, 5), $repo, $handle);
 		} catch (Throwable $error) {
 			fwrite(STDERR, $error->getMessage() . "\n");
 			exit($error->getCode() > 0 && $error->getCode() < 256 ? $error->getCode() : 1);

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -211,10 +211,14 @@ resolved = run()
 expected = [{"handle": intent["handle"], "path": intent["path"], "branch": "fix/310-dmc-cook", "task_url": "https://github.com/Extra-Chill/wp-coding-agents/issues/419", "safety": {"dirty": False, "unpushed": False, "primary": False}}]
 if resolved.returncode or json.loads(resolved.stdout) != expected:
     raise SystemExit(f"FAIL: resolve did not join typed tracker inventory to exact identity: {resolved!r}")
-for mode in ("missing_task", "mismatched_identity", "conflicting_lineage"):
+for mode in ("missing_task", "conflicting_lineage"):
     result = run(mode)
     if result.returncode == 0 or "does not prove tracker ownership" not in result.stderr:
         raise SystemExit(f"FAIL: {mode} inventory evidence must fail closed: {result!r}")
+for mode in ("mismatched_identity", "duplicate_identity"):
+    result = run(mode)
+    if result.returncode == 0 or "did not return one matching typed worktree record" not in result.stderr:
+        raise SystemExit(f"FAIL: {mode} inventory identity must fail closed: {result!r}")
 PY
 }
 
@@ -312,11 +316,14 @@ if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree list" ]; then
       mismatched_identity)
         printf '[{"handle":"other@worktree","path":"%s","branch":"fix/310-dmc-cook","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"},"owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Home Page","origin_agent":"intelligence-chubes4","origin_task":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"}}}]\n' "$DMC_STATE"
         ;;
+      duplicate_identity)
+        printf '[{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook"},{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook"}]\n' "$DMC_STATE" "$DMC_STATE"
+        ;;
       conflicting_lineage)
         printf '[{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"},"owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Other Site","origin_agent":"intelligence-chubes4","origin_task":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"}}}]\n' "$DMC_STATE"
         ;;
       *)
-        printf '[{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"},"owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Home Page","origin_agent":"intelligence-chubes4","origin_task":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"}}}]\n' "$DMC_STATE"
+        printf '[{"handle":"other@worktree","path":"%s-other","branch":"other"},{"handle":"fixture@fix-310-dmc-cook","path":"%s","branch":"fix/310-dmc-cook","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"},"owner_full":{"site":"Home Page","agent":"intelligence-chubes4"},"metadata":{"origin_site":"Home Page","origin_agent":"intelligence-chubes4","origin_task":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/419"}}}]\n' "$DMC_STATE" "$DMC_STATE"
         ;;
     esac
     exit 0


### PR DESCRIPTION
## Summary
- select the identity-matching worktree from repository-scoped DMC inventory
- fail closed when no record or multiple records match the canonical handle
- cover successful one-among-many resolution and ambiguous inventory

## Verification
- `bash tests/homeboy-dmc-provider.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- `bash -n tests/homeboy-dmc-provider.sh`
- `git diff --check`

Fixes #434.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the control-plane failure, implemented the handle-scoped inventory selection, added regression coverage, and ran verification. Chris Huber remains responsible for the submitted change.