### PR TITLE
Bound plugin-only upgrade phases

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -261,6 +261,7 @@ jobs:
           - path-helpers
           - post-upgrade-restore
           - plugins-only-scope
+          - plugin-upgrade-bounds
           - runtime-signature
           - upgrade-opencode-auth-plugin-sync
           - worktree-context-projections

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -71,23 +71,36 @@ upgrade_data_machine_plugins() {
   fi
 
   log "Phase 2: Updating Data Machine plugins to latest tagged releases..."
-  update_plugin_to_latest_tag data-machine https://github.com/Extra-Chill/data-machine.git
+  local status=0
+  if [ "${PLUGINS_ONLY:-false}" = true ] && [ ! -d "$SITE_PATH/wp-content/plugins/data-machine" ]; then
+    log "[data-machine] terminal=skipped reason=not-installed"
+  else
+    plugin_update_execute data-machine update_plugin_to_latest_tag data-machine https://github.com/Extra-Chill/data-machine.git || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+  fi
 
-  # Managed installs deliberately have no DMC. Without this gate every upgrade
-  # silently reinstalls and reactivates it, because update_plugin_to_latest_tag
-  # activates — which is exactly why hand-deactivating DMC never stuck.
-  if source_policy_workspace_enabled; then
-    local dmc_plugin_dir="$SITE_PATH/wp-content/plugins/data-machine-code"
-    if [ -d "$dmc_plugin_dir/.git" ] || [ ! -d "$dmc_plugin_dir" ]; then
-      # Preserve setup's git-checkout contract, including first installation.
-      update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+  local dmc_plugin_dir="$SITE_PATH/wp-content/plugins/data-machine-code"
+  if [ "${PLUGINS_ONLY:-false}" = true ]; then
+    if [ -d "$dmc_plugin_dir" ]; then
+      if [ -d "$dmc_plugin_dir/.git" ]; then
+        plugin_update_execute data-machine-code update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+      else
+        plugin_update_execute data-machine-code update_data_machine_code_copied_release || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+      fi
     else
-      update_data_machine_code_copied_release
+      log "[data-machine-code] terminal=skipped reason=not-installed"
+    fi
+  # Managed installs deliberately have no DMC. Without this gate every full
+  # upgrade would silently reinstall it after an operator removed it.
+  elif source_policy_workspace_enabled; then
+    if [ -d "$dmc_plugin_dir/.git" ] || [ ! -d "$dmc_plugin_dir" ]; then
+      plugin_update_execute data-machine-code update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+    else
+      plugin_update_execute data-machine-code update_data_machine_code_copied_release || status=$PLUGIN_UPDATE_EXIT_PARTIAL
     fi
   else
     log "  Skipping Data Machine Code (source mode: ${SOURCE_MODE:-owned})"
   fi
-
+  return "$status"
 }
 
 # Derive a Data Machine agent slug from a site domain. Shared by setup

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -195,6 +195,41 @@ detect_environment() {
   fi
 }
 
+# Plugin-only upgrades need only a validated site path and the WP-CLI transport.
+# In particular, do not start Studio just to discover a domain or multisite
+# state; the first bounded per-plugin wordpress-state phase owns that process.
+detect_plugins_only_environment() {
+  PLATFORM="linux"
+  case "$(uname -s)" in
+    Darwin) PLATFORM="mac"; OS="macos"; LOCAL_MODE=true; RUN_AS_ROOT=false ;;
+    Linux) OS="linux" ;;
+    *) error "Unsupported OS: $(uname -s)" ;;
+  esac
+
+  SITE_PATH="$EXISTING_WP"
+  if [ "${DRY_RUN:-false}" != true ]; then
+    [ -f "$SITE_PATH/wp-config.php" ] || [ -f "$SITE_PATH/wp-load.php" ] || \
+      error "No WordPress found at $SITE_PATH (missing wp-config.php and wp-load.php)"
+    SITE_PATH="$(cd "$SITE_PATH" 2>/dev/null && pwd || printf '%s' "$SITE_PATH")"
+  fi
+  WP_ROOT_FLAG=""
+  if [ "$LOCAL_MODE" != true ]; then
+    WP_ROOT_FLAG="--allow-root"
+  fi
+  WP_CMD="${WP_CMD:-wp}"
+  IS_STUDIO=false
+  if command -v studio >/dev/null 2>&1 && [ -f "$SITE_PATH/STUDIO.md" ]; then
+    IS_STUDIO=true
+    WP_CMD="studio wp"
+    log "Detected WordPress Studio environment (deferred bounded WP startup)"
+  fi
+  SITE_DOMAIN="${SITE_DOMAIN:-$(basename "$SITE_PATH")}"
+  SERVICE_USER="${USER:-$(id -un)}"
+  SERVICE_HOME="${HOME:-}"
+  log "Plugin-only site: $SITE_PATH"
+  log "Plugin-only scope: installed Data Machine plugins only; runtime, bridge, workspace, and service synchronization disabled"
+}
+
 # Derive SERVICE_USER / SERVICE_HOME / KIMAKI_DATA_DIR / DM_WORKSPACE_DIR from
 # LOCAL_MODE and RUN_AS_ROOT.
 #

--- a/lib/dmc-managed-release.sh
+++ b/lib/dmc-managed-release.sh
@@ -4,6 +4,25 @@
 DMC_MANAGED_RELEASE_REPO="${DMC_MANAGED_RELEASE_REPO:-Extra-Chill/data-machine-code}"
 DMC_MANAGED_RELEASE_API="${DMC_MANAGED_RELEASE_API:-https://api.github.com/repos/${DMC_MANAGED_RELEASE_REPO}/releases/latest}"
 
+_dmc_managed_release_phase() {
+  local phase="$1"
+  shift
+  if declare -F plugin_update_run_phase >/dev/null 2>&1 && [ "${PLUGIN_UPDATE_ACTIVE:-false}" = true ]; then
+    plugin_update_run_phase data-machine-code "$phase" "$@"
+  else
+    PLUGIN_PHASE_OUTPUT="$("$@")"
+  fi
+}
+
+_dmc_managed_release_abort() {
+  local message="$1" status="${2:-1}"
+  warn "$message"
+  if [ "${PLUGIN_UPDATE_ACTIVE:-false}" = true ]; then
+    return "$status"
+  fi
+  return 0
+}
+
 dmc_managed_release_plugin_dir() {
   printf '%s/wp-content/plugins/data-machine-code' "$SITE_PATH"
 }
