### PR TITLE
fix: bound DMC task lookup supervision

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -122,9 +122,9 @@ homeboy_dmc_command_json() {
       homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve "$provider" "$DM_WORKSPACE_DIR" '{path}'
       ;;
     resolve_task)
-      # DMC owns the bounded task predicate and returns the complete matching
-      # inventory; the adapter projects its DMC-specific row shape below.
-      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve_task '{task_url}' "${wp_argv[@]}" datamachine-code workspace worktree list '--task-ref={task_url}' --all --with-status --format=json "${wp_flags[@]}"
+      # A single bounded page proves the complete exact-task candidate set before
+      # probing its safety fields; the adapter refuses any continuation.
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve_task '{task_url}' "${wp_argv[@]}" datamachine-code workspace worktree list '--task-ref={task_url}' --with-status --limit=200 --envelope --format=json "${wp_flags[@]}"
       ;;
     ensure)
       # Homeboy owns each fanout worktree lifecycle. DMC verifies this complete
@@ -150,7 +150,7 @@ homeboy_dmc_command_json() {
 
 homeboy_dmc_worktree_provider_json() {
   local provider="$1"
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":10000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s,"resolve_not_found_exit_codes":[42],"resolve_task_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":12000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s,"resolve_not_found_exit_codes":[42],"resolve_task_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
     "$(homeboy_dmc_command_json resolve_identity "$provider")" \
     "$(homeboy_dmc_command_json attest_safety "$provider")" \
     "$(homeboy_dmc_command_json resolve "$provider")" \

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -9,7 +9,9 @@ const HOMEBOY_DMC_TASK_MAX_FIELD_BYTES = 4096;
 const HOMEBOY_DMC_TASK_MAX_OUTPUT_BYTES = 131072;
 const HOMEBOY_DMC_TASK_MAX_DMC_STDOUT_BYTES = 1048576;
 const HOMEBOY_DMC_TASK_MAX_DMC_STDERR_BYTES = 65536;
-const HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = 10;
+// Leave enough of Homeboy's 12-second supervision window to reap the DMC session
+// and report a typed adapter failure instead of being terminated externally.
+const HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = 8;
 const HOMEBOY_DMC_TASK_TERMINATION_GRACE_SECONDS = 1;
 
 if ( '_session_exec' === $operation ) {
@@ -189,7 +191,7 @@ if ( 'resolve_task' === $operation ) {
 		exit(1);
 	}
 	if ( null !== $capture['failure'] ) {
-		$message = 'timeout' === $capture['failure'] ? 'DMC task worktree lookup exceeded its bounded execution time.' : ( 'session' === $capture['failure'] ? 'Could not isolate the DMC task worktree lookup session.' : 'DMC task worktree lookup exceeded its bounded ' . $capture['failure'] . ' capture.' );
+		$message = 'timeout' === $capture['failure'] ? 'DMC task worktree execution exceeded the adapter budget.' : ( 'session' === $capture['failure'] ? 'Could not isolate the DMC task worktree lookup session.' : 'DMC task worktree execution exceeded its bounded ' . $capture['failure'] . ' capture.' );
 		fwrite(STDERR, $message . "\n");
 		exit(1);
 	}
@@ -199,24 +201,25 @@ if ( 'resolve_task' === $operation ) {
 	if ( 0 !== $status ) {
 		$overflow = json_decode($stdout, true);
 		if ( is_array($overflow) && 'worktree_task_candidates_overflow' === ( $overflow['error']['code'] ?? $overflow['code'] ?? null ) ) {
-			fwrite(STDERR, "DMC task worktree lookup exceeded its complete candidate bound.\n");
+			fwrite(STDERR, "DMC task worktree execution exceeded its complete candidate bound.\n");
 		} else {
-			fwrite(STDERR, 'DMC task worktree lookup failed: ' . trim($stderr) . "\n");
+			fwrite(STDERR, 'DMC task worktree execution failed: ' . trim($stderr) . "\n");
 		}
 		exit($status > 0 && $status < 256 ? $status : 1);
 	}
 	try {
 		$rows = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
 	} catch (Throwable $error) {
-		fwrite(STDERR, 'DMC task worktree lookup returned invalid JSON: ' . $error->getMessage() . "\n");
+		fwrite(STDERR, 'DMC task worktree projection returned invalid JSON: ' . $error->getMessage() . "\n");
 		exit(1);
 	}
-	if ( ! is_array($rows) || ! array_is_list($rows) ) {
-		fwrite(STDERR, "DMC task worktree lookup did not return a complete row array.\n");
+	if ( ! is_array($rows) || true !== ($rows['success'] ?? null) || ! is_array($rows['worktrees'] ?? null) || ! array_is_list($rows['worktrees']) || ! is_int($rows['total'] ?? null) || ! is_int($rows['returned'] ?? null) || null !== ($rows['next_cursor'] ?? null) || $rows['total'] !== $rows['returned'] || $rows['returned'] !== count($rows['worktrees']) ) {
+		fwrite(STDERR, "DMC task worktree projection did not return one complete bounded page.\n");
 		exit(1);
 	}
+	$rows = $rows['worktrees'];
 	if ( count($rows) > HOMEBOY_DMC_TASK_MAX_CANDIDATES ) {
-		fwrite(STDERR, "DMC task worktree lookup exceeded its complete candidate bound.\n");
+		fwrite(STDERR, "DMC task worktree projection exceeded its complete candidate bound.\n");
 		exit(1);
 	}
 	$result = array();
@@ -230,11 +233,11 @@ if ( 'resolve_task' === $operation ) {
 			|| ! is_string($row['branch'] ?? null) || '' === $row['branch']
 			|| ! is_array($safety) || ! is_bool($safety['dirty'] ?? null) || ! is_bool($safety['unpushed'] ?? null) || ! is_bool($safety['primary'] ?? null)
 		) {
-				fwrite(STDERR, "DMC task worktree lookup returned an incomplete or mismatched task candidate.\n");
+				fwrite(STDERR, "DMC task worktree projection returned an incomplete or mismatched task candidate.\n");
 			exit(1);
 		}
 		if ( strlen($row['handle']) > HOMEBOY_DMC_TASK_MAX_FIELD_BYTES || strlen($row['path']) > HOMEBOY_DMC_TASK_MAX_FIELD_BYTES || strlen($row['branch']) > HOMEBOY_DMC_TASK_MAX_FIELD_BYTES || strlen($task_url) > HOMEBOY_DMC_TASK_MAX_FIELD_BYTES ) {
-			fwrite(STDERR, "DMC task worktree lookup field exceeds its bounded projection limit.\n");
+			fwrite(STDERR, "DMC task worktree projection field exceeds its bounded limit.\n");
 			exit(1);
 		}
 			$result[] = array(
@@ -251,7 +254,7 @@ if ( 'resolve_task' === $operation ) {
 	}
 	$serialized = json_encode($result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
 	if ( strlen($serialized) > HOMEBOY_DMC_TASK_MAX_OUTPUT_BYTES ) {
-		fwrite(STDERR, "DMC task worktree lookup exceeds its bounded projection output.\n");
+		fwrite(STDERR, "DMC task worktree projection exceeds its bounded output.\n");
 		exit(1);
 	}
 	fwrite(STDOUT, $serialized . "\n");

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -56,6 +56,7 @@ assert_not_contains() {
 assert_provider_contract() {
   python3 - "$1" "$2" "$3" "$DM_WORKSPACE_DIR" "$DMC_PROVIDER_EXECUTABLE" <<'PY'
 import json
+import re
 import sys
 
 lines = [line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/worktree_providers/dmc|")]
@@ -66,14 +67,19 @@ provider = json.loads(payload)
 commands = provider["commands"]
 expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{handle}"]
 expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{path}"]
-expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "--task-ref={task_url}", "--all", "--with-status", "--format=json", f"--path={sys.argv[3]}"]
+expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "--task-ref={task_url}", "--with-status", "--limit=200", "--envelope", "--format=json", f"--path={sys.argv[3]}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", sys.argv[5], sys.argv[4], "{handle}"]
 expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", sys.argv[5], sys.argv[4], "{identity}"]
 expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", sys.argv[5], sys.argv[4], "{identity}", "{base}"]
-if provider.get("lookup_timeout_ms") != 10000:
-    raise SystemExit("FAIL: standalone DMC lookups must retain a bounded timeout")
+if provider.get("lookup_timeout_ms") != 12000:
+    raise SystemExit("FAIL: Homeboy must reserve a supervision margin beyond the DMC adapter budget")
+adapter = open(commands["resolve_task"][1], encoding="utf-8").read()
+adapter_budget = int(re.search(r"HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = (\d+)", adapter).group(1))
+adapter_grace = int(re.search(r"HOMEBOY_DMC_TASK_TERMINATION_GRACE_SECONDS = (\d+)", adapter).group(1))
+if (adapter_budget + adapter_grace) * 1000 >= provider["lookup_timeout_ms"]:
+    raise SystemExit("FAIL: DMC execution and adapter cleanup must finish before Homeboy supervision")
 if provider.get("lookup_output_limit_bytes") != 262144:
     raise SystemExit("FAIL: DMC task lookup output must have an explicit finite Homeboy cap")
 if provider.get("mutation_timeout_ms") != 120000:
@@ -294,14 +300,19 @@ if http_default_port.returncode or json.loads(http_default_port.stdout) != http_
 http_zero_padded_port = run("default_http", " HTTP://GITHUB.COM:080/Extra-Chill/wp-coding-agents/issues/425/?source=fixture#result ")
 if http_zero_padded_port.returncode or json.loads(http_zero_padded_port.stdout) != http_expected:
     raise SystemExit(f"FAIL: zero-padded HTTP default port did not round-trip through the adapter: {http_zero_padded_port!r}")
+started = time.monotonic()
+large_inventory = run("large_inventory")
+elapsed = time.monotonic() - started
+if large_inventory.returncode or json.loads(large_inventory.stdout) != expected or elapsed >= 12:
+    raise SystemExit(f"FAIL: exact-task projection did not complete within Homeboy's declared supervision budget: {large_inventory!r}, elapsed={elapsed}")
 largest_success = run("largest_success")
 largest_rows = json.loads(largest_success.stdout) if largest_success.returncode == 0 else []
 largest_size = len(largest_success.stdout.encode("utf-8"))
 if len(largest_rows) != 200 or largest_rows[0]["handle"] != "fixture@task-425-001" or largest_rows[-1]["handle"] != "fixture@task-425-200" or not 100000 < largest_size < 131072 or largest_size >= 262144:
     raise SystemExit(f"FAIL: largest successful task projection did not stay below both adapter and Homeboy caps: {largest_success!r}")
-for mode in ("mismatched_task", "incomplete_safety", "overflow", "over_budget", "aggregate_over_budget", "escaping_over_budget", "oversized_stdout", "oversized_stderr"):
+for mode in ("mismatched_task", "incomplete_safety", "incomplete_page", "overflow", "over_budget", "aggregate_over_budget", "escaping_over_budget", "oversized_stdout", "oversized_stderr"):
     result = run(mode)
-    expected_error = "bounded stdout capture" if mode == "oversized_stdout" else "bounded stderr capture" if mode == "oversized_stderr" else "complete candidate bound" if mode == "overflow" else "bounded projection output" if mode in ("aggregate_over_budget", "escaping_over_budget") else "bounded projection limit" if mode == "over_budget" else "incomplete or mismatched task candidate"
+    expected_error = "bounded stdout capture" if mode == "oversized_stdout" else "bounded stderr capture" if mode == "oversized_stderr" else "complete candidate bound" if mode == "overflow" else "bounded output" if mode in ("aggregate_over_budget", "escaping_over_budget") else "bounded limit" if mode == "over_budget" else "complete bounded page" if mode == "incomplete_page" else "incomplete or mismatched task candidate"
     if result.returncode == 0 or expected_error not in result.stderr:
         raise SystemExit(f"FAIL: {mode} task candidate must fail closed: {result!r}")
 
@@ -332,7 +343,7 @@ def assert_descendant_stopped(mode, expected_error, timeout):
             raise SystemExit(f"FAIL: {mode} lookup left process {pid} alive")
 
 assert_descendant_stopped("descendant_both", "bounded ", 5)
-assert_descendant_stopped("descendant_silent", "bounded execution time", 15)
+assert_descendant_stopped("descendant_silent", "execution exceeded the adapter budget", 11)
 PY
 }
 
@@ -420,29 +431,36 @@ cat > "$FAKE_BIN/studio" <<'SH'
 printf '%s\n' "$*" >> "$STUDIO_LOG"
 if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree list" ]; then
   case "$*" in
-    *--task-ref=https://github.com/Extra-Chill/wp-coding-agents/issues/425*--all*--with-status*--format=json*|*--task-ref=https://github.com/Extra-Chill/WP-Coding-Agents/issues/425*--all*--with-status*--format=json*|*--task-ref=http://github.com/Extra-Chill/wp-coding-agents/issues/425*--all*--with-status*--format=json*) ;;
+    *--task-ref=https://github.com/Extra-Chill/wp-coding-agents/issues/425*--with-status*--limit=200*--envelope*--format=json*|*--task-ref=https://github.com/Extra-Chill/WP-Coding-Agents/issues/425*--with-status*--limit=200*--envelope*--format=json*|*--task-ref=http://github.com/Extra-Chill/wp-coding-agents/issues/425*--with-status*--limit=200*--envelope*--format=json*) ;;
     *) exit 2 ;;
   esac
   printf '%s\n' "$$" > "$DMC_CHILD_PID"
   case "${DMC_TASK_LOOKUP_MODE:-zero}" in
     zero)
-      printf '[]\n'
+      printf '{"success":true,"total":0,"returned":0,"next_cursor":null,"worktrees":[]}\n'
       ;;
-    one|ambiguous|canonical|mismatched_task|incomplete_safety|default_http)
+    one|ambiguous|canonical|mismatched_task|incomplete_safety|default_http|large_inventory)
       task='https://github.com/Extra-Chill/wp-coding-agents/issues/425'
       [ "${DMC_TASK_LOOKUP_MODE:-}" = mismatched_task ] && task='https://github.com/Extra-Chill/wp-coding-agents/issues/other'
       [ "${DMC_TASK_LOOKUP_MODE:-}" = canonical ] && task='HTTPS://GITHUB.COM/Extra-Chill/WP-Coding-Agents/issues/425/?query=value#fragment'
       [ "${DMC_TASK_LOOKUP_MODE:-}" = default_http ] && task='http://github.com/Extra-Chill/wp-coding-agents/issues/425'
       safety='{"dirty":false,"unpushed":false,"primary":false}'
       [ "${DMC_TASK_LOOKUP_MODE:-}" = incomplete_safety ] && safety='{"dirty":false,"primary":false}'
-      printf '[{"handle":"fixture@task-425","path":"%s","branch":"fix/425-resolve-task","task_full":{"task_url":"%s"},"safety":%s}' "$DMC_STATE" "$task" "$safety"
+      if [ "${DMC_TASK_LOOKUP_MODE:-}" = large_inventory ]; then
+        i=1
+        while [ "$i" -le 5000 ]; do i=$((i + 1)); done
+      fi
+      printf '{"success":true,"total":%s,"returned":%s,"next_cursor":null,"worktrees":[{"handle":"fixture@task-425","path":"%s","branch":"fix/425-resolve-task","task_full":{"task_url":"%s"},"safety":%s}' "$( [ "${DMC_TASK_LOOKUP_MODE:-}" = ambiguous ] && printf 2 || printf 1 )" "$( [ "${DMC_TASK_LOOKUP_MODE:-}" = ambiguous ] && printf 2 || printf 1 )" "$DMC_STATE" "$task" "$safety"
       if [ "${DMC_TASK_LOOKUP_MODE:-}" = ambiguous ]; then
         printf ',{"handle":"fixture@task-425-other","path":"%s-other","branch":"fix/425-resolve-task","task_full":{"task_url":"%s"},"safety":{"dirty":false,"unpushed":false,"primary":false}}' "$DMC_STATE" "$task"
       fi
-      printf ']\n'
+      printf ']}\n'
       ;;
     largest_success|aggregate_over_budget|escaping_over_budget)
-      python3 -c 'import json, sys; mode, path = sys.argv[1:]; task = "https://github.com/Extra-Chill/wp-coding-agents/issues/425"; fill = "x" * (340 if mode == "largest_success" else 1024); fill = "\\\\" * 400 if mode == "escaping_over_budget" else fill; rows = [{"handle": f"fixture@task-425-{index:03d}", "path": f"{path}/{fill}", "branch": f"fix/425-resolve-task-{index:03d}", "task_full": {"task_url": task}, "safety": {"dirty": False, "unpushed": False, "primary": False}} for index in range(1, 201)]; print(json.dumps(rows, separators=(",", ":")))' "${DMC_TASK_LOOKUP_MODE:-}" "$DMC_STATE"
+      python3 -c 'import json, sys; mode, path = sys.argv[1:]; task = "https://github.com/Extra-Chill/wp-coding-agents/issues/425"; fill = "x" * (340 if mode == "largest_success" else 1024); fill = "\\\\" * 400 if mode == "escaping_over_budget" else fill; rows = [{"handle": f"fixture@task-425-{index:03d}", "path": f"{path}/{fill}", "branch": f"fix/425-resolve-task-{index:03d}", "task_full": {"task_url": task}, "safety": {"dirty": False, "unpushed": False, "primary": False}} for index in range(1, 201)]; print(json.dumps({"success": True, "total": 200, "returned": 200, "next_cursor": None, "worktrees": rows}, separators=(",", ":")))' "${DMC_TASK_LOOKUP_MODE:-}" "$DMC_STATE"
+      ;;
+    incomplete_page)
+      printf '{"success":true,"total":201,"returned":200,"next_cursor":"next","worktrees":[]}\n'
       ;;
     overflow)
       printf '{"success":false,"error":{"code":"worktree_task_candidates_overflow","message":"Task worktree lookup exceeded the complete bounded candidate limit.","data":{"status":409,"task_ref":"https://github.com/Extra-Chill/wp-coding-agents/issues/425","total":201,"limit":200}}}\n'
