### PR TITLE
Bound authoritative workspace discovery

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -160,10 +160,66 @@ discover_dm_workspace_dir() {
     return 0
   fi
 
-  local workspace_path
-  workspace_path=$(wp_cmd datamachine-code workspace path 2>/dev/null || true)
-  if [ -n "$workspace_path" ]; then
-    DM_WORKSPACE_DIR="$workspace_path"
+  local timeout_seconds="${DM_WORKSPACE_DISCOVERY_TIMEOUT_SECONDS:-30}"
+  case "$timeout_seconds" in
+    ''|*[!0-9]*) timeout_seconds=30 ;;
+  esac
+  [ "$timeout_seconds" -gt 0 ] || timeout_seconds=30
+
+  local temp_dir workspace_file stderr_file pid ticks max_ticks status replay_path replay_command
+  temp_dir="$(mktemp -d)" || return 1
+  workspace_file="$temp_dir/workspace"
+  stderr_file="$temp_dir/stderr"
+  printf -v replay_path '%q' "$SITE_PATH"
+  replay_command="${WP_CMD:-wp} datamachine-code workspace path ${WP_ROOT_FLAG:-} --path=$replay_path"
+
+  # Once authoritative discovery starts, a stale default must not survive a
+  # failure and masquerade as the discovered workspace.
+  DM_WORKSPACE_DIR=""
+  log "Discovering authoritative DMC workspace (timeout: ${timeout_seconds}s, elapsed: 0s)..."
+
+  local restore_monitor=false
+  case "$-" in
+    *m*) ;;
+    *) set -m; restore_monitor=true ;;
+  esac
+  wp_cmd datamachine-code workspace path >"$workspace_file" 2>"$stderr_file" &
+  pid=$!
+  [ "$restore_monitor" = false ] || set +m
+
+  ticks=0
+  max_ticks=$((timeout_seconds * 10))
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$ticks" -ge "$max_ticks" ]; then
+      kill -TERM -- "-$pid" 2>/dev/null || true
+      sleep 0.1
+      kill -KILL -- "-$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      [ ! -s "$stderr_file" ] || cat "$stderr_file" >&2
+      rm -f "$workspace_file" "$stderr_file"
+      rmdir "$temp_dir" 2>/dev/null || true
+      warn "DMC workspace discovery timed out after ${timeout_seconds}s. Replay: $replay_command"
+      return 124
+    fi
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+
+  if wait "$pid"; then status=0; else status=$?; fi
+  [ ! -s "$stderr_file" ] || cat "$stderr_file" >&2
+  if [ "$status" -ne 0 ]; then
+    rm -f "$workspace_file" "$stderr_file"
+    rmdir "$temp_dir" 2>/dev/null || true
+    warn "DMC workspace discovery failed with exit status $status. Replay: $replay_command"
+    return "$status"
+  fi
+
+  DM_WORKSPACE_DIR="$(cat "$workspace_file")"
+  rm -f "$workspace_file" "$stderr_file"
+  rmdir "$temp_dir" 2>/dev/null || true
+  if [ -z "$DM_WORKSPACE_DIR" ]; then
+    warn "DMC workspace discovery returned an empty path. Replay: $replay_command"
+    return 1
   fi
 }
 

--- a/tests/dm-workspace-discovery.sh
+++ b/tests/dm-workspace-discovery.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# tests/dm-workspace-discovery.sh — canonical DMC workspace root discovery.
+# tests/dm-workspace-discovery.sh — bounded canonical DMC workspace discovery.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -12,13 +12,37 @@ touch "$SITE_PATH/wp-config.php"
 
 export SITE_PATH
 export DRY_RUN=false
+export WP_CMD="studio wp"
+export WP_ROOT_FLAG=""
+
+MODE=success
+WP_CALLS_FILE="$TMP/wp-calls"
+CHILD_PID_FILE="$TMP/child.pid"
+DESCENDANT_PID_FILE="$TMP/descendant.pid"
+export WP_CALLS_FILE CHILD_PID_FILE DESCENDANT_PID_FILE
+
+log() { printf '%s\n' "$1"; }
+warn() { printf '%s\n' "$1"; }
 
 wp_cmd() {
+  printf 'call\n' >> "$WP_CALLS_FILE"
   if [ "$*" != "datamachine-code workspace path" ]; then
     echo "unexpected wp_cmd call: $*" >&2
     return 1
   fi
-  printf '%s\n' "$TMP/Developer"
+  case "$MODE" in
+    success)
+      sleep 0.2
+      printf '%s\n' "$TMP/Developer"
+      ;;
+    failure)
+      echo "DMC_ERROR_CODE=workspace_locked: sqlite busy" >&2
+      return 73
+      ;;
+    hang)
+      /bin/sh -c 'printf "%s\n" "$$" > "$CHILD_PID_FILE"; sleep 30 & printf "%s\n" "$!" > "$DESCENDANT_PID_FILE"; wait'
+      ;;
+  esac
 }
 
 # shellcheck disable=SC1091
@@ -26,18 +50,85 @@ source "$SCRIPT_DIR/lib/data-machine.sh"
 
 DM_WORKSPACE_DIR="$TMP/.datamachine/workspace"
 DATAMACHINE_WORKSPACE_PATH=""
