### PR TITLE
fix: recover interrupted DMC release pointer

### DIFF
--- a/lib/dmc-managed-release.sh
+++ b/lib/dmc-managed-release.sh
@@ -84,6 +84,26 @@ dmc_managed_release_release_root() {
   printf '%s/.wp-coding-agents-releases' "$(dmc_managed_release_plugin_dir)"
 }
 
+dmc_managed_release_pointer_matches() {
+  local plugin_dir="$1" version="$2" evidence_type="$3" evidence="$4"
+  local current="$plugin_dir/.wp-coding-agents-release-current" provenance="$plugin_dir/.wp-coding-agents-release-current/.wp-coding-agents-managed-release.json"
+  [ "$(dmc_managed_release_header_version "$current" 2>/dev/null || true)" = "$version" ] || return 1
+  [ -f "$provenance" ] || return 1
+  grep -Fq "\"repository\":\"$DMC_MANAGED_RELEASE_REPO\"" "$provenance" || return 1
+  grep -Fq "\"version\":\"$version\"" "$provenance" || return 1
+  [ "$evidence_type" != github_digest ] || grep -Fq "\"sha256\":\"$evidence\"" "$provenance"
+}
+
+dmc_managed_release_switch_pointer() {
+  local plugin_dir="$1" release_dir="$2"
+  local current="$plugin_dir/.wp-coding-agents-release-current" previous="$plugin_dir/.wp-coding-agents-release-previous" next="$plugin_dir/.wp-coding-agents-release-next"
+  rm -f "$next"
+  ln -s ".wp-coding-agents-releases/$(basename "$release_dir")" "$next" || return 1
+  rm -f "$previous"
+  [ ! -e "$current" ] || mv "$current" "$previous" || { rm -f "$next"; return 1; }
+  mv "$next" "$current" || { dmc_managed_release_recover "$plugin_dir" || true; return 1; }
+}
+
 # Restore a complete prior release after an interrupted symlink switch. The
 # root loader also uses this fallback, so DMC remains loadable before recovery.
 dmc_managed_release_recover() {
@@ -162,12 +182,38 @@ update_data_machine_code_copied_release() {
     return 0
   fi
 
-  if [ "$current" = "$target" ]; then
+  if [ "$current" = "$target" ] && dmc_managed_release_pointer_matches "$plugin_dir" "$target" "$evidence_type" "$evidence"; then
     if [ "${DRY_RUN:-false}" != true ]; then
       dmc_managed_release_recover "$plugin_dir" || { warn "Could not recover interrupted Data Machine Code release update"; return 0; }
     fi
     log "Data Machine Code copied install already at official release $target"
     return 0
+  fi
+  if [ "$current" = "$target" ] && [ "$evidence_type" = github_digest ]; then
+    local staged_release
+    staged_release="$(dmc_managed_release_release_root)/$target-$evidence"
+    if [ -d "$staged_release" ] && [ "$(dmc_managed_release_header_version "$staged_release" 2>/dev/null || true)" = "$target" ] && grep -Fq "\"sha256\":\"$evidence\"" "$staged_release/.wp-coding-agents-managed-release.json" 2>/dev/null; then
+      if [ "${DRY_RUN:-false}" = true ]; then
+        echo -e "${BLUE}[dry-run]${NC} Recover Data Machine Code $target from its verified staged release"
+        return 0
+      fi
+      local was_active=false
+      dmc_managed_release_active && was_active=true
+      if ! dmc_managed_release_switch_pointer "$plugin_dir" "$staged_release"; then
+        warn "Could not recover interrupted Data Machine Code release pointer"
+        return 0
+      fi
+      if [ "$was_active" = true ] && { ! activate_plugin data-machine-code || ! dmc_managed_release_active; }; then
+        rm -f "$plugin_dir/.wp-coding-agents-release-current"
+        dmc_managed_release_recover "$plugin_dir" || true
+        warn "Data Machine Code $target recovery activation verification failed — prior release restored"
+        return 0
+      fi
+      fix_ownership "$plugin_dir"
+      UPDATED_ITEMS+=("data-machine-code $target (recovered official copied release)")
+      log "Recovered Data Machine Code $target release pointer from its verified staged release"
+      return 0
+    fi
   fi
   if [ "${DRY_RUN:-false}" = true ]; then
     if [ "$evidence_type" = github_digest ]; then

--- a/tests/dmc-managed-release.sh
+++ b/tests/dmc-managed-release.sh
@@ -62,12 +62,18 @@ case "$out" in *"$SHA"*) : ;; *) fail "dry-run did not carry the normalized GitH
 # current copied install: no download/deploy and no update record.
 DRY_RUN=false
 printf '<?php\n/*\n * Version: 2.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
