### PR TITLE
fix: XML-escape Data Machine worker LaunchAgent commands

### DIFF
--- a/services/datamachine-worker.sh
+++ b/services/datamachine-worker.sh
@@ -11,6 +11,14 @@ _datamachine_worker_shell_quote() {
   printf "'%s'" "$value"
 }
 
+_datamachine_worker_xml_text() {
+  local value="$1"
+  value=${value//&/\&amp;}
+  value=${value//</\&lt;}
+  value=${value//>/\&gt;}
+  printf '%s' "$value"
+}
+
 _datamachine_worker_uses_studio() {
   [ "${WP_CMD:-wp}" = "studio wp" ]
 }
@@ -87,32 +95,38 @@ EOF
 datamachine_worker_render_launchd() {
   local label="$1"
   local log_dir="$SERVICE_HOME/.datamachine"
+  local command_xml label_xml log_dir_xml service_home_xml site_path_xml
   [ "$label" = "com.wp.datamachine-worker" ] || return 1
+  command_xml="$(_datamachine_worker_xml_text "$(_datamachine_worker_command)")"
+  label_xml="$(_datamachine_worker_xml_text "$label")"
+  log_dir_xml="$(_datamachine_worker_xml_text "$log_dir")"
+  service_home_xml="$(_datamachine_worker_xml_text "$SERVICE_HOME")"
+  site_path_xml="$(_datamachine_worker_xml_text "$SITE_PATH")"
   cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>$label</string>
+    <string>$label_xml</string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>$(_datamachine_worker_command)</string>
+        <string>$command_xml</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>$SITE_PATH</string>
+    <string>$site_path_xml</string>
     <key>StartInterval</key>
     <integer>120</integer>
     <key>StandardOutPath</key>
-    <string>$log_dir/datamachine-worker.log</string>
+    <string>$log_dir_xml/datamachine-worker.log</string>
     <key>StandardErrorPath</key>
-    <string>$log_dir/datamachine-worker.error.log</string>
+    <string>$log_dir_xml/datamachine-worker.error.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>HOME</key>
-        <string>$SERVICE_HOME</string>
+        <string>$service_home_xml</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>

--- a/tests/__snapshots__/datamachine-worker/launchd
+++ b/tests/__snapshots__/datamachine-worker/launchd
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>cd "/var/www/site" && wp cron event run --due-now && wp datamachine worker run --once</string>
+        <string>cd "/var/www/site" &amp;&amp; wp cron event run --due-now &amp;&amp; wp datamachine worker run --once</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
+++ b/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>cd "/var/www/site" && '/tmp/datamachine-worker-studio-path/studio tools/studio' wp cron event run --due-now && '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
+        <string>cd "/var/www/site" &amp;&amp; '/tmp/datamachine-worker-studio-path/studio tools/studio' wp cron event run --due-now &amp;&amp; '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -21,6 +21,23 @@ grep -q '^OnUnitActiveSec=2min$' <<< "$timer"
 grep -q '<integer>120</integer>' <<< "$plist"
 grep -q 'com.wp.datamachine-worker' <<< "$plist"
 
+if command -v plutil >/dev/null 2>&1; then
+  saved_site_path="$SITE_PATH"
+  saved_service_home="$SERVICE_HOME"
+  SITE_PATH='/tmp/site & <queue>'
+  SERVICE_HOME='/tmp/home & <worker>'
+  metachar_plist="$(datamachine_worker_render_launchd com.wp.datamachine-worker)"
+  metachar_file="$(mktemp)"
+  printf '%s\n' "$metachar_plist" > "$metachar_file"
+  plutil -lint "$metachar_file" >/dev/null
+  [ "$(plutil -extract WorkingDirectory raw -o - "$metachar_file")" = "$SITE_PATH" ]
+  [ "$(plutil -extract EnvironmentVariables.HOME raw -o - "$metachar_file")" = "$SERVICE_HOME" ]
+  [ "$(plutil -extract ProgramArguments.2 raw -o - "$metachar_file")" = "$(_datamachine_worker_command)" ]
+  rm -f "$metachar_file"
+  SITE_PATH="$saved_site_path"
+  SERVICE_HOME="$saved_service_home"
+fi
+
 # launchd has a minimal PATH. Resolve a Studio CLI from a directory outside
 # that PATH and assert the command embeds its absolute, shell-quoted path.
 studio_root="/tmp/datamachine-worker-studio-path"
@@ -48,5 +65,16 @@ studio_plist="$(datamachine_worker_render_launchd com.wp.datamachine-worker)"
 PATH="$saved_path"
 
 diff -u "$snapshot_dir/launchd-studio-absolute-path" <(printf '%s\n' "$studio_plist")
-grep -Fq "'$studio_bin' wp cron event run --due-now && '$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
+grep -Fq "'$studio_bin' wp cron event run --due-now &amp;&amp; '$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
+
+if command -v plutil >/dev/null 2>&1; then
+  plist_file="$studio_root/datamachine-worker.plist"
+  printf '%s\n' "$studio_plist" > "$plist_file"
+  plutil -lint "$plist_file" >/dev/null
+  rendered_command="$(plutil -extract ProgramArguments.2 raw -o - "$plist_file")"
+  [ "$rendered_command" = "$(_datamachine_worker_command)" ] || {
+    echo "FAIL: escaped LaunchAgent command did not round-trip" >&2
+    exit 1
+  }
+fi
 echo "PASS: tests/datamachine-worker.sh"


### PR DESCRIPTION
## Summary

- XML-escape every dynamic Data Machine worker LaunchAgent text node
- preserve the decoded shell command and dynamic paths exactly
- validate rendered plists and metacharacter round trips with macOS `plutil`

Closes #461.

## Verification

- `bash tests/datamachine-worker.sh`
- `bash -n services/datamachine-worker.sh tests/datamachine-worker.sh`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the failed service reconciliation, isolated the invalid plist, implemented XML-safe rendering, added macOS parse/round-trip coverage, and ran verification. Chris Huber directed the repair and remains responsible.