+DM_WORKSPACE_DISCOVERY_TIMEOUT_SECONDS=2
 discover_dm_workspace_dir
 if [ "$DM_WORKSPACE_DIR" != "$TMP/Developer" ]; then
-  echo "FAIL: canonical DMC workspace was not discovered: $DM_WORKSPACE_DIR"
+  echo "FAIL: slow canonical DMC workspace was not discovered: $DM_WORKSPACE_DIR"
   exit 1
 fi
 
 DATAMACHINE_WORKSPACE_PATH="$TMP/explicit-workspace"
 DM_WORKSPACE_DIR="$TMP/Developer"
+rm -f "$WP_CALLS_FILE"
 discover_dm_workspace_dir
 if [ "$DM_WORKSPACE_DIR" != "$TMP/explicit-workspace" ]; then
   echo "FAIL: explicit workspace path was not authoritative: $DM_WORKSPACE_DIR"
   exit 1
 fi
+if [ -e "$WP_CALLS_FILE" ]; then
+  echo "FAIL: explicit workspace path still invoked authoritative discovery"
+  exit 1
+fi
+
+DATAMACHINE_WORKSPACE_PATH=""
+DM_WORKSPACE_DIR="$TMP/guessed-workspace"
+MODE=failure
+set +e
+discover_dm_workspace_dir >"$TMP/failure.out" 2>"$TMP/failure.err"
+failure_status=$?
+set -e
+failure_output="$(cat "$TMP/failure.out")$(cat "$TMP/failure.err")"
+if [ "$failure_status" -ne 73 ] || [[ "$failure_output" != *"DMC_ERROR_CODE=workspace_locked: sqlite busy"* ]]; then
+  echo "FAIL: nonzero discovery did not preserve status and stderr: status=$failure_status output=$failure_output"
+  exit 1
+fi
+if [[ "$failure_output" != *"studio wp datamachine-code workspace path"*"--path=$SITE_PATH"* ]]; then
+  echo "FAIL: discovery failure did not name the replay command: $failure_output"
+  exit 1
+fi
+if [ -n "$DM_WORKSPACE_DIR" ]; then
+  echo "FAIL: failed authoritative discovery retained guessed workspace: $DM_WORKSPACE_DIR"
+  exit 1
+fi
+
+MODE=hang
+DM_WORKSPACE_DIR="$TMP/guessed-workspace"
+DM_WORKSPACE_DISCOVERY_TIMEOUT_SECONDS=1
+started="$(python3 -c 'import time; print(time.monotonic())')"
+set +e
+discover_dm_workspace_dir >"$TMP/timeout.out" 2>"$TMP/timeout.err"
+timeout_status=$?
+set -e
+elapsed="$(python3 -c 'import sys, time; print(time.monotonic() - float(sys.argv[1]))' "$started")"
+timeout_output="$(cat "$TMP/timeout.out")$(cat "$TMP/timeout.err")"
+if [ "$timeout_status" -ne 124 ] || ! python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) < 2.5 else 1)' "$elapsed"; then
+  echo "FAIL: hanging discovery was not bounded: status=$timeout_status elapsed=${elapsed}s"
+  exit 1
+fi
+if [[ "$timeout_output" != *"timeout: 1s, elapsed: 0s"* ]] || [[ "$timeout_output" != *"timed out after 1s"* ]]; then
+  echo "FAIL: timeout diagnostic omitted phase timing: $timeout_output"
+  exit 1
+fi
+if [[ "$timeout_output" != *"studio wp datamachine-code workspace path"*"--path=$SITE_PATH"* ]]; then
+  echo "FAIL: timeout diagnostic did not name the replay command: $timeout_output"
+  exit 1
+fi
+
+for pid_file in "$CHILD_PID_FILE" "$DESCENDANT_PID_FILE"; do
+  if [ ! -s "$pid_file" ]; then
+    echo "FAIL: hanging fixture did not record process in $pid_file"
+    exit 1
+  fi
+  pid="$(cat "$pid_file")"
+  attempts=0
+  while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 20 ]; do
+    sleep 0.1
+    attempts=$((attempts + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "FAIL: timed out discovery left process $pid alive"
+    exit 1
+  fi
+done
 
 echo "PASS: tests/dm-workspace-discovery.sh"


### PR DESCRIPTION
## Summary
- bound authoritative DMC workspace discovery during setup and upgrade
- preserve typed stderr/status and emit an exact replay command
- terminate the discovery process group and fail closed without retaining guessed workspace state
- preserve explicit workspace-path authority

Fixes #441.

## Verification
- `/bin/bash tests/dm-workspace-discovery.sh`
- `shellcheck lib/data-machine.sh tests/dm-workspace-discovery.sh`
- `bash tests/ci-coverage.sh`
- `bash tests/homeboy-components.sh`
- `bash tests/homeboy-dmc-provider.sh`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the live hang, implemented the bounded process lifecycle, reviewed Bash 3.2 process-group behavior, and ran focused verification. Chris Huber directed the work and remains responsible.