@@ -65,6 +84,10 @@ if not isinstance(checksum_url, str) or not re.fullmatch(r'https://[^\t\r\n]+', 
     raise SystemExit('release checksum download URL is invalid')
 print('\t'.join((version, archive_url, name, 'checksum_sidecar', checksum_url)))
 PY
+}
+
+dmc_managed_release_resolve_environment() {
+  dmc_managed_release_resolve "${DMC_RELEASE_JSON:-}"
 }
 
 dmc_managed_release_expected_sha256() {
@@ -170,21 +193,34 @@ update_data_machine_code_copied_release() {
   [ -d "$plugin_dir" ] || return 0
   [ ! -d "$plugin_dir/.git" ] || return 0
 
-  local current release tuple target archive_url archive_name evidence_type evidence extra
+  local current release tuple target archive_url archive_name evidence_type evidence extra phase_status
   current="$(dmc_managed_release_header_version "$plugin_dir" 2>/dev/null || true)"
-  if ! release="$(curl -fsSL "$DMC_MANAGED_RELEASE_API")" || ! tuple="$(dmc_managed_release_resolve "$release")"; then
-    warn "Could not resolve the official Data Machine Code release — copied install unchanged"
-    return 0
+  if _dmc_managed_release_phase release-discovery curl -fsSL "$DMC_MANAGED_RELEASE_API"; then
+    release="$PLUGIN_PHASE_OUTPUT"
+  else
+    phase_status=$?
+    _dmc_managed_release_abort "Could not resolve the official Data Machine Code release — copied install unchanged" "$phase_status"
+    return $?
   fi
+  DMC_RELEASE_JSON="$release"; export DMC_RELEASE_JSON
+  if _dmc_managed_release_phase release-resolution dmc_managed_release_resolve_environment; then
+    tuple="$PLUGIN_PHASE_OUTPUT"
+  else
+    phase_status=$?
+    unset DMC_RELEASE_JSON
+    _dmc_managed_release_abort "Could not resolve the official Data Machine Code release — copied install unchanged" "$phase_status"
+    return $?
+  fi
+  unset DMC_RELEASE_JSON
   IFS=$'\t' read -r target archive_url archive_name evidence_type evidence extra <<< "$tuple"
   if [ -n "$extra" ] || [ -z "$target" ] || [ -z "$archive_url" ] || [ -z "$archive_name" ] || [ -z "$evidence_type" ] || [ -z "$evidence" ]; then
-    warn "Could not resolve the official Data Machine Code release — copied install unchanged"
-    return 0
+    _dmc_managed_release_abort "Could not resolve the official Data Machine Code release — copied install unchanged"
+    return $?
   fi
 
   if [ "$current" = "$target" ] && dmc_managed_release_pointer_matches "$plugin_dir" "$target" "$evidence_type" "$evidence"; then
     if [ "${DRY_RUN:-false}" != true ]; then
-      dmc_managed_release_recover "$plugin_dir" || { warn "Could not recover interrupted Data Machine Code release update"; return 0; }
+      dmc_managed_release_recover "$plugin_dir" || { _dmc_managed_release_abort "Could not recover interrupted Data Machine Code release update"; return $?; }
     fi
     log "Data Machine Code copied install already at official release $target"
     return 0
@@ -197,19 +233,11 @@ update_data_machine_code_copied_release() {
         echo -e "${BLUE}[dry-run]${NC} Recover Data Machine Code $target from its verified staged release"
         return 0
       fi
-      local was_active=false
-      dmc_managed_release_active && was_active=true
       if ! dmc_managed_release_switch_pointer "$plugin_dir" "$staged_release"; then
-        warn "Could not recover interrupted Data Machine Code release pointer"
-        return 0
+        _dmc_managed_release_abort "Could not recover interrupted Data Machine Code release pointer"
+        return $?
       fi
-      if [ "$was_active" = true ] && { ! activate_plugin data-machine-code || ! dmc_managed_release_active; }; then
-        rm -f "$plugin_dir/.wp-coding-agents-release-current"
-        dmc_managed_release_recover "$plugin_dir" || true
-        warn "Data Machine Code $target recovery activation verification failed — prior release restored"
-        return 0
-      fi
-      fix_ownership "$plugin_dir"
+      _dmc_managed_release_phase ownership-normalization fix_ownership "$plugin_dir" || return $?
       UPDATED_ITEMS+=("data-machine-code $target (recovered official copied release)")
       log "Recovered Data Machine Code $target release pointer from its verified staged release"
       return 0
@@ -225,99 +253,110 @@ update_data_machine_code_copied_release() {
     return 0
   fi
 
-  local staging archive checksum expected actual extracted candidate staged releases release_dir legacy_dir legacy_name next current previous loader_tmp was_active
-  staging="$(mktemp -d)" || { warn "Could not create Data Machine Code release staging directory"; return 0; }
+  local staging archive checksum expected actual extracted candidate staged releases release_dir legacy_dir legacy_name current loader_tmp
+  staging="$(mktemp -d)" || { _dmc_managed_release_abort "Could not create Data Machine Code release staging directory"; return $?; }
   trap 'rm -rf "$staging"' RETURN
   archive="$staging/release.zip"
-  if ! curl -fsSL "$archive_url" -o "$archive"; then
-    warn "Could not download official Data Machine Code release $target — copied install unchanged"
-    return 0
+  if _dmc_managed_release_phase archive-download curl -fsSL "$archive_url" -o "$archive"; then
+    :
+  else
+    phase_status=$?
+    _dmc_managed_release_abort "Could not download official Data Machine Code release $target — copied install unchanged" "$phase_status"
+    return $?
   fi
   if [ "$evidence_type" = github_digest ]; then
     expected="$evidence"
   else
     checksum="$staging/release.sha256"
-    if ! curl -fsSL "$evidence" -o "$checksum"; then
-      warn "Could not download official Data Machine Code release $target — copied install unchanged"
-      return 0
+    if _dmc_managed_release_phase checksum-download curl -fsSL "$evidence" -o "$checksum"; then
+      :
+    else
+      phase_status=$?
+      _dmc_managed_release_abort "Could not download official Data Machine Code release $target — copied install unchanged" "$phase_status"
+      return $?
     fi
     expected="$(dmc_managed_release_expected_sha256 "$checksum" "$archive_name")"
   fi
-  actual="$(dmc_managed_release_sha256 "$archive")"
-  if ! [[ "$expected" =~ ^[a-f0-9]{64}$ ]] || [ "$actual" != "$expected" ]; then
-    warn "Official Data Machine Code release $target failed published SHA-256 verification — copied install unchanged"
-    return 0
+  if _dmc_managed_release_phase archive-sha256 dmc_managed_release_sha256 "$archive"; then
+    actual="$PLUGIN_PHASE_OUTPUT"
+  else
+    phase_status=$?
+    _dmc_managed_release_abort "Could not hash official Data Machine Code release $target — copied install unchanged" "$phase_status"
+    return $?
   fi
-  dmc_managed_release_recover "$plugin_dir" || { warn "Could not recover interrupted Data Machine Code release update"; return 0; }
+  if ! [[ "$expected" =~ ^[a-f0-9]{64}$ ]] || [ "$actual" != "$expected" ]; then
+    _dmc_managed_release_abort "Official Data Machine Code release $target failed published SHA-256 verification — copied install unchanged"
+    return $?
+  fi
+  dmc_managed_release_recover "$plugin_dir" || { _dmc_managed_release_abort "Could not recover interrupted Data Machine Code release update"; return $?; }
   extracted="$staging/extracted"
   mkdir -p "$extracted"
-  if ! unzip -q "$archive" -d "$extracted"; then
-    warn "Could not extract verified Data Machine Code release $target — copied install unchanged"
-    return 0
+  if _dmc_managed_release_phase archive-extraction unzip -q "$archive" -d "$extracted"; then
+    :
+  else
+    phase_status=$?
+    _dmc_managed_release_abort "Could not extract verified Data Machine Code release $target — copied install unchanged" "$phase_status"
+    return $?
   fi
   candidate="$extracted"
   [ -f "$candidate/data-machine-code.php" ] || candidate="$(dirname "$(command find "$extracted" -mindepth 2 -maxdepth 2 -name data-machine-code.php -print -quit)")"
   if [ ! -f "$candidate/data-machine-code.php" ] || [ "$(dmc_managed_release_header_version "$candidate" 2>/dev/null || true)" != "$target" ]; then
-    warn "Verified Data Machine Code release $target has no matching plugin entrypoint — copied install unchanged"
-    return 0
+    _dmc_managed_release_abort "Verified Data Machine Code release $target has no matching plugin entrypoint — copied install unchanged"
+    return $?
   fi
   releases="$(dmc_managed_release_release_root)"
   current="$plugin_dir/.wp-coding-agents-release-current"
-  previous="$plugin_dir/.wp-coding-agents-release-previous"
   # First conversion keeps a complete copy of the running copied deployment
   # behind current before replacing its entrypoint with the stable loader.
   # The release directory is excluded so copying into a child never recurses.
   if [ ! -e "$current/data-machine-code.php" ]; then
     legacy_dir="$staging/legacy"
     legacy_name="legacy-${TIMESTAMP:-$(date +%s)}"
-    if ! rsync -a --exclude='.wp-coding-agents-releases' --exclude='.wp-coding-agents-release-current' --exclude='.wp-coding-agents-release-previous' --exclude='.wp-coding-agents-release-next' "$plugin_dir/" "$legacy_dir/"; then
-      warn "Could not preserve the current Data Machine Code release before deployment"
-      return 0
+    if _dmc_managed_release_phase current-release-preservation rsync -a --exclude='.wp-coding-agents-releases' --exclude='.wp-coding-agents-release-current' --exclude='.wp-coding-agents-release-previous' --exclude='.wp-coding-agents-release-next' "$plugin_dir/" "$legacy_dir/"; then
+      :
+    else
+      phase_status=$?
+      _dmc_managed_release_abort "Could not preserve the current Data Machine Code release before deployment" "$phase_status"
+      return $?
     fi
     mkdir -p "$releases"
     if ! mv "$legacy_dir" "$releases/$legacy_name" || ! ln -s ".wp-coding-agents-releases/$legacy_name" "$current"; then
-      warn "Could not prepare Data Machine Code interruption recovery"
-      return 0
+      _dmc_managed_release_abort "Could not prepare Data Machine Code interruption recovery"
+      return $?
     fi
   fi
   release_dir="$releases/$target-$actual"
   mkdir -p "$releases"
   if [ ! -d "$release_dir" ]; then
     staged="$releases/.staging-$target-${TIMESTAMP:-$(date +%s)}"
-    cp -a "$candidate" "$staged"
+    if _dmc_managed_release_phase release-staging cp -a "$candidate" "$staged"; then
+      :
+    else
+      phase_status=$?
+      _dmc_managed_release_abort "Could not stage Data Machine Code $target — copied install unchanged" "$phase_status"
+      return $?
+    fi
     printf '{"repository":"%s","version":"%s","sha256":"%s","archive_url":"%s"}\n' "$DMC_MANAGED_RELEASE_REPO" "$target" "$actual" "$archive_url" > "$staged/.wp-coding-agents-managed-release.json"
-    mv "$staged" "$release_dir" || { warn "Could not stage Data Machine Code $target — copied install unchanged"; return 0; }
+    mv "$staged" "$release_dir" || { _dmc_managed_release_abort "Could not stage Data Machine Code $target — copied install unchanged"; return $?; }
   fi
-  next="$plugin_dir/.wp-coding-agents-release-next"
-  ln -s ".wp-coding-agents-releases/$(basename "$release_dir")" "$next" || { warn "Could not prepare Data Machine Code $target release pointer"; return 0; }
   # Keep activation state exactly as found. Inactive plugins are deployable but
   # must not become active as a side effect of an updater run.
-  was_active=false
-  dmc_managed_release_active && was_active=true
   loader_tmp="$plugin_dir/.wp-coding-agents-loader-${TIMESTAMP:-$(date +%s)}.php"
   dmc_managed_release_loader "$target" > "$loader_tmp"
-  mv "$loader_tmp" "$plugin_dir/data-machine-code.php" || { rm -f "$next"; warn "Could not install Data Machine Code release loader"; return 0; }
+  mv "$loader_tmp" "$plugin_dir/data-machine-code.php" || { _dmc_managed_release_abort "Could not install Data Machine Code release loader"; return $?; }
   # There is always a loader-visible target: before current is replaced it sees
   # current; between the two renames it falls back to previous; afterward it
   # sees the new current. A later invocation restores previous -> current.
-  [ ! -e "$current" ] || mv "$current" "$previous"
-  if ! mv "$next" "$current"; then
-    dmc_managed_release_recover "$plugin_dir" || true
-    warn "Could not switch Data Machine Code $target release pointer — prior release retained"
-    return 0
-  fi
-  if [ "$was_active" = true ] && { ! activate_plugin data-machine-code || ! dmc_managed_release_active; }; then
-    rm -f "$current"
-    dmc_managed_release_recover "$plugin_dir" || true
-    warn "Data Machine Code $target activation verification failed — prior release restored"
-    return 0
+  if ! dmc_managed_release_switch_pointer "$plugin_dir" "$release_dir"; then
+    _dmc_managed_release_abort "Could not switch Data Machine Code $target release pointer — prior release retained"
+    return $?
   fi
   if [ "$(dmc_managed_release_header_version "$plugin_dir" 2>/dev/null || true)" != "$target" ] || ! grep -Fq "\"sha256\":\"$actual\"" "$(dmc_managed_release_provenance_file)"; then
     rm -f "$current"
     dmc_managed_release_recover "$plugin_dir" || true
-    warn "Data Machine Code $target version/provenance verification failed — prior release restored"
-    return 0
+    _dmc_managed_release_abort "Data Machine Code $target version/provenance verification failed — prior release restored"
+    return $?
   fi
-  fix_ownership "$plugin_dir"
+  _dmc_managed_release_phase ownership-normalization fix_ownership "$plugin_dir" || return $?
   UPDATED_ITEMS+=("data-machine-code $target (official copied release)")
 }

--- a/lib/plugin-upgrade.sh
+++ b/lib/plugin-upgrade.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+# Bounded, observable execution for setup-installed plugin upgrades.
+
+PLUGIN_UPDATE_EXIT_PARTIAL=75
+PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS="${PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS:-120}"
+PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS="${PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS:-480}"
+PLUGIN_UPDATE_PROGRESS_SECONDS="${PLUGIN_UPDATE_PROGRESS_SECONDS:-10}"
+PLUGIN_UPDATE_KILL_GRACE_SECONDS="${PLUGIN_UPDATE_KILL_GRACE_SECONDS:-2}"
+
+plugin_update_positive_integer() {
+  case "${1:-}" in
+    ''|*[!0-9]*|0) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+plugin_update_initialize() {
+  plugin_update_positive_integer "$PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS" || PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS=120
+  plugin_update_positive_integer "$PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS" || PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS=480
+  plugin_update_positive_integer "$PLUGIN_UPDATE_PROGRESS_SECONDS" || PLUGIN_UPDATE_PROGRESS_SECONDS=10
+  plugin_update_positive_integer "$PLUGIN_UPDATE_KILL_GRACE_SECONDS" || PLUGIN_UPDATE_KILL_GRACE_SECONDS=2
+  PLUGIN_UPDATE_STARTED_AT="${PLUGIN_UPDATE_STARTED_AT:-$(date +%s)}"
+  declare -p PLUGIN_UPDATE_FAILURES >/dev/null 2>&1 || PLUGIN_UPDATE_FAILURES=()
+  declare -p PLUGIN_UPDATE_POINTER_EVIDENCE >/dev/null 2>&1 || PLUGIN_UPDATE_POINTER_EVIDENCE=()
+}
+
+plugin_update_resume_command() {
+  local script="${SCRIPT_DIR:-.}/upgrade.sh" path="${SITE_PATH:-}"
+  printf '%q --plugins-only --wp-path %q' "$script" "$path"
+}
+
+plugin_update_command_string() {
+  local arg rendered=""
+  for arg in "$@"; do
+    printf -v arg '%q' "$arg"
+    rendered="${rendered}${rendered:+ }$arg"
+  done
+  printf '%s' "$rendered"
+}
+
+plugin_update_remaining_seconds() {
+  local now elapsed remaining
+  now="$(date +%s)"
+  elapsed=$((now - PLUGIN_UPDATE_STARTED_AT))
+  remaining=$((PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS - elapsed))
+  [ "$remaining" -gt 0 ] || remaining=0
+  printf '%s' "$remaining"
+}
+
+# Run one child command in its own process group. On timeout, only the process
+# group created here is signalled; the evidence names the exact root command.
+plugin_update_run_phase() {
+  local slug="$1" phase="$2"
+  shift 2
+  local remaining timeout command temp_dir stdout_file stderr_file pid pgid
+  local started now elapsed next_progress status restore_monitor=false
+
+  plugin_update_initialize
+  remaining="$(plugin_update_remaining_seconds)"
+  if [ "$remaining" -eq 0 ]; then
+    warn "[$slug] phase=$phase terminal=total-timeout elapsed=${PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS}s"
+    warn "[$slug] resume: $(plugin_update_resume_command)"
+    PLUGIN_PHASE_OUTPUT=""
+    return 124
+  fi
+  timeout="$PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS"
+  [ "$remaining" -ge "$timeout" ] || timeout="$remaining"
+  command="$(plugin_update_command_string "$@")"
+  temp_dir="$(mktemp -d)" || return 1
+  stdout_file="$temp_dir/stdout"
+  stderr_file="$temp_dir/stderr"
+
+  log "[$slug] phase=$phase start timeout=${timeout}s command=$command"
+  case "$-" in
+    *m*) ;;
+    *) set -m; restore_monitor=true ;;
+  esac
+  ( "$@" ) >"$stdout_file" 2>"$stderr_file" &
+  pid=$!
+  [ "$restore_monitor" = false ] || set +m
+  pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d '[:space:]')"
+  started="$(date +%s)"
+  next_progress="$PLUGIN_UPDATE_PROGRESS_SECONDS"
+
+  while kill -0 "$pid" 2>/dev/null; do
+    now="$(date +%s)"
+    elapsed=$((now - started))
+    if [ "$elapsed" -ge "$timeout" ]; then
+      warn "[$slug] phase=$phase terminal=timeout elapsed=${elapsed}s child_pid=$pid child_pgid=${pgid:-unknown} command=$command"
+      local child
+      child="$(ps -ax -o pid=,ppid=,pgid=,etime=,state=,command= 2>/dev/null | awk -v group="${pgid:-$pid}" '$3 == group')"
+      [ -z "$child" ] || warn "[$slug] timed-out-child: $child"
+      if [ -n "$pgid" ] && [ "$pgid" = "$pid" ]; then
+        kill -TERM -- "-$pgid" 2>/dev/null || true
+      else
+        kill -TERM "$pid" 2>/dev/null || true
+      fi
+      sleep "$PLUGIN_UPDATE_KILL_GRACE_SECONDS"
+      if kill -0 "$pid" 2>/dev/null; then
+        if [ -n "$pgid" ] && [ "$pgid" = "$pid" ]; then
+          kill -KILL -- "-$pgid" 2>/dev/null || true
+        else
+          kill -KILL "$pid" 2>/dev/null || true
+        fi
+      fi
+      wait "$pid" 2>/dev/null || true
+      [ ! -s "$stderr_file" ] || while IFS= read -r line; do warn "[$slug] child-stderr: $line"; done < "$stderr_file"
+      PLUGIN_PHASE_OUTPUT=""
+      warn "[$slug] resume: $(plugin_update_resume_command)"
+      rm -rf "$temp_dir"
+      return 124
+    fi
+    if [ "$elapsed" -ge "$next_progress" ]; then
+      log "[$slug] phase=$phase progress elapsed=${elapsed}s child_pid=$pid child_pgid=${pgid:-unknown}"
+      next_progress=$((next_progress + PLUGIN_UPDATE_PROGRESS_SECONDS))
+    fi
+    sleep 1
+  done
+
+  if wait "$pid"; then status=0; else status=$?; fi
+  now="$(date +%s)"
+  elapsed=$((now - started))
+  PLUGIN_PHASE_OUTPUT="$(cat "$stdout_file")"
+  if [ "$status" -ne 0 ]; then
+    [ ! -s "$stderr_file" ] || while IFS= read -r line; do warn "[$slug] child-stderr: $line"; done < "$stderr_file"
+    warn "[$slug] phase=$phase terminal=failed status=$status elapsed=${elapsed}s command=$command"
+    warn "[$slug] resume: $(plugin_update_resume_command)"
+  else
+    log "[$slug] phase=$phase terminal=complete elapsed=${elapsed}s"
+  fi
+  rm -rf "$temp_dir"
+  return "$status"
+}
+
+plugin_update_local_version() {
+  local slug="$1" file
+  case "$slug" in
+    data-machine) file="$SITE_PATH/wp-content/plugins/$slug/data-machine.php" ;;
+    data-machine-code) file="$SITE_PATH/wp-content/plugins/$slug/data-machine-code.php" ;;
+    wp-codebox) file="$SITE_PATH/wp-content/plugins/$slug/wp-codebox.php" ;;
+    *) return 1 ;;
+  esac
+  [ -f "$file" ] || return 1
+  grep -m1 -E '^[[:space:]]*\*?[[:space:]]*Version:' "$file" | sed -E 's/.*Version:[[:space:]]*([^[:space:]]+).*/\1/'
+}
+
+plugin_update_state_from_json() {
+  local json="$1" slug="$2"
+  PLUGIN_STATE_TUPLE="$(PLUGIN_STATES_JSON="$json" PLUGIN_STATE_SLUG="$slug" python3 <<'PY'
+import json
+import os
+
+slug = os.environ['PLUGIN_STATE_SLUG']
+for plugin in json.loads(os.environ['PLUGIN_STATES_JSON']):
+    if plugin.get('name') == slug:
+        print('%s\t%s' % (plugin.get('version', ''), plugin.get('status', '')))
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+)"
+}
+
+plugin_update_release_pointer() {
+  local slug="$1" plugin_dir="$SITE_PATH/wp-content/plugins/$1"
+  if [ "$slug" = data-machine-code ] && [ ! -d "$plugin_dir/.git" ]; then
+    readlink "$plugin_dir/.wp-coding-agents-release-current" 2>/dev/null || printf 'missing'
+  else
+    printf 'not-applicable'
+  fi
+}
+
+plugin_update_local_release_valid() {
+  local slug="$1" plugin_dir="$SITE_PATH/wp-content/plugins/$1"
+  [ "$slug" = data-machine-code ] || return 0
+  [ -d "$plugin_dir/.git" ] && return 0
+  local root_version pointer_version provenance
+  root_version="$(plugin_update_local_version "$slug" 2>/dev/null || true)"
+  pointer_version="$(grep -m1 -E '^[[:space:]]*\*?[[:space:]]*Version:' "$plugin_dir/.wp-coding-agents-release-current/data-machine-code.php" 2>/dev/null | sed -E 's/.*Version:[[:space:]]*([^[:space:]]+).*/\1/' || true)"
+  provenance="$plugin_dir/.wp-coding-agents-release-current/.wp-coding-agents-managed-release.json"
+  [ -n "$root_version" ] && [ "$pointer_version" = "$root_version" ] && [ -f "$provenance" ] && grep -Fq "\"version\":\"$root_version\"" "$provenance"
+}
+
+plugin_update_record_failure() {
+  local slug="$1" type="$2" status="$3"
+  PLUGIN_UPDATE_FAILURES+=("$slug type=$type status=$status")
+  PENDING_ITEMS+=("$slug plugin upgrade partial ($type; resume: $(plugin_update_resume_command))")
+}
+
+plugin_update_execute() {
+  local slug="$1"
+  shift
+  local plugin_dir="$SITE_PATH/wp-content/plugins/$slug"
+  local before_version="unknown" after_version="unknown"
+  local before_pointer after_pointer update_status=0
+
+  plugin_update_initialize
+  before_pointer="$(plugin_update_release_pointer "$slug")"
+  before_version="$(plugin_update_local_version "$slug" 2>/dev/null || printf unknown)"
+  log "[$slug] installed-before version=${before_version:-unknown} activation=preserved-without-database-mutation"
+
+  # Read by updater modules sourced into the same shell.
+  # shellcheck disable=SC2034
+  PLUGIN_UPDATE_ACTIVE=true
+  if "$@"; then update_status=0; else update_status=$?; fi
+  # shellcheck disable=SC2034
+  PLUGIN_UPDATE_ACTIVE=false
+
+  after_pointer="$(plugin_update_release_pointer "$slug")"
+  PLUGIN_UPDATE_POINTER_EVIDENCE+=("$slug changed=$( [ "$before_pointer" = "$after_pointer" ] && printf no || printf yes ) before=$before_pointer after=$after_pointer")
+  after_version="$(plugin_update_local_version "$slug" 2>/dev/null || printf unknown)"
+
+  if [ "$update_status" -ne 0 ]; then
+    plugin_update_record_failure "$slug" "$( [ "$update_status" -eq 124 ] && printf timeout || printf command-failure )" "$update_status"
+  fi
+
+  if [ "$update_status" -eq 0 ]; then
+    log "[$slug] apply-terminal=complete version=${after_version:-unknown} release_pointer_changed=$( [ "$before_pointer" = "$after_pointer" ] && printf no || printf yes )"
+    return 0
+  fi
+  warn "[$slug] apply-terminal=partial-failure update_status=$update_status release_pointer_changed=$( [ "$before_pointer" = "$after_pointer" ] && printf no || printf yes )"
+  return "$PLUGIN_UPDATE_EXIT_PARTIAL"
+}
+
+plugin_update_slug_failed() {
+  local slug="$1" failure
+  for failure in "${PLUGIN_UPDATE_FAILURES[@]:-}"; do
+    case "$failure" in "$slug "*) return 0 ;; esac
+  done
+  return 1
+}
+
+plugin_update_pointer_changed() {
+  local slug="$1" evidence
+  for evidence in "${PLUGIN_UPDATE_POINTER_EVIDENCE[@]:-}"; do
+    case "$evidence" in "$slug "*) case "$evidence" in *" changed=yes "*) printf yes ;; *) printf no ;; esac; return 0 ;; esac
+  done
+  printf no
+}
+
+plugin_update_verify_installed_plugins() {
+  local slugs=("$@") slug plugin_dir tuple version status file_version phase_status=0 failed=false
+  if [ "${DRY_RUN:-false}" = true ]; then
+    for slug in "${slugs[@]}"; do
+      [ -d "$SITE_PATH/wp-content/plugins/$slug" ] || continue
+      log "[$slug] terminal=dry-run version=$(plugin_update_local_version "$slug" 2>/dev/null || printf unknown) activation=unchanged"
+    done
+    return 0
+  fi
+
+  for slug in "${slugs[@]}"; do
+    [ -d "$SITE_PATH/wp-content/plugins/$slug" ] || continue
+    if plugin_update_local_release_valid "$slug"; then
+      [ "$slug" != data-machine-code ] || log "[$slug] release-pointer-verification=complete version=$(plugin_update_local_version "$slug") provenance=present"
+    else
+      plugin_update_record_failure "$slug" release-pointer-verification 1
+      warn "[$slug] release-pointer-verification=failed"
+      failed=true
+    fi
+  done
+
+  if plugin_update_run_phase plugins wordpress-terminal-verification wp_cmd plugin list --fields=name,status,version --format=json --skip-plugins; then
+    PLUGIN_STATES_AFTER_JSON="$PLUGIN_PHASE_OUTPUT"
+  else
+    phase_status=$?
+    for slug in "${slugs[@]}"; do
+      [ -d "$SITE_PATH/wp-content/plugins/$slug" ] || continue
+      plugin_update_record_failure "$slug" verification "$phase_status"
+      warn "[$slug] terminal=partial-failure verification_status=$phase_status release_pointer_changed=$(plugin_update_pointer_changed "$slug")"
+    done
+    return "$PLUGIN_UPDATE_EXIT_PARTIAL"
+  fi
+
+  for slug in "${slugs[@]}"; do
+    plugin_dir="$SITE_PATH/wp-content/plugins/$slug"
+    [ -d "$plugin_dir" ] || continue
+    if plugin_update_state_from_json "$PLUGIN_STATES_AFTER_JSON" "$slug"; then
+      tuple="$PLUGIN_STATE_TUPLE"
+      IFS=$'\t' read -r version status <<< "$tuple"
+    else
+      version=""; status="missing"
+    fi
+    file_version="$(plugin_update_local_version "$slug" 2>/dev/null || true)"
+    log "[$slug] installed-after version=${version:-missing} active=$( case "$status" in active|active-network) printf yes ;; *) printf no ;; esac ) file_version=${file_version:-missing}"
+    if [ -z "$version" ] || [ "$version" != "$file_version" ] || [ "$status" = missing ]; then
+      plugin_update_record_failure "$slug" verification 1
+      failed=true
+    fi
+    if plugin_update_slug_failed "$slug"; then
+      warn "[$slug] terminal=partial-failure version=${version:-missing} status=$status release_pointer_changed=$(plugin_update_pointer_changed "$slug")"
+    else
+      log "[$slug] terminal=complete version=$version status=$status release_pointer_changed=$(plugin_update_pointer_changed "$slug")"
+    fi
+  done
+  [ "$failed" = false ]
+}
+
+plugin_update_print_terminal_summary() {
+  local evidence failure
+  log "Plugin release-pointer evidence:"
+  for evidence in "${PLUGIN_UPDATE_POINTER_EVIDENCE[@]:-}"; do
+    [ -z "$evidence" ] || log "  $evidence"
+  done
+  if [ "${#PLUGIN_UPDATE_FAILURES[@]}" -gt 0 ]; then
+    warn "PLUGIN_UPGRADE_RESULT=partial_failure exit=$PLUGIN_UPDATE_EXIT_PARTIAL"
+    for failure in "${PLUGIN_UPDATE_FAILURES[@]}"; do warn "  $failure"; done
+  else
+    log "PLUGIN_UPGRADE_RESULT=complete"
+  fi
+}

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -142,40 +142,92 @@ update_plugin_to_latest_tag() {
     return 0
   fi
 
-  if [ -n "$(git -C "$plugin_dir" status --porcelain 2>/dev/null)" ]; then
+  local phase_status
+  if plugin_update_run_phase "$slug" working-tree-inspection git -C "$plugin_dir" status --porcelain; then
+    :
+  else
+    phase_status=$?
+    warn "Could not inspect the $slug working tree"
+    return "$phase_status"
+  fi
+  if [ -n "$PLUGIN_PHASE_OUTPUT" ]; then
     warn "Plugin $slug has local changes — skipping tagged release update"
     return 0
   fi
 
-  git -C "$plugin_dir" fetch --tags --force origin || {
+  if plugin_update_run_phase "$slug" tag-fetch git -C "$plugin_dir" fetch --tags --force origin; then
+    :
+  else
+    phase_status=$?
     warn "Could not fetch tags for $slug"
-    return 0
-  }
+    return "$phase_status"
+  fi
 
   local latest_tag
-  latest_tag=$(git -C "$plugin_dir" tag --sort=-v:refname | grep -E '^v?[0-9]' | head -n 1)
+  if plugin_update_run_phase "$slug" tag-discovery git -C "$plugin_dir" tag --sort=-v:refname; then
+    :
+  else
+    phase_status=$?
+    warn "Could not inspect tags for $slug"
+    return "$phase_status"
+  fi
+  latest_tag=$(printf '%s\n' "$PLUGIN_PHASE_OUTPUT" | grep -E '^v?[0-9]' | head -n 1)
   if [ -z "$latest_tag" ]; then
     warn "No version tags found for $slug — skipping"
-    return 0
+    return 1
   fi
 
   local current_ref
-  current_ref=$(git -C "$plugin_dir" describe --tags --exact-match 2>/dev/null || git -C "$plugin_dir" rev-parse --short HEAD)
+  if plugin_update_run_phase "$slug" current-release bash -c \
+      'git -C "$1" describe --tags --exact-match 2>/dev/null || git -C "$1" rev-parse --short HEAD' _ "$plugin_dir"; then
+    current_ref="$PLUGIN_PHASE_OUTPUT"
+  else
+    phase_status=$?
+    warn "Could not identify the installed release for $slug"
+    return "$phase_status"
+  fi
 
   if [ "$current_ref" = "$latest_tag" ]; then
     log "Plugin $slug already at latest tag ($latest_tag)"
   else
     log "Updating plugin $slug: $current_ref → $latest_tag"
-    git -C "$plugin_dir" checkout --detach "$latest_tag" || {
+    if plugin_update_run_phase "$slug" release-checkout git -C "$plugin_dir" checkout --detach "$latest_tag"; then
+      :
+    else
+      phase_status=$?
       warn "Could not checkout $latest_tag for $slug"
-      return 0
-    }
+      return "$phase_status"
+    fi
     UPDATED_ITEMS+=("$slug $latest_tag")
   fi
 
-  install_plugin_dependencies "$slug" "$plugin_dir" true
-  activate_plugin "$slug"
-  fix_ownership "$plugin_dir"
+  install_plugin_dependencies_bounded "$slug" "$plugin_dir" || return $?
+  plugin_update_run_phase "$slug" ownership-normalization fix_ownership "$plugin_dir" || return $?
+}
+
+install_plugin_dependencies_bounded() {
+  local slug="$1" plugin_dir="$2"
+  if [ -f "$plugin_dir/composer.json" ]; then
+    plugin_update_run_phase "$slug" composer-install env COMPOSER_ALLOW_SUPERUSER=1 composer install \
+      --no-dev --no-interaction --working-dir="$plugin_dir" || return $?
+  fi
+  if [ -f "$plugin_dir/package.json" ]; then
+    log "Building $slug JS assets..."
+    plugin_update_run_phase "$slug" npm-install npm install --prefix "$plugin_dir" || return $?
+    plugin_update_run_phase "$slug" build-script-inspection jq -r '.scripts.build // ""' "$plugin_dir/package.json" || return $?
+    local build_script="$PLUGIN_PHASE_OUTPUT"
+    if printf '%s' "$build_script" | grep -q "wp-env"; then
+      if ! command -v docker >/dev/null 2>&1; then
+        log "Skipping $slug build — script requires wp-env (Docker is not installed)."
+      elif plugin_update_run_phase "$slug" docker-readiness docker info; then
+        plugin_update_run_phase "$slug" npm-build npm run build --prefix "$plugin_dir" || return $?
+      else
+        log "Skipping $slug build — script requires wp-env (Docker daemon not reachable within the plugin phase deadline)."
+      fi
+    else
+      plugin_update_run_phase "$slug" npm-build npm run build --prefix "$plugin_dir" || return $?
+    fi
+  fi
 }
 
 # Normalize web-tree ownership or group permissions (no-op in local mode).

