### PR TITLE
Validate generated DMC resolve commands

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -607,7 +607,7 @@ configure_homeboy_dmc_worktree_provider() {
 
   if [ -n "${SITE_PATH:-}" ] && { [ -f "$SITE_PATH/wp-config.php" ] || [ -f "$SITE_PATH/wp-load.php" ]; }; then
     if ! homeboy_dmc_worktree_provider_ready "$provider" "$provider_json"; then
-      homeboy_handle_failure "wp-coding-agents generated Homeboy DMC provider command readiness failed; rerun '$SCRIPT_DIR/upgrade.sh --plugins-only' to converge the integration."
+      homeboy_handle_failure "wp-coding-agents generated Homeboy DMC provider command readiness failed; rerun: \"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\""
       return 0
     fi
   fi

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -164,25 +164,67 @@ homeboy_dmc_worktree_provider_json() {
 }
 
 homeboy_dmc_worktree_provider_ready() {
-  local provider="$1" response
+  local provider="$1" provider_json="${2:-}"
 
   [ -f "$provider" ] || return 1
   [ -d "${DM_WORKSPACE_DIR:-}" ] || return 1
+  [ -n "$provider_json" ] || return 1
 
-  # Identity is the standalone, repo-independent contract used by Homeboy's
-  # generated provider. An unknown canonical handle must receive a typed decline.
-  response="$(php "$provider" identity "$DM_WORKSPACE_DIR" 'homeboy-readiness@probe' 2>/dev/null)" || return 1
-  printf '%s' "$response" | python3 -c '
+  # Exercise the exact generated argv with the only input Homeboy supplies to
+  # resolve. This catches stale or unknown placeholders before a Cook while the
+  # typed missing handle keeps the probe read-only.
+  HOMEBOY_DMC_PROVIDER_JSON="$provider_json" python3 - <<'PY'
 import json
+import os
+import re
+import subprocess
 import sys
 
 try:
-    payload = json.load(sys.stdin)
-except Exception:
+    provider = json.loads(os.environ["HOMEBOY_DMC_PROVIDER_JSON"])
+    command = provider["commands"]["resolve"]
+    not_found_exit_codes = provider["commands"]["resolve_not_found_exit_codes"]
+    if not isinstance(command, list) or not command or not all(isinstance(part, str) for part in command):
+        raise ValueError("commands.resolve must be a non-empty argv array")
+    if not isinstance(not_found_exit_codes, list) or not all(isinstance(code, int) for code in not_found_exit_codes):
+        raise ValueError("commands.resolve_not_found_exit_codes must be an integer array")
+except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+    print(f"Invalid generated Homeboy DMC provider contract: {error}", file=sys.stderr)
     sys.exit(1)
 
-sys.exit(0 if payload.get("schema") == "datamachine-code/worktree-identity/v1" and payload.get("status") == "not_owned" and payload.get("ownership") == "not_owned" else 1)
-' >/dev/null 2>&1
+handle = "homeboy-readiness@probe"
+command = [part.replace("{handle}", handle) for part in command]
+for argument in command:
+    placeholder = re.search(r"\{[^{}]+\}", argument)
+    if placeholder:
+        print(
+            "worktree provider `dmc` resolve command contains an unresolved "
+            f"placeholder: {placeholder.group(0)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+environment = os.environ.copy()
+environment.pop("HOMEBOY_DMC_PROVIDER_JSON", None)
+try:
+    result = subprocess.run(command, text=True, capture_output=True, env=environment)
+except OSError as error:
+    print(f"Could not run generated Homeboy DMC resolve command: {error}", file=sys.stderr)
+    sys.exit(1)
+try:
+    payload = json.loads(result.stdout)
+except json.JSONDecodeError:
+    payload = {}
+if (
+    result.returncode not in not_found_exit_codes
+    or payload.get("success") is not False
+    or payload.get("error", {}).get("code") != "worktree_not_found"
+):
+    print("Generated Homeboy DMC resolve command failed its typed read-only fixture.", file=sys.stderr)
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    sys.exit(1)
+PY
 }
 
 homeboy_dmc_worktree_provider_executable() {
@@ -564,8 +606,8 @@ configure_homeboy_dmc_worktree_provider() {
   fi
 
   if [ -n "${SITE_PATH:-}" ] && { [ -f "$SITE_PATH/wp-config.php" ] || [ -f "$SITE_PATH/wp-load.php" ]; }; then
-    if ! homeboy_dmc_worktree_provider_ready "$provider"; then
-      homeboy_handle_failure "Data Machine Code standalone worktree provider is not available; skipping Homeboy DMC worktree provider setup."
+    if ! homeboy_dmc_worktree_provider_ready "$provider" "$provider_json"; then
+      homeboy_handle_failure "wp-coding-agents generated Homeboy DMC provider command readiness failed; rerun '$SCRIPT_DIR/upgrade.sh --plugins-only' to converge the integration."
       return 0
     fi
   fi

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -575,6 +575,25 @@ if [ -f "$HOMEBOY_CONFIG_LOG" ]; then
 fi
 
 DRY_RUN=false
+
+# Readiness runs the generated resolve argv, not just DMC's underlying identity
+# executable. Historical and unknown placeholders must fail before config write.
+provider_json="$(homeboy_dmc_worktree_provider_json "$DMC_PROVIDER_EXECUTABLE")"
+rm -f "$DMC_STATE"
+homeboy_dmc_worktree_provider_ready "$DMC_PROVIDER_EXECUTABLE" "$provider_json"
+stale_resolve_json="$(printf '%s' "$provider_json" | python3 -c 'import json, sys; provider = json.load(sys.stdin); provider["commands"]["resolve"].append("{repo}"); print(json.dumps(provider, separators=(",", ":")))')"
+if homeboy_dmc_worktree_provider_ready "$DMC_PROVIDER_EXECUTABLE" "$stale_resolve_json" 2> "$TMP/stale-resolve-readiness.log"; then
+  echo "FAIL: readiness accepted the historical repo-scoped resolve template"
+  exit 1
+fi
+assert_contains 'resolve command contains an unresolved placeholder: {repo}' "$TMP/stale-resolve-readiness.log"
+unknown_resolve_json="$(printf '%s' "$provider_json" | python3 -c 'import json, sys; provider = json.load(sys.stdin); provider["commands"]["resolve"].append("{unknown}"); print(json.dumps(provider, separators=(",", ":")))')"
+if homeboy_dmc_worktree_provider_ready "$DMC_PROVIDER_EXECUTABLE" "$unknown_resolve_json" 2> "$TMP/unknown-resolve-readiness.log"; then
+  echo "FAIL: readiness accepted an unknown resolve placeholder"
+  exit 1
+fi
+assert_contains 'resolve command contains an unresolved placeholder: {unknown}' "$TMP/unknown-resolve-readiness.log"
+
 configure_homeboy_dmc_worktree_provider > "$TMP/apply.log"
 
 assert_contains 'identity|homeboy-readiness@probe' "$DMC_PROVIDER_LOG"
@@ -602,8 +621,8 @@ assert_not_contains "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-wor
 assert_resolution_contract "$HOMEBOY_CONFIG_LOG"
 
 # The same generated set operation is used during upgrade, replacing stale
-# installed provider objects rather than retaining missing provider commands.
-printf '/worktree_providers/dmc|{"commands":{"ensure":["stale"]}}\n' > "$HOMEBOY_CONFIG_LOG"
+# installed provider objects rather than retaining incompatible resolve commands.
+printf '/worktree_providers/dmc|{"commands":{"resolve":["provider","resolve","{handle}","{repo}"],"ensure":["stale"]}}\n' > "$HOMEBOY_CONFIG_LOG"
 rm -f "$DMC_STATE"
 configure_homeboy_dmc_worktree_provider > "$TMP/upgrade.log"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -627,6 +627,20 @@ rm -f "$DMC_STATE"
 configure_homeboy_dmc_worktree_provider > "$TMP/upgrade.log"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 
+# Failure guidance must replay a full upgrade, which updates DMC before
+# reconciling the provider config. --plugins-only deliberately does not.
+homeboy_dmc_worktree_provider_ready() { return 1; }
+HOMEBOY_CONFIG_LOG="$TMP/readiness-failure-config.log"
+export HOMEBOY_CONFIG_LOG
+configure_homeboy_dmc_worktree_provider > "$TMP/readiness-failure.log"
+assert_contains "rerun: \"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\"" "$TMP/readiness-failure.log"
+assert_not_contains '--plugins-only' "$TMP/readiness-failure.log"
+if [ -f "$HOMEBOY_CONFIG_LOG" ]; then
+  echo "FAIL: failed readiness should not write Homeboy provider config"
+  cat "$HOMEBOY_CONFIG_LOG"
+  exit 1
+fi
+
 HOMEBOY_MODE="disabled"
 HOMEBOY_CONFIG_LOG="$TMP/disabled-homeboy-config.log"
 export HOMEBOY_CONFIG_LOG


### PR DESCRIPTION
## Summary

- validate the exact generated DMC `resolve` argv during readiness instead of only probing the underlying identity executable
- reject historical `{repo}` and unknown placeholders before a Cook can use the provider
- require the typed, read-only `worktree_not_found` response from the generated command
- emit a replayable wp-coding-agents convergence command when readiness fails
- cover current, stale, unknown-placeholder, and upgrade-convergence contracts

Closes #447.

## Verification

- focused DMC provider integration tests passed
- Bash syntax checks passed
- ShellCheck passed
- `git diff --check` passed

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding subagents reproduced the command-template mismatch, implemented the generated-argv readiness contract, audited recovery guidance and command safety, and added regression coverage. Chris Huber directed the work and remains responsible.
