### PR TITLE
fix: skip stale plugins during release recovery

### DIFF
--- a/lib/dmc-managed-release.sh
+++ b/lib/dmc-managed-release.sh
@@ -77,7 +77,7 @@ dmc_managed_release_provenance_file() {
 }
 
 dmc_managed_release_active() {
-  wp_cmd plugin is-active data-machine-code >/dev/null 2>&1
+  wp_cmd plugin is-active data-machine-code --skip-plugins >/dev/null 2>&1
 }
 
 dmc_managed_release_release_root() {

--- a/tests/dmc-managed-release.sh
+++ b/tests/dmc-managed-release.sh
@@ -21,7 +21,7 @@ fix_ownership() { :; }
 ACTIVATIONS=0
 ACTIVE=true
 activate_plugin() { ACTIVATIONS=$((ACTIVATIONS + 1)); ACTIVE=true; }
-wp_cmd() { [ "$ACTIVE" = true ] && [ "$1 $2 $3" = "plugin is-active data-machine-code" ]; }
+wp_cmd() { [ "$ACTIVE" = true ] && [ "$1 $2 $3 $4" = "plugin is-active data-machine-code --skip-plugins" ]; }
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 PLUGIN="$SITE_PATH/wp-content/plugins/data-machine-code"


### PR DESCRIPTION
## Summary

- query copied DMC activation state with plugin bootstrap disabled
- prevent a stale active DMC tree from hanging recovery before the verified pointer switch
- require the bootstrap-free query in deterministic updater coverage

Fixes #438

## Validation

- `studio wp plugin is-active data-machine-code --skip-plugins`
- `bash tests/dmc-managed-release.sh`
- `bash tests/ci-coverage.sh`
- `bash -n lib/dmc-managed-release.sh`
- `bash -n tests/dmc-managed-release.sh`
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenCode using OpenAI `gpt-5.6-sol` reproduced the stale plugin bootstrap hang, implemented the bootstrap-free active-state probe, and ran the listed validation. Chris Huber directed the work and remains responsible for the change.