--- a/lib/wp-codebox.sh
+++ b/lib/wp-codebox.sh
@@ -21,11 +21,30 @@ WP_CODEBOX_PLUGIN_SUBTREE="${WP_CODEBOX_PLUGIN_SUBTREE:-packages/wordpress-plugi
 
 # Resolve the latest version tag from the remote without a full clone.
 _wp_codebox_latest_tag() {
-  git ls-remote --tags --refs "$WP_CODEBOX_REPO_URL" 2>/dev/null \
+  local refs="${1:-}"
+  if [ -z "$refs" ]; then
+    refs="$(git ls-remote --tags --refs "$WP_CODEBOX_REPO_URL" 2>/dev/null)"
+  fi
+  printf '%s\n' "$refs" \
     | awk -F/ '{print $NF}' \
     | grep -E '^v?[0-9]' \
     | sort -V \
     | tail -n 1
+}
+
+_wp_codebox_fail() {
+  warn "$1"
+  [ "${PLUGIN_UPDATE_ACTIVE:-false}" != true ]
+}
+
+_wp_codebox_sync_files() {
+  local src="$1" plugin_dir="$2"
+  rm -rf "$plugin_dir/src"
+  cp -a "$src/src" "$plugin_dir/src"
+  [ -d "$src/assets" ] && { rm -rf "$plugin_dir/assets"; cp -a "$src/assets" "$plugin_dir/assets"; }
+  cp -a "$src/wp-codebox.php" "$plugin_dir/wp-codebox.php"
+  [ ! -f "$src/README.md" ] || cp -a "$src/README.md" "$plugin_dir/README.md"
+  [ ! -f "$src/package.json" ] || cp -a "$src/package.json" "$plugin_dir/package.json"
 }
 
 # Read the Version: header from a plugin main file.