+mkdir -p "$PLUGIN/.wp-coding-agents-releases/current"
+printf '<?php\n/*\n * Version: 2.0.0\n */\n' > "$PLUGIN/.wp-coding-agents-releases/current/data-machine-code.php"
+printf '{"repository":"Extra-Chill/data-machine-code","version":"2.0.0","sha256":"%s"}\n' "$SHA" > "$PLUGIN/.wp-coding-agents-releases/current/.wp-coding-agents-managed-release.json"
+ln -s .wp-coding-agents-releases/current "$PLUGIN/.wp-coding-agents-release-current"
 UPDATED_ITEMS=(); LOG=""
 update_data_machine_code_copied_release
 case "$LOG" in *"already at official release 2.0.0"*) : ;; *) fail "current copied install was not recognized";; esac
 [ "${#UPDATED_ITEMS[@]}" -eq 0 ] || fail "current copied install recorded an update"
 
 # GitHub digest mismatch: preserve the old deployment.
+rm -rf "$PLUGIN"
+mkdir -p "$PLUGIN"
 printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/data-machine-code.php"
 DMC_TEST_RELEASE_JSON='{"tag_name":"v2.0.0","assets":[{"name":"dmc.zip","browser_download_url":"https://release/dmc.zip","digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}]}'
 LOG=""
@@ -86,6 +92,22 @@ update_data_machine_code_copied_release
 [ -f "$PLUGIN/.wp-coding-agents-release-current/data-machine-code.php" ] || fail "copied release current pointer missing"
 [ ! -e "$PLUGIN/.wp-coding-agents-release-current/obsolete" ] || fail "copied release included stale files"
 [ "${#UPDATED_ITEMS[@]}" -eq 1 ] || fail "copied release was not recorded"
+
+# Interruption after writing the new loader but before switching current is
+# recovered from the already verified staged release without another download.
+target_pointer="$(readlink "$PLUGIN/.wp-coding-agents-release-current")"
+rm -f "$PLUGIN/.wp-coding-agents-release-current"
+mkdir -p "$PLUGIN/.wp-coding-agents-releases/interrupted-old"
+printf '<?php\n/*\n * Version: 1.0.0\n */\n' > "$PLUGIN/.wp-coding-agents-releases/interrupted-old/data-machine-code.php"
+ln -s .wp-coding-agents-releases/interrupted-old "$PLUGIN/.wp-coding-agents-release-current"
+archive="$DMC_TEST_ARCHIVE"; DMC_TEST_ARCHIVE="$TMP/missing.zip"; export DMC_TEST_ARCHIVE
+UPDATED_ITEMS=(); LOG=""
+update_data_machine_code_copied_release
+DMC_TEST_ARCHIVE="$archive"; export DMC_TEST_ARCHIVE
+[ "$(readlink "$PLUGIN/.wp-coding-agents-release-current")" = "$target_pointer" ] || fail "interrupted loader/pointer state did not select the verified staged release"
+[ "$(dmc_managed_release_header_version "$PLUGIN/.wp-coding-agents-release-current")" = "2.0.0" ] || fail "interrupted loader/pointer recovery left stale code active"
+[ "${#UPDATED_ITEMS[@]}" -eq 1 ] || fail "interrupted loader/pointer recovery was not recorded"
+case "$LOG" in *"Recovered Data Machine Code 2.0.0 release pointer"*) : ;; *) fail "interrupted loader/pointer recovery was not reported";; esac
 
 # Legacy checksum sidecars remain accepted and verified before deployment.
 rm -rf "$PLUGIN"


### PR DESCRIPTION
## Summary

- validate the managed release pointer provenance instead of trusting only the root loader version
- recover a loader-new/pointer-old interruption from the already staged release with the published GitHub digest
- retain the prior complete release as rollback and preserve plugin activation state
- add exact regression coverage that makes the release archive unavailable during recovery

Fixes #438

## Validation

- `bash tests/dmc-managed-release.sh`
- `bash tests/ci-coverage.sh`
- `bash -n lib/dmc-managed-release.sh`
- `bash -n tests/dmc-managed-release.sh`
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenCode using OpenAI `gpt-5.6-sol` diagnosed the interrupted loader/pointer state, implemented staged-artifact reconciliation, and ran the listed validation. Chris Huber directed the work and remains responsible for the change.