### PR TITLE
Fix DMC provider discovery with PHP diagnostic prefixes

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -293,12 +293,30 @@ homeboy_dmc_worktree_provider_executable() {
   printf '%s' "$response" | python3 -c '
 import json
 import os
+import re
 import sys
 
+raw = sys.stdin.read()
 try:
-    payload = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
+    payload = json.loads(raw)
+except json.JSONDecodeError:
+    lines = raw.splitlines()
+    diagnostic_found = False
+    while lines:
+        line = lines.pop(0)
+        if not line.strip():
+            continue
+        if re.match(r"^(?:PHP )?(?:Deprecated|Warning|Notice):\s", line.lstrip()):
+            diagnostic_found = True
+            continue
+        lines.insert(0, line)
+        break
+    if not diagnostic_found:
+        sys.exit(1)
+    try:
+        payload = json.loads("\n".join(lines).strip())
+    except json.JSONDecodeError:
+        sys.exit(1)
 
 executable = payload.get("executable")
 if payload.get("schema") != "datamachine-code/standalone-worktree-provider-command/v1" or not isinstance(executable, str) or not os.path.isfile(executable):

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -636,6 +636,8 @@ while True:
   exit 0
 fi
 if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree provider" ]; then
+  [ "${DMC_PROVIDER_DISCOVERY_MODE:-}" = diagnostic_prefix ] && printf '\nDeprecated: Case statements followed by a semicolon are deprecated.\n'
+  [ "${DMC_PROVIDER_DISCOVERY_MODE:-}" = arbitrary_prefix ] && printf 'unexpected output\n'
   printf '{"schema":"datamachine-code/standalone-worktree-provider-command/v1","executable":"%s"}\n' "$DMC_PROVIDER_EXECUTABLE"
   exit 0
 fi
@@ -701,6 +703,16 @@ export HOMEBOY_CONFIG_LOG STUDIO_LOG DMC_STATE DMC_ENSURE_LOG DMC_PLAN_PATH DMC_
 # macOS ships Bash 3.2, which has no mapfile/readarray builtin. Disable it
 # when the test runs under newer Bash so this path stays portable.
 enable -n mapfile 2>/dev/null || true
+
+discovered_provider="$(DMC_PROVIDER_DISCOVERY_MODE=diagnostic_prefix homeboy_dmc_worktree_provider_executable)"
+[ "$discovered_provider" = "$DMC_PROVIDER_EXECUTABLE" ] || {
+  echo "FAIL: provider discovery rejected a leading PHP diagnostic"
+  exit 1
+}
+if DMC_PROVIDER_DISCOVERY_MODE=arbitrary_prefix homeboy_dmc_worktree_provider_executable >/dev/null 2>&1; then
+  echo "FAIL: provider discovery accepted an arbitrary output prefix"
+  exit 1
+fi
 
 DRY_RUN=true
 configure_homeboy_dmc_worktree_provider > "$TMP/dry-run.log"


### PR DESCRIPTION
## Summary

- accept leading PHP deprecation, warning, and notice diagnostics before DMC provider discovery JSON
- retain strict provider schema and executable validation
- reject arbitrary non-diagnostic output prefixes

Closes #463.

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `bash -n lib/homeboy.sh tests/homeboy-dmc-provider.sh`
- `git diff --check`

## AI assistance disclosure

GPT-5.6 Sol, via OpenCode, reproduced the Studio runtime failure, implemented the parser and regression coverage, and ran verification under human direction.