@@ -56,10 +75,20 @@ update_wp_codebox_plugin_subtree() {
   fi
 
   local latest_tag
-  latest_tag="$(_wp_codebox_latest_tag)"
+  if declare -F plugin_update_run_phase >/dev/null 2>&1; then
+    if plugin_update_run_phase wp-codebox tag-discovery git ls-remote --tags --refs "$WP_CODEBOX_REPO_URL"; then
+      latest_tag="$(_wp_codebox_latest_tag "$PLUGIN_PHASE_OUTPUT")"
+    else
+      local phase_status=$?
+      _wp_codebox_fail "Could not resolve latest WP Codebox tag — copied install unchanged"
+      return "$phase_status"
+    fi
+  else
+    latest_tag="$(_wp_codebox_latest_tag)"
+  fi
   if [ -z "$latest_tag" ]; then
-    warn "Could not resolve latest WP Codebox tag — skipping subtree update"
-    return 0
+    _wp_codebox_fail "Could not resolve latest WP Codebox tag — copied install unchanged"
+    return $?
   fi
 
   local current_version
@@ -84,34 +113,36 @@ update_wp_codebox_plugin_subtree() {
   # shellcheck disable=SC2064
   trap "rm -rf '$staging'" RETURN
 
-  if ! git clone --depth 1 --branch "$latest_tag" --filter=blob:none --sparse \
-      "$WP_CODEBOX_REPO_URL" "$staging/repo" >/dev/null 2>&1; then
-    warn "Could not clone WP Codebox at ${latest_tag} — skipping subtree update"
-    return 0
+  if plugin_update_run_phase wp-codebox release-clone git clone --depth 1 --branch "$latest_tag" --filter=blob:none --sparse \
+      "$WP_CODEBOX_REPO_URL" "$staging/repo"; then
+    :
+  else
+    local phase_status=$?
+    _wp_codebox_fail "Could not clone WP Codebox at ${latest_tag} — copied install unchanged"
+    return "$phase_status"
   fi
 
-  if ! git -C "$staging/repo" sparse-checkout set "$WP_CODEBOX_PLUGIN_SUBTREE" >/dev/null 2>&1; then
-    warn "Could not sparse-checkout ${WP_CODEBOX_PLUGIN_SUBTREE} — skipping subtree update"
-    return 0
+  if plugin_update_run_phase wp-codebox sparse-checkout git -C "$staging/repo" sparse-checkout set "$WP_CODEBOX_PLUGIN_SUBTREE"; then
+    :
+  else
+    local phase_status=$?
+    _wp_codebox_fail "Could not sparse-checkout ${WP_CODEBOX_PLUGIN_SUBTREE} — copied install unchanged"
+    return "$phase_status"
   fi
 
   local src="$staging/repo/$WP_CODEBOX_PLUGIN_SUBTREE"
   if [ ! -f "$src/wp-codebox.php" ]; then
-    warn "WP Codebox plugin subtree missing wp-codebox.php at ${latest_tag} — skipping subtree update"
-    return 0
+    _wp_codebox_fail "WP Codebox plugin subtree missing wp-codebox.php at ${latest_tag} — copied install unchanged"
+    return $?
   fi
 
-  # Sync the subtree into the plugin dir. Replace src/ wholesale (the file set
-  # changes between versions), then copy the remaining top-level plugin files.
-  rm -rf "$plugin_dir/src"
-  cp -a "$src/src" "$plugin_dir/src"
-  [ -d "$src/assets" ] && { rm -rf "$plugin_dir/assets"; cp -a "$src/assets" "$plugin_dir/assets"; }
-  cp -a "$src/wp-codebox.php" "$plugin_dir/wp-codebox.php"
-  [ -f "$src/README.md" ] && cp -a "$src/README.md" "$plugin_dir/README.md"
-  [ -f "$src/package.json" ] && cp -a "$src/package.json" "$plugin_dir/package.json"
-
-  fix_ownership "$plugin_dir"
-  activate_plugin wp-codebox
+  if plugin_update_run_phase wp-codebox subtree-sync _wp_codebox_sync_files "$src" "$plugin_dir"; then
+    :
+  else
+    local phase_status=$?
+    return "$phase_status"
+  fi
+  plugin_update_run_phase wp-codebox ownership-normalization fix_ownership "$plugin_dir" || return $?
 
   UPDATED_ITEMS+=("wp-codebox $latest_tag")
 }

--- a/tests/dmc-managed-release.sh
+++ b/tests/dmc-managed-release.sh
@@ -93,6 +93,16 @@ update_data_machine_code_copied_release
 [ ! -e "$PLUGIN/.wp-coding-agents-release-current/obsolete" ] || fail "copied release included stale files"
 [ "${#UPDATED_ITEMS[@]}" -eq 1 ] || fail "copied release was not recorded"
 
+# Repeated switches replace (rather than move into) an existing previous
+# symlink, so rollback always names the immediately prior release.
+original_release="$(readlink "$PLUGIN/.wp-coding-agents-release-current")"
+mkdir -p "$PLUGIN/.wp-coding-agents-releases/switch-test"
+printf '<?php\n/*\n * Version: 1.9.0\n */\n' > "$PLUGIN/.wp-coding-agents-releases/switch-test/data-machine-code.php"
+dmc_managed_release_switch_pointer "$PLUGIN" "$PLUGIN/.wp-coding-agents-releases/switch-test"
+[ "$(readlink "$PLUGIN/.wp-coding-agents-release-previous")" = "$original_release" ] || fail "switch did not preserve the immediate prior release"
+dmc_managed_release_switch_pointer "$PLUGIN" "$PLUGIN/$original_release"
+[ "$(readlink "$PLUGIN/.wp-coding-agents-release-previous")" = .wp-coding-agents-releases/switch-test ] || fail "repeated switch retained a stale previous release"
+
 # Interruption after writing the new loader but before switching current is
 # recovered from the already verified staged release without another download.
 target_pointer="$(readlink "$PLUGIN/.wp-coding-agents-release-current")"

--- a/tests/fixtures/plugin-updates/hung.sh
+++ b/tests/fixtures/plugin-updates/hung.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+[ -z "${PLUGIN_FIXTURE_PID_FILE:-}" ] || printf '%s\n' "$$" > "$PLUGIN_FIXTURE_PID_FILE"
+trap '' TERM
+while :; do sleep 1; done

--- a/tests/fixtures/plugin-updates/partial-pointer-hung.sh
+++ b/tests/fixtures/plugin-updates/partial-pointer-hung.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+plugin_dir="$1"
+rm -f "$plugin_dir/.wp-coding-agents-release-current"
+ln -s .wp-coding-agents-releases/new "$plugin_dir/.wp-coding-agents-release-current"
+exec "$(dirname "$0")/hung.sh"

--- a/tests/fixtures/plugin-updates/slow.sh
+++ b/tests/fixtures/plugin-updates/slow.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+sleep "${PLUGIN_FIXTURE_SLEEP_SECONDS:-2}"
+printf 'slow-fixture-complete\n'

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/lib/wordpress.sh"
 source "$SCRIPT_DIR/lib/homeboy.sh"
 
 for entrypoint in setup.sh upgrade.sh; do
-  discover_line=$(grep -n '^discover_dm_workspace_dir$' "$SCRIPT_DIR/$entrypoint" | tail -1 | cut -d: -f1)
+  discover_line=$(grep -n '^[[:space:]]*discover_dm_workspace_dir$' "$SCRIPT_DIR/$entrypoint" | tail -1 | cut -d: -f1)
   if [ "$entrypoint" = "upgrade.sh" ]; then
     configure_line=$(grep -n '^reconcile_provider_and_service_state$' "$SCRIPT_DIR/$entrypoint" | tail -1 | cut -d: -f1)
   else

--- a/tests/plugin-upgrade-bounds.sh
+++ b/tests/plugin-upgrade-bounds.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Deterministic slow/hung coverage for bounded plugin upgrade children.
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/lib/plugin-upgrade.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SCRIPT_DIR="$ROOT_DIR"
+SITE_PATH="$TMP/site"
+DRY_RUN=false
+PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS=4
+PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS=20
+PLUGIN_UPDATE_PROGRESS_SECONDS=1
+PLUGIN_UPDATE_KILL_GRACE_SECONDS=1
+PLUGIN_UPDATE_STARTED_AT="$(date +%s)"
+PLUGIN_UPDATE_FAILURES=()
+PLUGIN_UPDATE_POINTER_EVIDENCE=()
+PENDING_ITEMS=()
+LOG=""
+
+log() { LOG="$LOG$*\n"; }
+warn() { LOG="$LOG$*\n"; }
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+slow="$ROOT_DIR/tests/fixtures/plugin-updates/slow.sh"
+hung="$ROOT_DIR/tests/fixtures/plugin-updates/hung.sh"
+partial="$ROOT_DIR/tests/fixtures/plugin-updates/partial-pointer-hung.sh"
+
+# A slow child emits progress and still completes under its deadline.
+PLUGIN_FIXTURE_SLEEP_SECONDS=2 plugin_update_run_phase fixture slow-sync "$slow" || fail "slow fixture timed out"
+[ "$PLUGIN_PHASE_OUTPUT" = slow-fixture-complete ] || fail "slow fixture output was not retained"
+case "$LOG" in *"phase=slow-sync progress"*"phase=slow-sync terminal=complete"*) : ;; *) fail "slow fixture omitted progress or terminal evidence" ;; esac
+
+# A hung child is named, killed as its own process group, and returns 124.
+LOG=""
+PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS=1
+PLUGIN_FIXTURE_PID_FILE="$TMP/hung.pid"; export PLUGIN_FIXTURE_PID_FILE
+started="$(date +%s)"
+if plugin_update_run_phase fixture hung-sync "$hung"; then
+  fail "hung fixture completed"
+else
+  status=$?
+fi
+elapsed=$(($(date +%s) - started))
+[ "$status" -eq 124 ] || fail "hung fixture returned $status instead of 124"
+[ "$elapsed" -le 4 ] || fail "hung fixture exceeded practical cleanup bound (${elapsed}s)"
+case "$LOG" in *"phase=hung-sync terminal=timeout"*"timed-out-child:"*"resume:"*) : ;; *) fail "hung fixture omitted timeout child or resume evidence" ;; esac
+child_pid="$(cat "$TMP/hung.pid")"
+if kill -0 "$child_pid" 2>/dev/null; then fail "timed-out fixture child $child_pid survived"; fi
+
+# A timeout after an atomic DMC pointer switch reports partial mutation and
+# verifies that WordPress still sees the same active installed version.
+PLUGIN="$SITE_PATH/wp-content/plugins/data-machine-code"
+mkdir -p "$PLUGIN/.wp-coding-agents-releases/old" "$PLUGIN/.wp-coding-agents-releases/new"
+printf '<?php\n/* Version: 1.0.0 */\n' > "$PLUGIN/data-machine-code.php"
+printf '<?php\n/* Version: 1.0.0 */\n' > "$PLUGIN/.wp-coding-agents-releases/old/data-machine-code.php"
+printf '<?php\n/* Version: 1.0.0 */\n' > "$PLUGIN/.wp-coding-agents-releases/new/data-machine-code.php"
+ln -s .wp-coding-agents-releases/old "$PLUGIN/.wp-coding-agents-release-current"
+wp_cmd() { printf '[{"name":"data-machine-code","status":"active","version":"1.0.0"}]\n'; }
+partial_update() { plugin_update_run_phase data-machine-code release-pointer-switch "$partial" "$PLUGIN"; }
+
+LOG=""
+PLUGIN_UPDATE_STARTED_AT="$(date +%s)"
+PLUGIN_UPDATE_FAILURES=()
+PLUGIN_UPDATE_POINTER_EVIDENCE=()
+PENDING_ITEMS=()
+if plugin_update_execute data-machine-code partial_update; then
+  fail "partial pointer fixture completed"
+else
+  status=$?
+fi
+[ "$status" -eq "$PLUGIN_UPDATE_EXIT_PARTIAL" ] || fail "partial apply did not return typed partial status"
+plugin_update_verify_installed_plugins data-machine-code || true
+[ "$status" -eq "$PLUGIN_UPDATE_EXIT_PARTIAL" ] || fail "partial fixture did not return typed partial status"
+[ "$(readlink "$PLUGIN/.wp-coding-agents-release-current")" = .wp-coding-agents-releases/new ] || fail "fixture did not switch release pointer"
+case "${PLUGIN_UPDATE_POINTER_EVIDENCE[*]}" in *"changed=yes"*"before=.wp-coding-agents-releases/old"*"after=.wp-coding-agents-releases/new"*) : ;; *) fail "partial release-pointer mutation was not reported" ;; esac
+case "$LOG" in *"installed-after version=1.0.0 active=yes"*"terminal=partial-failure"*) : ;; *) fail "partial terminal verification evidence missing" ;; esac
+
+echo "plugin-upgrade-bounds tests passed"

