### PR TITLE
Enable native OpenCode general-subagent dispatch

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -48,6 +48,19 @@ jobs:
       - name: Run tests/opencode-subagents.sh
         run: bash tests/opencode-subagents.sh
 
+  opencode-general-dispatch:
+    name: bounded OpenCode general dispatch (#453)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install supported OpenCode fixture
+        run: npm install --global opencode-ai@1.18.20
+      - name: Run tests/opencode-general-dispatch.sh
+        run: bash tests/opencode-general-dispatch.sh
+
   managed-skill-targets:
     name: managed skill target deduplication (#306)
     runs-on: ubuntu-latest

--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 # Project Data Machine's persisted portable agent graph for OpenCode.
 
+OPENCODE_GENERAL_DISPATCH_MIN_VERSION="1.18.20"
+
+opencode_general_dispatch_supported() {
+  local version agents
+  if ! command -v opencode >/dev/null 2>&1; then
+    warn "OpenCode general-subagent dispatch requires OpenCode >= $OPENCODE_GENERAL_DISPATCH_MIN_VERSION, but the opencode binary is unavailable"
+    return 1
+  fi
+
+  version="$(opencode --version 2>/dev/null || true)"
+  if ! python3 - "$version" "$OPENCODE_GENERAL_DISPATCH_MIN_VERSION" <<'PY'
+import re, sys
+
+actual, minimum = sys.argv[1:]
+match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", actual.strip())
+raise SystemExit(0 if not match or tuple(map(int, match.groups())) >= tuple(map(int, minimum.split("."))) else 1)
+PY
+  then
+    warn "OpenCode $version does not provide the managed general-subagent dispatch contract; install OpenCode >= $OPENCODE_GENERAL_DISPATCH_MIN_VERSION"
+    return 1
+  fi
+
+  agents="$(cd "$SITE_PATH" && opencode agent list --pure 2>/dev/null)" || {
+    warn "OpenCode $version could not report its agent capabilities; general-subagent dispatch was not enabled"
+    return 1
+  }
+  if ! printf '%s\n' "$agents" | grep -qx 'general (subagent)'; then
+    warn "OpenCode $version does not expose the native general subagent; general-subagent dispatch was not enabled"
+    return 1
+  fi
+}
+
 opencode_external_graph_eval() {
   local reader_code="$1"
   local timeout_seconds="${OPENCODE_EXTERNAL_GRAPH_TIMEOUT_SECONDS:-120}"
@@ -47,6 +79,11 @@ opencode_project_subagents() {
   [ -n "${AGENT_SLUG:-}" ] || return 0
   [ -f "$SITE_PATH/wp-config.php" ] || [ "${EXTERNAL_WORDPRESS:-false}" = true ] || return 0
   [ -f "$SITE_PATH/opencode.json" ] || return 0
+
+  if ! opencode_general_dispatch_supported; then
+    OPENCODE_SUBAGENT_PROJECTION_FAILURE=unsupported_runtime
+    return 1
+  fi
 
   local graph_helper projector agent_json
   graph_helper="$SCRIPT_DIR/lib/read-opencode-subagent-graph.php"

--- a/lib/project-opencode-subagents.py
+++ b/lib/project-opencode-subagents.py
@@ -155,6 +155,7 @@ def graph(data):
         if len(set(names.values())) != len(names): fail(f"{name} has duplicate SKILL.md names")
         result[slug] = {"description": text(node.get("description"), f"{name}.description"), "model": text(node.get("model"), f"{name}.model", True) or None, "instructions": instructions, "skills": skills, "references": references, "skill_names": names, "permission": policy}
     if coordinator not in edges_by_node: fail("graph does not contain its coordinator")
+    if "general" in result and coordinator != "general": fail("graph child slug general is reserved for OpenCode's native subagent")
     if any(edge not in result for edges in edges_by_node.values() for edge in edges): fail("graph contains an unresolved child edge")
     return result, edges_by_node, coordinator
 
@@ -272,7 +273,7 @@ def main():
             target = Path("skills") / skill_roots[base] / "references" / relative.relative_to(base)
             desired[root / target] = source_bytes(source); artifacts.append(str(target))
         # Only the coordinator's own task configuration belongs in opencode.json.
-        task = {"*": "deny", **{edge: "allow" for edge in edges[coordinator]}}
+        task = {"*": "deny", "general": "allow", **{edge: "allow" for edge in edges[coordinator]}}
         current = config["permission"].get("task")
         if current not in (None, previous["task_permission"]): fail("refusing to overwrite user-owned OpenCode permission.task")
         current_skill = config["permission"].get("skill", {})

--- a/tests/external-wordpress-runtime.sh
+++ b/tests/external-wordpress-runtime.sh
@@ -128,6 +128,7 @@ source "$SCRIPT_DIR/lib/skills.sh"
 source "$SCRIPT_DIR/lib/opencode-subagents.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/runtimes/opencode.sh"
+opencode_general_dispatch_supported() { return 0; }
 error() { printf '%s\n' "$*" >&2; return 1; }
 
 external_wordpress_prepare_transport
@@ -190,7 +191,7 @@ assert root.joinpath(".opencode/skills/editorial/references/context.bin").read_b
 manifest = json.loads(root.joinpath(".opencode/.wp-coding-agents-subagents.json").read_text())
 assert manifest["agents"] == ["agents/reviewer.md", "agents/writer.md"]
 config = json.loads(root.joinpath("opencode.json").read_text())
-assert config["permission"]["task"] == {"*": "deny", "writer": "allow", "reviewer": "allow"}
+assert config["permission"]["task"] == {"*": "deny", "general": "allow", "writer": "allow", "reviewer": "allow"}
 writer = root.joinpath(".opencode/agents/writer.md").read_text()
 assert '"task":{"*":"deny","reviewer":"allow"}' in writer
 PY

--- a/tests/opencode-general-dispatch.sh
+++ b/tests/opencode-general-dispatch.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# Live OpenCode contract for bounded native general-subagent dispatch.
+set -eu
+
+# A managed parent session exports its own server/config identity. The child
+# process must discover only this test's temporary project configuration.
+unset OPENCODE OPENCODE_CONFIG OPENCODE_PID OPENCODE_PORT OPENCODE_PRINT_LOGS OPENCODE_LOG_LEVEL
+unset OPENCODE_EXPERIMENTAL_WORKSPACES OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS
+unset KIMAKI KIMAKI_DATA_DIR KIMAKI_CONFIG_DIR KIMAKI_OPENCODE_PROCESS KIMAKI_THREAD_ID
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+TMP="$(cd "$TMP" && pwd -P)"
+trap 'kill "${SERVER_PID:-}" 2>/dev/null || true; rm -rf "$TMP"' EXIT
+SITE="$TMP/site"
+WORKSPACE="$TMP/workspace"
+PORT_FILE="$TMP/port"
+STATE_FILE="$TMP/state.json"
+OUTPUT_FILE="$TMP/output.jsonl"
+mkdir -p "$SITE/wp-content/plugins/vendor" "$SITE/.opencode" "$WORKSPACE" "$TMP/home" "$TMP/config" "$TMP/data" "$TMP/cache" "$TMP/state"
+export HOME="$TMP/home" XDG_CONFIG_HOME="$TMP/config" XDG_DATA_HOME="$TMP/data" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state"
+printf '%s\n' 'installed source' > "$SITE/wp-content/plugins/vendor/plugin.php"
+printf '%s\n' '# Coordinator' > "$TMP/SOUL.md"
+
+python3 - "$PORT_FILE" "$STATE_FILE" "$SITE" <<'PY' &
+import json
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+port_file, state_file, site = sys.argv[1:]
+condition = threading.Condition()
+children = []
+child_directories = []
+
+def response(content=None, tool_calls=None, finish="stop"):
+    message = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    return {
+        "id": "chatcmpl-fixture", "object": "chat.completion", "created": int(time.time()), "model": "fixture",
+        "choices": [{"index": 0, "message": message, "finish_reason": finish}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        request = json.loads(self.rfile.read(length))
+        encoded = json.dumps(request.get("messages", []))
+        if any(message.get("role") == "tool" for message in request.get("messages", [])):
+            body = response("PARENT_COMPLETE")
+        elif "ALPHA_ONLY" in encoded or "BETA_ONLY" in encoded:
+            marker = "ALPHA_ONLY" if "ALPHA_ONLY" in encoded else "BETA_ONLY"
+            with condition:
+                children.append(marker)
+                child_directories.append(site in encoded)
+                condition.notify_all()
+                concurrent = condition.wait_for(lambda: len(children) == 2, timeout=10)
+                with open(state_file, "w", encoding="utf-8") as handle:
+                    json.dump({"children": sorted(children), "concurrent": concurrent, "explicit_directory": all(child_directories)}, handle)
+            body = response(marker)
+        else:
+            calls = []
+            for index, marker in enumerate(("ALPHA_ONLY", "BETA_ONLY"), 1):
+                arguments = json.dumps({
+                    "description": f"fixture task {index}",
+                    "prompt": f"Complete this independent coding fixture. Return exactly {marker}.",
+                    "subagent_type": "general",
+                })
+                calls.append({"id": f"call_{index}", "type": "function", "function": {"name": "task", "arguments": arguments}})
+            body = response(tool_calls=calls, finish="tool_calls")
+        if request.get("stream"):
+            message = body["choices"][0]["message"]
+            delta = {"role": "assistant"}
+            if message.get("tool_calls") is not None:
+                delta["tool_calls"] = message["tool_calls"]
+            else:
+                delta["content"] = message.get("content") or ""
+            chunks = [
+                {"id": body["id"], "object": "chat.completion.chunk", "created": body["created"], "model": body["model"],
+                 "choices": [{"index": 0, "delta": delta, "finish_reason": None}]},
+                {"id": body["id"], "object": "chat.completion.chunk", "created": body["created"], "model": body["model"],
+                 "choices": [{"index": 0, "delta": {}, "finish_reason": body["choices"][0]["finish_reason"]}]},
+            ]
+            payload = b"".join(b"data: " + json.dumps(chunk).encode() + b"\n\n" for chunk in chunks) + b"data: [DONE]\n\n"
+            content_type = "text/event-stream"
+        else:
+            payload = json.dumps(body).encode()
+            content_type = "application/json"
+        self.send_response(200)
+        self.send_header("content-type", content_type)
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="utf-8") as handle:
+    handle.write(str(server.server_port))
+server.serve_forever()
+PY
+SERVER_PID=$!
+
+for _ in $(seq 1 400); do
+  [ -s "$PORT_FILE" ] && break
+  sleep 0.05
+done
+[ -s "$PORT_FILE" ] || { echo "FAIL: fixture provider did not start"; exit 1; }
+PORT="$(cat "$PORT_FILE")"
+
+python3 - "$SITE/opencode.json" "$WORKSPACE" "$PORT" <<'PY'
+import json, sys
+path, workspace, port = sys.argv[1:]
+json.dump({
+    "$schema": "https://opencode.ai/config.json",
+    "model": "fixture/test",
+    "provider": {"fixture": {
+        "npm": "@ai-sdk/openai-compatible",
+        "name": "Fixture",
+        "options": {"baseURL": f"http://127.0.0.1:{port}/v1", "apiKey": "fixture"},
+        "models": {"test": {"name": "Fixture"}},
+    }},
+    "permission": {
+        "external_directory": {f"{workspace}/**": "allow"},
+        "edit": {"wp-content/plugins/**": "deny"},
+    },
+}, open(path, "w"), indent=2)
+PY
+
+python3 - "$TMP/graph.json" "$TMP/SOUL.md" <<'PY'
+import json, sys
+path, soul = sys.argv[1:]
+json.dump({
+    "success": True,
+    "coordinator": "coordinator",
+    "nodes": [{
+        "slug": "coordinator", "description": "Routes work", "subagents": [], "model": "",
+        "sources": {"instructions": {"SOUL.md": soul}, "skills": {}, "references": {}},
+        "tool_policy": {"default": "deny", "allow": []}, "skill_policy": {"paths": []},
+    }],
+}, open(path, "w"))
+PY
+
+SITE_PATH="$SITE"
+source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/lib/opencode-subagents.sh"
+warn() { printf '%s\n' "$*" >&2; }
+opencode_general_dispatch_supported
+python3 "$SCRIPT_DIR/lib/project-opencode-subagents.py" "$TMP/graph.json" "$SITE"
+
+python3 - "$SITE/opencode.json" "$WORKSPACE" <<'PY'
+import json, sys
+config = json.load(open(sys.argv[1]))
+assert config["permission"]["task"] == {"*": "deny", "general": "allow"}
+assert config["permission"]["external_directory"] == {f"{sys.argv[2]}/**": "allow"}
+assert config["permission"]["edit"] == {"wp-content/plugins/**": "deny"}
+PY
+
+(cd "$SITE" && opencode agent list --pure) > "$TMP/agents.txt"
+python3 - "$TMP/agents.txt" "$WORKSPACE" <<'PY'
+import re, sys
+text, workspace = open(sys.argv[1]).read(), sys.argv[2]
+parts = re.split(r'^(\w+) \((?:primary|subagent)\)\n', text, flags=re.M)
+sections = dict(zip(parts[1::2], parts[2::2]))
+assert "build" in sections and "general" in sections, text
+build, general = sections["build"], sections["general"]
+assert '"permission": "task"' in build and '"pattern": "general"' in build and '"action": "allow"' in build
+assert workspace in general and 'wp-content/plugins/**' in general
+PY
+
+python3 - "$SITE" "$OUTPUT_FILE" <<'PY'
+import os, pathlib, subprocess, sys
+site, output = sys.argv[1:]
+try:
+    result = subprocess.run(
+        ["opencode", "run", "--pure", "--dir", site, "--format", "json", "--model", "fixture/test", "--agent", "build",
+         "Dispatch both independent fixture tasks concurrently with the task tool."],
+        cwd=site, text=True, capture_output=True, timeout=45,
+    )
+except subprocess.TimeoutExpired as error:
+    sys.stderr.write((error.stderr or b"").decode() if isinstance(error.stderr, bytes) else (error.stderr or ""))
+    sys.stderr.write((error.stdout or b"").decode() if isinstance(error.stdout, bytes) else (error.stdout or ""))
+    raise
+open(output, "w", encoding="utf-8").write(result.stdout)
+if result.returncode:
+    sys.stderr.write(f"opencode run exited {result.returncode}\n")
+    sys.stderr.write(result.stderr)
+    sys.stderr.write(result.stdout)
+    for path in pathlib.Path(os.environ["XDG_DATA_HOME"]).glob("**/*.log"):
+        sys.stderr.write(f"\n== {path} ==\n{path.read_text(errors='replace')}")
+    raise SystemExit(result.returncode)
+PY
+
+[ -f "$STATE_FILE" ] || { printf '%s\n' 'FAIL: fixture provider received no child requests'; cat "$OUTPUT_FILE"; exit 1; }
+python3 - "$STATE_FILE" "$OUTPUT_FILE" <<'PY'
+import json, re, sys
+state = json.load(open(sys.argv[1]))
+assert state == {"children": ["ALPHA_ONLY", "BETA_ONLY"], "concurrent": True, "explicit_directory": True}, state
+strings = []
+tasks = []
+def collect(value):
+    if isinstance(value, str): strings.append(value)
+    elif isinstance(value, list):
+        for item in value: collect(item)
+    elif isinstance(value, dict):
+        for item in value.values(): collect(item)
+for line in open(sys.argv[2]):
+    event = json.loads(line)
+    collect(event)
+    part = event.get("part", {})
+    if event.get("type") == "tool_use" and part.get("tool") == "task":
+        tasks.append(part)
+text = "\n".join(strings)
+sessions = re.findall(r'<task id="([^"]+)" state="completed">', text)
+assert len(set(sessions)) == 2, text
+assert len(tasks) == 2 and all(task["state"]["status"] == "completed" for task in tasks), tasks
+metadata = [task["state"]["metadata"] for task in tasks]
+assert {item["sessionId"] for item in metadata} == set(sessions), metadata
+assert all(item["model"] == {"providerID": "fixture", "modelID": "test"} for item in metadata), metadata
+assert "ALPHA_ONLY" in text and "BETA_ONLY" in text and "PARENT_COMPLETE" in text
+PY
+
+printf '%s\n' 'opencode-general-dispatch: two native general tasks completed concurrently with distinct sessions'

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -17,6 +17,7 @@ source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/opencode-subagents.sh"
 log() { :; }
 warn() { printf '%s\n' "$*" >&2; }
+opencode_general_dispatch_supported() { return 0; }
 
 FAILED=0
 assert() { if "$@"; then printf '  ok   %s\n' "$*"; else printf '  FAIL %s\n' "$*"; FAILED=$((FAILED + 1)); fi; }
@@ -101,7 +102,7 @@ import sys
 assert open(sys.argv[1], 'rb').read() == open(sys.argv[2], 'rb').read()
 assert open(sys.argv[3], 'rb').read() == open(sys.argv[4], 'rb').read()
 PY
-assert_python 'manifest records only managed files and task is limited to direct children' "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json" "$SITE_PATH/opencode.json" <<'PY'
+assert_python 'manifest records only managed files and task is limited to native general and direct children' "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json" "$SITE_PATH/opencode.json" <<'PY'
 import json, sys
 manifest = json.load(open(sys.argv[1]))
 assert manifest['agents'] == ['agents/researcher.md', 'agents/reviewer.md', 'agents/writer.md']
@@ -110,7 +111,7 @@ assert 'skills/editorial/references/context.bin' in manifest['artifacts']
 config = json.load(open(sys.argv[2]))
 assert config['model'] == 'preserve' and config['mcp'] == {}
 assert config['permission']['read'] == 'allow'
-assert config['permission']['task'] == {'*': 'deny', 'researcher': 'allow', 'reviewer': 'allow', 'writer': 'allow'}
+assert config['permission']['task'] == {'*': 'deny', 'general': 'allow', 'researcher': 'allow', 'reviewer': 'allow', 'writer': 'allow'}
 assert config['permission']['skill']['root-skill'] == 'allow'
 assert config['permission']['skill']['user-skill'] == 'ask'
 assert open(sys.argv[1].replace('.wp-coding-agents-subagents.json', 'skills/root-skill/SKILL.md'), 'rb').read().startswith(b'---\nname: root-skill\n')
@@ -252,5 +253,65 @@ json.dump(data, open(p, 'w'))
 PY
 if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
 printf '%s\n' '  ok   graph-wide duplicate skill name is rejected'
+
+write_graph
+python3 - "$TMP/graph.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+data['nodes'][1]['slug'] = 'general'
+data['nodes'][0]['subagents'][0] = 'general'
+json.dump(data, open(p, 'w'))
+PY
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+printf '%s\n' '  ok   graph children cannot shadow the native general subagent'
+
+echo '==> unsupported OpenCode versions report the dispatch capability boundary'
+mkdir -p "$TMP/unsupported-bin"
+cat > "$TMP/unsupported-bin/opencode" <<'SH'
+#!/bin/bash
+case "${1:-}" in
+  --version) printf '%s\n' '1.18.19' ;;
+  agent) printf '%s\n' 'general (subagent)' ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$TMP/unsupported-bin/opencode"
+capability_output="$(
+  exec 2>&1
+  PATH="$TMP/unsupported-bin:$PATH"
+  source "$SCRIPT_DIR/lib/opencode-subagents.sh"
+  if opencode_general_dispatch_supported; then exit 1; fi
+)" || FAILED=$((FAILED + 1))
+case "$capability_output" in
+  *"OpenCode 1.18.19 does not provide the managed general-subagent dispatch contract; install OpenCode >= 1.18.20"*)
+    printf '%s\n' '  ok   unsupported runtime receives an actionable minimum-version diagnostic'
+    ;;
+  *)
+    printf '%s\n' '  FAIL unsupported runtime diagnostic was not actionable'
+    FAILED=$((FAILED + 1))
+    ;;
+esac
+
+mkdir -p "$TMP/development-bin"
+cat > "$TMP/development-bin/opencode" <<'SH'
+#!/bin/bash
+case "${1:-}" in
+  --version) printf '%s\n' '0.0.0-fix/native-task-development-build' ;;
+  agent) printf '%s\n' 'general (subagent)' ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$TMP/development-bin/opencode"
+if (
+  PATH="$TMP/development-bin:$PATH"
+  source "$SCRIPT_DIR/lib/opencode-subagents.sh"
+  opencode_general_dispatch_supported
+); then
+  printf '%s\n' '  ok   capable development runtime is accepted by its advertised agent surface'
+else
+  printf '%s\n' '  FAIL capable development runtime was rejected by release-only version parsing'
+  FAILED=$((FAILED + 1))
+fi
 
 [ "$FAILED" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #453.

## Summary
- allow the native `general` subagent through managed coordinator task policy
- enforce the supported release floor while accepting capability-advertising development builds
- preserve workspace and installed-source restrictions in delegated sessions
- add a live OpenCode fixture proving two concurrent tasks complete with distinct resumable session IDs

## Verification
- `bash tests/opencode-subagents.sh`
- `bash tests/external-wordpress-runtime.sh`
- `bash tests/opencode-general-dispatch.sh` with the managed development build
- `PATH=/tmp/opencode-1.18.20/node_modules/.bin:$PATH bash tests/opencode-general-dispatch.sh` with OpenCode 1.18.20
- `bash tests/ci-coverage.sh`
- related projection and syntax suites

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode audited the interrupted candidate, diagnosed and corrected the live fixture parser and development-build capability gate, ran the verification suites, and prepared this PR under Chris Huber's direction.