### PR TITLE
Align Homeboy upgrade verification guidance

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -244,6 +244,7 @@ jobs:
           - homeboy-components
           - homeboy-dmc-provider
           - homeboy-project-id
+          - homeboy-verification-guidance
           - kimaki-credential-seeding
           - kimaki-install-existing
           - kimaki-launchd-start

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -671,10 +671,18 @@ recompose_agents_md_for_homeboy() {
 }
 
 print_homeboy_verification_commands() {
+  local verification_wp_flags=""
+  [ -n "${SITE_PATH:-}" ] && verification_wp_flags=" --path=$SITE_PATH"
+  [ -n "${WP_ROOT_FLAG:-}" ] && verification_wp_flags="$verification_wp_flags $WP_ROOT_FLAG"
+
   log "Homeboy verification commands:"
+  echo "  homeboy --version"
   echo "  homeboy extension list"
   echo "  homeboy extension show wordpress"
+  echo "  homeboy config show /worktree_providers/dmc"
   echo "  homeboy project show <project-id>"
   echo "  homeboy project components list <project-id>"
+  echo "  $WP_CMD datamachine-code workspace worktree provider --format=json$verification_wp_flags"
+  echo "  $WP_CMD datamachine memory compose AGENTS.md$verification_wp_flags"
   echo "  ./scripts/verify-homeboy-codebox-canary.sh --workspace <repo-or-worktree> --secret-env <ENV_NAME> --agents-api <path> --agent-runtime <path> --agent-runtime-tools <path> --provider-plugin-path <path>  # opt-in model-backed Codebox canary; use --provider claude-code and the carried ai-provider-for-claude-code path for Claude Code; add --run to execute"
 }

--- a/operator-entrypoints/wp-coding-agents-setup/verify.md
+++ b/operator-entrypoints/wp-coding-agents-setup/verify.md
@@ -152,23 +152,33 @@ Verify the selected runtime can be started manually in the terminal or over SSH.
 
 ### `verify-homeboy`
 
-This overlay proves Homeboy is installed, linked, and advertised to Data Machine. It does **not** prove the repo-aware Homeboy Codebox `agent-task` path can launch a sandbox, hydrate provider auth, mount the workspace at `/workspace`, and return patch/change evidence.
+This overlay proves Homeboy is installed and linked, the DMC standalone provider is callable and configured in Homeboy, and the project/component model is inspectable. It does **not** prove the repo-aware Homeboy Codebox `agent-task` path can launch a sandbox, hydrate provider auth, mount the workspace at `/workspace`, and return patch/change evidence.
 
 ```bash
 homeboy --version
 homeboy extension list
+homeboy extension show wordpress
+homeboy config show /worktree_providers/dmc
 homeboy project show <project-id>
 homeboy project components list <project-id>
-wp option get datamachine_code_homeboy_available --path=/path/to/site
+wp datamachine-code workspace worktree provider --format=json --path=/path/to/site
 wp datamachine memory compose AGENTS.md --path=/path/to/site
 ```
 
 For WordPress Studio:
 
 ```bash
-studio wp option get datamachine_code_homeboy_available
+studio wp datamachine-code workspace worktree provider --format=json
 studio wp datamachine memory compose AGENTS.md
 ```
+
+The DMC command should return the `datamachine-code/standalone-worktree-provider-command/v1` schema with a callable executable. `homeboy config show /worktree_providers/dmc` should show that provider as an enabled command provider. The optional legacy `datamachine_code_homeboy_available` option is not part of this readiness contract; do not fail verification when it is absent.
+
+Attribute failures before retrying:
+
+- Missing or invalid standalone provider output is owned by Data Machine Code. Update or reactivate DMC, then rerun setup.
+- A missing or disabled `/worktree_providers/dmc` entry is owned by the wp-coding-agents Homeboy integration. Rerun Homeboy configuration after DMC is healthy.
+- Extension readiness and project/component lookup failures are owned by Homeboy. Use the failed command's diagnostics and repair that Homeboy configuration.
 
 Expected model:
 
@@ -232,7 +242,7 @@ Actionable failure interpretation:
 - Missing provider secret env names: pass `--secret-env NAME`; pass only env var names, never token values.
 - Missing `/workspace` mount: verify the provider config contains a read-only mount with `target: "/workspace"` and `source` set to the existing repo/worktree path.
 
-This canary is stronger than `datamachine_code_homeboy_available=1`: that option means Data Machine should advertise Homeboy guidance, while the canary proves the Codebox executor returned durable run, log, changed-files, and patch evidence for a repo-aware task.
+This canary is stronger than the basic Homeboy overlay: the overlay proves configured provider and project/component inspection, while the canary proves the Codebox executor returned durable run, log, changed-files, and patch evidence for a repo-aware task.
 
 ### `verify-codex-codebox-provider`
 

--- a/skills/upgrade-wp-coding-agents/SKILL.md
+++ b/skills/upgrade-wp-coding-agents/SKILL.md
@@ -52,13 +52,17 @@ The user says something like:
    ```bash
    homeboy --version
    homeboy extension list
+   homeboy extension show wordpress
+   homeboy config show /worktree_providers/dmc
    homeboy project show <project-id>
    homeboy project components list <project-id>
-   wp option get datamachine_code_homeboy_available --path=/path/to/site
+   wp datamachine-code workspace worktree provider --format=json --path=/path/to/site
    wp config get DATAMACHINE_COMPOSE_AGENTS_MD --path=/path/to/site
    wp datamachine memory compose AGENTS.md --path=/path/to/site
    ```