--- a/tests/plugins-only-scope.sh
+++ b/tests/plugins-only-scope.sh
@@ -13,6 +13,14 @@ require_source() {
   }
 }
 
+require_file_source() {
+  local file="$1" pattern="$2" description="$3"
+  grep -Fq -- "$pattern" "$file" || {
+    echo "FAIL: missing $description" >&2
+    exit 1
+  }
+}
+
 require_source 'plugins)   [ "$PLUGINS_ONLY" = true ]; return $? ;;' "plugins-only plugin phase"
 require_source 'reconciliation|transport|systemd|patch) [ "$RECONCILE_SERVICES_ONLY" = true ]; return $? ;;' "separate reconciliation phases"
 require_source 'reconcile_provider_and_service_state() {' "provider and service reconciliation phase"
@@ -22,6 +30,9 @@ require_source '  configure_homeboy_dmc_worktree_provider' "Homeboy reconciliati
 require_source '  _run_filter_active systemd || return 0' "launchd mutation guard"
 require_source './upgrade.sh --reconcile-services' "explicit reconciliation command"
 require_source 'if [ "$PLUGINS_ONLY" != true ]; then' "plugins-only source-policy mutation guard"
+require_source 'detect_plugins_only_environment' "narrow plugin-only environment detection"
+require_file_source "$ROOT_DIR/lib/detect.sh" 'Plugin-only scope: installed Data Machine plugins only; runtime, bridge, workspace, and service synchronization disabled' "plugin-only scope evidence"
+require_source '--plugins-only cannot be combined with service, runtime, migration, or other --*-only operations' "plugin-only exclusivity guard"
 require_source 'if _run_filter_active systemd; then' "systems-capability mutation guard"
 require_source '_print_plugins_only_verify_block' "plugins-only summary"
 
