### PR TITLE
Fix DMC workspace discovery with PHP diagnostic prefixes

### DIFF
--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -225,7 +225,32 @@ discover_dm_workspace_dir() {
     return "$status"
   fi
 
-  DM_WORKSPACE_DIR="$(cat "$workspace_file")"
+  if ! DM_WORKSPACE_DIR="$(python3 - "$workspace_file" <<'PY'
+import re
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+while lines:
+    line = lines.pop(0)
+    if not line.strip():
+        continue
+    if re.match(r"^(?:PHP )?(?:Deprecated|Warning|Notice):\s", line.lstrip()):
+        continue
+    lines.insert(0, line)
+    break
+
+values = [line for line in lines if line.strip()]
+if len(values) != 1:
+    raise SystemExit(1)
+print(values[0])
+PY
+  )"; then
+    DM_WORKSPACE_DIR=""
+    rm -f "$workspace_file" "$stderr_file"
+    rmdir "$temp_dir" 2>/dev/null || true
+    warn "DMC workspace discovery returned invalid output. Replay: $replay_command"
+    return 1
+  fi
   rm -f "$workspace_file" "$stderr_file"
   rmdir "$temp_dir" 2>/dev/null || true
   if [ -z "$DM_WORKSPACE_DIR" ]; then

--- a/tests/dm-workspace-discovery.sh
+++ b/tests/dm-workspace-discovery.sh
@@ -35,6 +35,15 @@ wp_cmd() {
       sleep 0.2
       printf '%s\n' "$TMP/Developer"
       ;;
+    diagnostic_prefix)
+      printf '\nDeprecated: Case statements followed by a semicolon are deprecated.\n%s\n' "$TMP/Developer"
+      ;;
+    arbitrary_prefix)
+      printf 'unexpected output\n%s\n' "$TMP/Developer"
+      ;;
+    ambiguous)
+      printf '%s\n%s\n' "$TMP/Developer" "$TMP/other-workspace"
+      ;;
     failure)
       echo "DMC_ERROR_CODE=workspace_locked: sqlite busy" >&2
       return 73
@@ -56,6 +65,27 @@ if [ "$DM_WORKSPACE_DIR" != "$TMP/Developer" ]; then
   echo "FAIL: slow canonical DMC workspace was not discovered: $DM_WORKSPACE_DIR"
   exit 1
 fi
+
+MODE=diagnostic_prefix
+DM_WORKSPACE_DIR=""
+discover_dm_workspace_dir
+if [ "$DM_WORKSPACE_DIR" != "$TMP/Developer" ]; then
+  echo "FAIL: canonical DMC workspace with a PHP diagnostic prefix was not discovered: $DM_WORKSPACE_DIR"
+  exit 1
+fi
+
+for invalid_mode in arbitrary_prefix ambiguous; do
+  MODE="$invalid_mode"
+  DM_WORKSPACE_DIR="$TMP/guessed-workspace"
+  set +e
+  discover_dm_workspace_dir >"$TMP/$invalid_mode.out" 2>"$TMP/$invalid_mode.err"
+  invalid_status=$?
+  set -e
+  if [ "$invalid_status" -eq 0 ] || [ -n "$DM_WORKSPACE_DIR" ]; then
+    echo "FAIL: $invalid_mode workspace output was accepted: $DM_WORKSPACE_DIR"
+    exit 1
+  fi
+done
 
 DATAMACHINE_WORKSPACE_PATH="$TMP/explicit-workspace"
 DM_WORKSPACE_DIR="$TMP/Developer"


### PR DESCRIPTION
## Summary

- strip recognized leading PHP diagnostics from DMC workspace path output
- require exactly one non-empty canonical path line
- reject arbitrary prefixes and ambiguous output

Closes #465.

## Verification

- `bash tests/dm-workspace-discovery.sh`
- `bash tests/homeboy-dmc-provider.sh`
- `bash -n lib/data-machine.sh tests/dm-workspace-discovery.sh`
- `git diff --check`

## AI assistance disclosure

GPT-5.6 Sol, via OpenCode, reproduced the provider-readiness failure, implemented strict scalar output parsing and regression coverage, and ran verification under human direction.