-   For WordPress Studio installs, use `studio wp option get datamachine_code_homeboy_available` and `studio wp datamachine memory compose AGENTS.md`. Do not create `homeboy.json` in the site root to "fix" a missing project; that confuses a Homeboy project with a component.
+   For WordPress Studio installs, use `studio wp datamachine-code workspace worktree provider --format=json` and `studio wp datamachine memory compose AGENTS.md`. The provider command should return the `datamachine-code/standalone-worktree-provider-command/v1` schema, and Homeboy config should show an enabled `dmc` command provider. The optional legacy `datamachine_code_homeboy_available` option is not a runtime readiness check; its absence is not a verification failure.
+
+   Attribute failures to the owning layer. A missing standalone provider command belongs to Data Machine Code; update or reactivate DMC before rerunning setup or upgrade. A missing `/worktree_providers/dmc` entry belongs to wp-coding-agents Homeboy integration; rerun its Homeboy configuration. Extension readiness and project/component lookup failures belong to Homeboy. Do not create `homeboy.json` in the site root to "fix" a missing project; that confuses a Homeboy project with a component.
 
    Setup and upgrade write `define( 'DATAMACHINE_COMPOSE_AGENTS_MD', true )` to wp-config.php (idempotent grep-guard; skipped on Studio and dry-run). This is the gate that turns on core-owned AGENTS.md composition — `wp config get DATAMACHINE_COMPOSE_AGENTS_MD` should return `true` after either run.
 

--- a/tests/homeboy-verification-guidance.sh
+++ b/tests/homeboy-verification-guidance.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Keep generated Homeboy summary commands and operator guidance on one contract.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/homeboy.sh"
+
+WP_CMD="wp"
+SITE_PATH="/path/to/site"
+WP_ROOT_FLAG=""
+
+SUMMARY="$(print_homeboy_verification_commands)"
+WP_CMD="studio wp"
+SITE_PATH=""
+STUDIO_SUMMARY="$(print_homeboy_verification_commands)"
+SKILL="skills/upgrade-wp-coding-agents/SKILL.md"
+SETUP_VERIFY="operator-entrypoints/wp-coding-agents-setup/verify.md"
+
+assert_contract_command() {
+  local command="$1" file
+
+  case "$SUMMARY" in
+    *"$command"*) ;;
+    *) echo "FAIL: generated summary is missing: $command"; exit 1 ;;
+  esac
+
+  for file in "$SKILL" "$SETUP_VERIFY"; do
+    if ! grep -qF -- "$command" "$file"; then
+      echo "FAIL: $file is missing generated summary command: $command"
+      exit 1
+    fi
+  done
+}
+
+assert_contract_command "homeboy --version"
+assert_contract_command "homeboy extension list"
+assert_contract_command "homeboy extension show wordpress"
+assert_contract_command "homeboy config show /worktree_providers/dmc"
+assert_contract_command "homeboy project show <project-id>"
+assert_contract_command "homeboy project components list <project-id>"
+assert_contract_command "wp datamachine-code workspace worktree provider --format=json --path=/path/to/site"
+assert_contract_command "wp datamachine memory compose AGENTS.md --path=/path/to/site"
+
+for command in \
+  "studio wp datamachine-code workspace worktree provider --format=json" \
+  "studio wp datamachine memory compose AGENTS.md"; do
+  case "$STUDIO_SUMMARY" in
+    *"$command"*) ;;
+    *) echo "FAIL: generated Studio summary is missing: $command"; exit 1 ;;
+  esac
+  for file in "$SKILL" "$SETUP_VERIFY"; do
+    if ! grep -qF -- "$command" "$file"; then
+      echo "FAIL: $file is missing generated Studio summary command: $command"
+      exit 1
+    fi
+  done
+done
+
+for file in "$SKILL" "$SETUP_VERIFY"; do
+  if grep -qF -- "option get datamachine_code_homeboy_available" "$file"; then
+    echo "FAIL: $file still probes optional legacy Homeboy state"
+    exit 1
+  fi
+done
+
+case "$SUMMARY" in
+  *"option get datamachine_code_homeboy_available"*)
+    echo "FAIL: generated summary probes optional legacy Homeboy state"
+    exit 1
+    ;;
+esac
+
+echo "OK: Homeboy verification guidance matches the generated runtime summary"

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -446,6 +446,7 @@ stray=$(grep -n 'datamachine memory compose AGENTS.md' upgrade.sh lib/*.sh \
   | grep -v 'wp_run_as_service_user' \
   | grep -v 'dry-run' \
   | sed 's/^[^:]*:[0-9]*: *//' \
+  | grep -v '^echo ' \
   | grep -v '^#' || true)
 if [ -z "$stray" ]; then
   echo "  ok   no compose call site bypasses the service-user helper"


### PR DESCRIPTION
## Summary
- derive Homeboy verification guidance from the active DMC contract
- keep generated upgrade instructions and runtime summaries aligned
- cover the operator-facing guidance deterministically

## Testing
- `bash tests/homeboy-verification-guidance.sh`
- `bash -n lib/homeboy.sh upgrade.sh`

Fixes #437

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to investigate, implement, rebase, and verify this change under human orchestration.