@@ -45,14 +56,18 @@ load_upgrade_function() {
   sed -n "/^$1() {/,/^}/p" "$UPGRADE"
 }
 
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SITE_PATH="$TMP/site"
+mkdir -p "$SITE_PATH/wp-content/plugins/wp-codebox"
+PLUGIN_UPDATE_EXIT_PARTIAL=75
+
 eval "$(load_upgrade_function _run_filter_active)"
 eval "$(load_upgrade_function update_data_machine_plugins)"
 eval "$(load_upgrade_function reconcile_provider_and_service_state)"
 eval "$(load_upgrade_function update_chat_bridge_systemd)"
 eval "$(load_upgrade_function update_chat_bridge_launchd)"
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
 LOCAL_SERVICE="$TMP/com.wp.kimaki.plist"
 VPS_SERVICE="$TMP/kimaki.service"
 printf 'local service sentinel\n' > "$LOCAL_SERVICE"
@@ -69,6 +84,8 @@ PLATFORM=mac
 CHAT_BRIDGE=kimaki
 upgrade_data_machine_plugins() { printf 'data-machine\n' >> "$TMP/plugins"; }
 update_wp_codebox_plugin_subtree() { printf 'codebox\n' >> "$TMP/plugins"; }
+plugin_update_execute() { local slug="$1"; shift; "$@"; }
+plugin_update_verify_installed_plugins() { :; }
 set_compose_agents_md_constant() { printf 'configuration\n' >> "$TMP/reconciliation"; }
 dmc_managed_release_integration_sync() { printf 'dmc\n' >> "$TMP/reconciliation"; }
 sync_carried_plugins() { printf 'carried\n' >> "$TMP/reconciliation"; }