@@ -450,7 +468,7 @@ if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree list" ]; then
       ;;
     over_budget)
       oversized="$(python3 -c 'print("x" * 4097)')"
-      printf '[{"handle":"fixture@task-425","path":"%s","branch":"fix/425-resolve-task","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/425"},"safety":{"dirty":false,"unpushed":false,"primary":false}}]\n' "$oversized"
+      printf '{"success":true,"total":1,"returned":1,"next_cursor":null,"worktrees":[{"handle":"fixture@task-425","path":"%s","branch":"fix/425-resolve-task","task_full":{"task_url":"https://github.com/Extra-Chill/wp-coding-agents/issues/425"},"safety":{"dirty":false,"unpushed":false,"primary":false}}]}\n' "$oversized"
       ;;
     oversized_stdout)
       python3 -c 'import sys; sys.stdout.write("x" * 1048577)'
@@ -538,7 +556,7 @@ assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-pr
 assert_contains "\"converge\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"converge\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{identity}\",\"{base}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{path}\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve_task\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve_task\",\"{task_url}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--task-ref={task_url}\",\"--all\",\"--with-status\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_task\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve_task\",\"{task_url}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--task-ref={task_url}\",\"--with-status\",\"--limit=200\",\"--envelope\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"resolve_task_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"


### PR DESCRIPTION
## Summary
- replace exhaustive task lookup output with a complete bounded envelope
- leave explicit cleanup margin between the adapter and Homeboy supervision deadlines
- distinguish DMC execution failures from adapter projection failures
- cover large inventories, incomplete pages, output bounds, and descendant cleanup

Closes #442.

## Verification
- `bash tests/homeboy-dmc-provider.sh`
- full shell suite

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode traced the nested deadlines and DMC projection contract, implemented the repair, and ran the repository checks. OpenAI GPT-5.6 Sol via OpenCode reviewed and independently reran the provider contract. Chris Huber directed the work and is responsible for the change.