--- a/tests/wp-codebox-subtree.sh
+++ b/tests/wp-codebox-subtree.sh
@@ -28,6 +28,11 @@ warn() { LOG_LINES+=("WARN: $*"); }
 fix_ownership() { :; }
 activate_plugin() { :; }
 update_plugin_to_latest_tag() { LOG_LINES+=("DELEGATED: $1"); }
+plugin_update_run_phase() {
+  local slug="$1" phase="$2"
+  shift 2
+  PLUGIN_PHASE_OUTPUT="$("$@")"
+}
 
 logged_contains() {
   local needle="$1"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy owned-source-discovery service-migration wordpress data-machine dmc-managed-release dmc-managed-release-integration carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents systems-capabilities; do
+for lib in common detect source-policy owned-source-discovery service-migration plugin-upgrade wordpress data-machine dmc-managed-release dmc-managed-release-integration carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents systems-capabilities; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -201,6 +201,11 @@ USAGE:
                                 backwards compat — also handles cc-connect
                                 and telegram when they are the detected bridge)
   ./upgrade.sh --plugins-only   Only update setup-installed Data Machine plugins
+                                Uses 120s child / 480s total deadlines by default,
+                                emits per-plugin terminal evidence, and exits 75
+                                on a resumable partial failure. Override with
+                                PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS and
+                                PLUGIN_UPDATE_TOTAL_TIMEOUT_SECONDS.
   ./upgrade.sh --reconcile-services
                                 Only reconcile carried providers, DMC/Homeboy,
                                 chat-bridge configuration, and service templates
@@ -354,6 +359,11 @@ fi
 if [ "$PLUGINS_ONLY" = true ] && [ "$SKIP_PLUGINS" = true ]; then
   error "Cannot combine --plugins-only and --skip-plugins"
 fi
+if [ "$PLUGINS_ONLY" = true ] && { [ "$KIMAKI_ONLY" = true ] || [ "$SKILLS_ONLY" = true ] || \
+   [ "$AGENTS_MD_ONLY" = true ] || [ "$RECONCILE_SERVICES_ONLY" = true ] || \
+   [ "${SYSTEMS_CAPABILITIES_ONLY:-false}" = true ] || [ "$MIGRATE_NON_ROOT" = true ]; }; then
+  error "--plugins-only cannot be combined with service, runtime, migration, or other --*-only operations"
+fi
 
 # ============================================================================
 # Phase 1: Detect environment
@@ -388,28 +398,31 @@ if [ -z "$EXISTING_WP" ]; then
   fi
 fi
 
-# Auto-detect runtime(s). Same model as setup.sh: DETECTED_RUNTIMES is the
-# full list (drives multi-runtime skills install); RUNTIME is the primary
-# (first-match cascade: claude-code > opencode > codex). Explicit --runtime
-# narrows to a single runtime.
-if [ -n "$RUNTIME" ]; then
-  DETECTED_RUNTIMES=("$RUNTIME")
+if [ "$PLUGINS_ONLY" = true ]; then
+  detect_plugins_only_environment
 else
-  if command -v claude &>/dev/null; then
-    DETECTED_RUNTIMES+=("claude-code")
+  # Auto-detect runtime(s). Same model as setup.sh: DETECTED_RUNTIMES is the
+  # full list (drives multi-runtime skills install); RUNTIME is the primary
+  # (first-match cascade: claude-code > opencode > codex). Explicit --runtime
+  # narrows to a single runtime.
+  if [ -n "$RUNTIME" ]; then
+    DETECTED_RUNTIMES=("$RUNTIME")
+  else
+    if command -v claude &>/dev/null; then
+      DETECTED_RUNTIMES+=("claude-code")
+    fi
+    if command -v opencode &>/dev/null; then
+      DETECTED_RUNTIMES+=("opencode")
+    fi
+    if command -v codex &>/dev/null; then
+      DETECTED_RUNTIMES+=("codex")
+    fi
+    if [ ${#DETECTED_RUNTIMES[@]} -eq 0 ]; then
+      warn "No runtime binary found — defaulting to opencode"
+      DETECTED_RUNTIMES=("opencode")
+    fi
+    RUNTIME="${DETECTED_RUNTIMES[0]}"
   fi
-  if command -v opencode &>/dev/null; then
-    DETECTED_RUNTIMES+=("opencode")
-  fi
-  if command -v codex &>/dev/null; then
-    DETECTED_RUNTIMES+=("codex")
-  fi
-  if [ ${#DETECTED_RUNTIMES[@]} -eq 0 ]; then
-    warn "No runtime binary found — defaulting to opencode"
-    DETECTED_RUNTIMES=("opencode")
-  fi
-  RUNTIME="${DETECTED_RUNTIMES[0]}"
-fi
 
 RUNTIME_FILE="$SCRIPT_DIR/runtimes/${RUNTIME}.sh"
 if [ ! -f "$RUNTIME_FILE" ]; then
@@ -510,10 +523,13 @@ if [ "$DRY_RUN" = true ]; then
   log "Dry-run mode: no changes will be made"
 fi
 echo ""
+fi
 
 # Track what was touched for the summary
 UPDATED_ITEMS=()
 PENDING_ITEMS=()
+PLUGIN_UPDATE_FAILURES=()
+PLUGIN_UPDATE_POINTER_EVIDENCE=()
 
 if [ "${SYSTEMS_CAPABILITIES_ONLY:-false}" = true ]; then
   [ -n "${SYSTEMS_CAPABILITIES_PROFILE:-}" ] || error "--systems-capabilities-only requires --systems-capabilities <profile>"
@@ -591,8 +607,19 @@ _run_filter_active() {
 
 update_data_machine_plugins() {
   _run_filter_active plugins || return 0
-  upgrade_data_machine_plugins
-  update_wp_codebox_plugin_subtree
+  local status=0
+  upgrade_data_machine_plugins || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+  if [ "$PLUGINS_ONLY" = true ]; then
+    if [ -d "$SITE_PATH/wp-content/plugins/wp-codebox" ]; then
+      plugin_update_execute wp-codebox update_wp_codebox_plugin_subtree || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+    else
+      log "[wp-codebox] terminal=skipped reason=not-installed"
+    fi
+  else
+    plugin_update_execute wp-codebox update_wp_codebox_plugin_subtree || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+  fi
+  plugin_update_verify_installed_plugins data-machine data-machine-code wp-codebox || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+  return "$status"
 }
 
 reconcile_provider_and_service_state() {
@@ -1338,7 +1365,11 @@ refresh_opencode_runtime_signature_phase() {
 print_summary() {
   echo ""
   echo "=========================================="
-  log "Upgrade complete."
+  if [ "$PLUGINS_ONLY" = true ] && [ "${PLUGIN_ONLY_EXIT_STATUS:-0}" -ne 0 ]; then
+    warn "Plugin upgrade partially completed."
+  else
+    log "Upgrade complete."
+  fi
   echo "=========================================="
 
   if [ ${#UPDATED_ITEMS[@]} -eq 0 ]; then
@@ -1383,6 +1414,8 @@ print_summary() {
 
   echo ""
   if [ "$PLUGINS_ONLY" = true ]; then
+    plugin_update_print_terminal_summary
+    echo ""
     _print_plugins_only_verify_block
   else
     _print_bridge_restart_hint
@@ -1463,16 +1496,19 @@ _print_verify_block() {
 
 _print_plugins_only_verify_block() {
   log "Verify:"
-  log "  $WP_CMD plugin get data-machine --field=version --path=$SITE_PATH $WP_ROOT_FLAG"
-  log "  $WP_CMD plugin get data-machine-code --field=version --path=$SITE_PATH $WP_ROOT_FLAG"
+  log "  $WP_CMD plugin get data-machine --fields=name,status,version --format=json --skip-plugins --path=$SITE_PATH $WP_ROOT_FLAG"
+  log "  $WP_CMD plugin get data-machine-code --fields=name,status,version --format=json --skip-plugins --path=$SITE_PATH $WP_ROOT_FLAG"
 }
 
 # ============================================================================
 # Execute
 # ============================================================================
 
-update_data_machine_plugins
-discover_dm_workspace_dir
+PLUGIN_ONLY_EXIT_STATUS=0
+update_data_machine_plugins || PLUGIN_ONLY_EXIT_STATUS=$?
+if [ "$PLUGINS_ONLY" != true ]; then
+  discover_dm_workspace_dir
+fi
 reconcile_provider_and_service_state
 sync_cli_transport_runtime
 update_ai_gateway
@@ -1495,3 +1531,6 @@ update_chat_bridge_launchd
 update_datamachine_worker_service
 refresh_opencode_runtime_signature_phase
 print_summary
+if [ "$PLUGINS_ONLY" = true ]; then
+  exit "$PLUGIN_ONLY_EXIT_STATUS"
+fi


### PR DESCRIPTION
## Summary

- isolate plugin-only upgrade execution from unrelated runtime and bridge discovery
- add bounded plugin update phases with explicit progress, timeout, pointer-change, and resume evidence
- centralize plugin synchronization while preserving Studio, DMC-managed release, and WP Codebox behavior

Closes #454

## Testing

- added `tests/plugin-upgrade-bounds.sh` with hung, slow, and partial-pointer fixtures
- expanded plugin-only, DMC managed release, and WP Codebox subtree coverage
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to inspect the completed repair, verify repository and tracker state, and prepare this pull request under Chris Huber’s direction.