### PR TITLE
fix: make Data Machine worker a durable opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ cd wp-coding-agents
 SITE_DOMAIN=example.com ./setup.sh
 ```
 
+### Optional Data Machine Worker
+
+Setup and upgrades leave the managed Data Machine worker disabled by default.
+Interactive CLI operations continue to work without it. Install the worker only
+when the site should drain Data Machine work while no operator or web request is
+present:
+
+```bash
+./setup.sh --with-datamachine-worker
+```
+
+The choice persists across upgrades. Disable it and remove the managed launchd
+or systemd service with `./upgrade.sh --no-datamachine-worker`. The worker runs
+one bounded `wp datamachine worker run --once` pass every two minutes; it does
+not execute generic due WP-Cron events.
+
 ### External WordPress Runtime
 
 Run the coding runtime on a host without a mounted WordPress tree. The control

--- a/services/datamachine-worker.sh
+++ b/services/datamachine-worker.sh
@@ -1,9 +1,39 @@
 #!/bin/bash
-# Data Machine queue heartbeat service. Runs a bounded worker pass regularly so
-# headless WordPress installs do not depend on HTTP-triggered WP-Cron traffic.
+# Optional Data Machine queue worker. This service drains Data Machine work; it
+# does not act as a generic WP-Cron heartbeat.
 
 datamachine_worker_systemd_units() { echo "datamachine-worker.service datamachine-worker.timer"; }
 datamachine_worker_launchd_label() { echo "com.wp.datamachine-worker"; }
+datamachine_worker_state_file() { printf '%s/.config/wp-coding-agents/datamachine-worker.enabled' "$SERVICE_HOME"; }
+datamachine_worker_systemd_dir() { printf '%s' "${DATAMACHINE_WORKER_SYSTEMD_DIR:-/etc/systemd/system}"; }
+datamachine_worker_launchd_dir() { printf '%s' "${DATAMACHINE_WORKER_LAUNCHD_DIR:-$SERVICE_HOME/Library/LaunchAgents}"; }
+
+datamachine_worker_desired_state() {
+  local requested="${DATAMACHINE_WORKER_REQUEST:-${WP_CODING_AGENTS_DATAMACHINE_WORKER_ENABLED:-}}"
+  case "$requested" in
+    1|true|enabled) printf 'enabled\n'; return 0 ;;
+    0|false|disabled) printf 'disabled\n'; return 0 ;;
+    "") ;;
+    *) error "Unknown Data Machine worker state: $requested (supported: enabled, disabled)" ;;
+  esac
+
+  if [ -f "$(datamachine_worker_state_file)" ]; then
+    printf 'enabled\n'
+  else
+    printf 'disabled\n'
+  fi
+}
+
+datamachine_worker_record_state() {
+  local state="$1" file
+  file="$(datamachine_worker_state_file)"
+  if [ "$state" = "enabled" ]; then
+    run_cmd mkdir -p "${file%/*}"
+    write_file "$file" "enabled"
+    return
+  fi
+  run_cmd rm -f "$file"
+}
 
 _datamachine_worker_shell_quote() {
   local value="$1"
@@ -54,17 +84,17 @@ datamachine_worker_prepare_command() {
 _datamachine_worker_command() {
   if _datamachine_worker_uses_studio; then
     [ -n "${STUDIO_BIN:-}" ] || datamachine_worker_prepare_command || return 1
-    printf 'cd "%s" && %s wp cron event run --due-now && %s wp datamachine worker run --once' "$SITE_PATH" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")"
+    printf 'cd "%s" && %s wp datamachine worker run --once' "$SITE_PATH" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")"
     return
   fi
 
-  printf '%s' "cd \"$SITE_PATH\" && $WP_CMD cron event run --due-now && $WP_CMD datamachine worker run --once"
+  printf '%s' "cd \"$SITE_PATH\" && $WP_CMD datamachine worker run --once"
 }
 
 datamachine_worker_render_systemd_service() {
   cat <<EOF
 [Unit]
-Description=Data Machine queue worker heartbeat (wp-coding-agents)
+Description=Optional Data Machine queue worker (wp-coding-agents)
 After=network.target
 
 [Service]
@@ -80,7 +110,7 @@ EOF
 datamachine_worker_render_systemd_timer() {
   cat <<'EOF'
 [Unit]
-Description=Run Data Machine queue worker heartbeat every two minutes
+Description=Run the optional Data Machine queue worker every two minutes
 
 [Timer]
 OnBootSec=2min
@@ -141,7 +171,7 @@ datamachine_worker_install() {
   if [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
     local label plist_dir plist
     label="$(datamachine_worker_launchd_label)"
-    plist_dir="$HOME/Library/LaunchAgents"
+    plist_dir="$(datamachine_worker_launchd_dir)"
     plist="$plist_dir/$label.plist"
     run_cmd mkdir -p "$plist_dir" "$SERVICE_HOME/.datamachine"
     write_file "$plist" "$(datamachine_worker_render_launchd "$label")"
@@ -149,17 +179,17 @@ datamachine_worker_install() {
       launchctl bootout "gui/$(id -u)" "$plist" 2>/dev/null || true
       launchctl bootstrap "gui/$(id -u)" "$plist"
     fi
-    log "Data Machine worker heartbeat: $label"
+    log "Data Machine worker: $label"
     return
   fi
 
   if [ "$LOCAL_MODE" = true ]; then
-    warn "Data Machine worker heartbeat requires launchd or systemd; local manual mode is not supervised."
+    warn "Data Machine worker requires launchd or systemd; local manual mode is not supervised."
     return
   fi
 
-  write_file "/etc/systemd/system/datamachine-worker.service" "$(datamachine_worker_render_systemd_service)"
-  write_file "/etc/systemd/system/datamachine-worker.timer" "$(datamachine_worker_render_systemd_timer)"
+  write_file "$(datamachine_worker_systemd_dir)/datamachine-worker.service" "$(datamachine_worker_render_systemd_service)"
+  write_file "$(datamachine_worker_systemd_dir)/datamachine-worker.timer" "$(datamachine_worker_render_systemd_timer)"
   if [ "$DRY_RUN" = false ]; then
     systemctl daemon-reload
     systemctl enable --now datamachine-worker.timer
@@ -172,7 +202,7 @@ datamachine_worker_update() {
   if [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
     local label plist
     label="$(datamachine_worker_launchd_label)"
-    plist="$HOME/Library/LaunchAgents/$label.plist"
+    plist="$(datamachine_worker_launchd_dir)/$label.plist"
     if [ ! -f "$plist" ]; then
       datamachine_worker_install
       return
@@ -185,13 +215,56 @@ datamachine_worker_update() {
     return
   fi
   [ "$LOCAL_MODE" = true ] && return 0
-  if [ ! -f /etc/systemd/system/datamachine-worker.service ] || [ ! -f /etc/systemd/system/datamachine-worker.timer ]; then
+  local systemd_dir
+  systemd_dir="$(datamachine_worker_systemd_dir)"
+  if [ ! -f "$systemd_dir/datamachine-worker.service" ] || [ ! -f "$systemd_dir/datamachine-worker.timer" ]; then
     datamachine_worker_install
     return
   fi
-  _smart_update_systemd_unit /etc/systemd/system/datamachine-worker.service "$(datamachine_worker_render_systemd_service)" datamachine-worker.service
-  _smart_update_systemd_unit /etc/systemd/system/datamachine-worker.timer "$(datamachine_worker_render_systemd_timer)" datamachine-worker.timer
+  _smart_update_systemd_unit "$systemd_dir/datamachine-worker.service" "$(datamachine_worker_render_systemd_service)" datamachine-worker.service
+  _smart_update_systemd_unit "$systemd_dir/datamachine-worker.timer" "$(datamachine_worker_render_systemd_timer)" datamachine-worker.timer
   if [ "$DRY_RUN" = false ]; then
     systemctl restart datamachine-worker.timer
+  fi
+}
+
+datamachine_worker_remove() {
+  if [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = "mac" ]; then
+    local label plist
+    label="$(datamachine_worker_launchd_label)"
+    plist="$(datamachine_worker_launchd_dir)/$label.plist"
+    if [ "$DRY_RUN" = true ]; then
+      echo -e "${BLUE}[dry-run]${NC} Would unload and remove $plist"
+    else
+      launchctl bootout "gui/$(id -u)" "$plist" 2>/dev/null || true
+      rm -f "$plist"
+    fi
+    log "Data Machine worker: disabled"
+    return
+  fi
+
+  [ "$LOCAL_MODE" = true ] && return 0
+  local systemd_dir service timer
+  systemd_dir="$(datamachine_worker_systemd_dir)"
+  service="$systemd_dir/datamachine-worker.service"
+  timer="$systemd_dir/datamachine-worker.timer"
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would disable and remove datamachine-worker.timer"
+  else
+    systemctl disable --now datamachine-worker.timer 2>/dev/null || true
+    rm -f "$service" "$timer"
+    systemctl daemon-reload
+  fi
+  log "Data Machine worker: disabled"
+}
+
+datamachine_worker_reconcile() {
+  local state
+  state="$(datamachine_worker_desired_state)"
+  datamachine_worker_record_state "$state"
+  if [ "$state" = "enabled" ]; then
+    datamachine_worker_update
+  else
+    datamachine_worker_remove
   fi
 }

--- a/setup.sh
+++ b/setup.sh
@@ -179,6 +179,14 @@ while [[ $# -gt 0 ]]; do
       WITH_HOMEBOY=true
       shift
       ;;
+    --with-datamachine-worker)
+      DATAMACHINE_WORKER_REQUEST=enabled
+      shift
+      ;;
+    --no-datamachine-worker)
+      DATAMACHINE_WORKER_REQUEST=disabled
+      shift
+      ;;
     --with-ai-gateway)
       WITH_AI_GATEWAY=true
       shift
@@ -371,7 +379,13 @@ OPTIONS:
                       Opt in to root-managed journald, debug-log rotation, and
                       DMC process-inspection capabilities on a VPS.
   --with-homeboy     Create/update a Homeboy project and install/verify the
-                      WordPress Homeboy extension
+                       WordPress Homeboy extension
+  --with-datamachine-worker
+                      Opt in to a managed service that runs one bounded Data
+                      Machine worker pass every two minutes. This does not run
+                      generic WP-Cron events.
+  --no-datamachine-worker
+                      Disable the worker and remove its managed service state.
   --with-ai-gateway  Opt in to WP AI Gateway setup for OpenCode runtimes.
                      Installs/activates the gateway/provider stack, configures
                      the gateway route, mints/reuses a gateway token, and adds
@@ -611,5 +625,5 @@ if [ "$EXTERNAL_WORDPRESS" != true ]; then cli_transport_install; inbound_event_
 # way a live change will.
 if [ "$EXTERNAL_WORDPRESS" != true ]; then source_reconcile_sync; source_reconcile_run; fi
 install_chat_bridge
-if [ "$EXTERNAL_WORDPRESS" != true ]; then datamachine_worker_install; fi
+if [ "$EXTERNAL_WORDPRESS" != true ]; then datamachine_worker_reconcile; fi
 print_summary

--- a/tests/__snapshots__/datamachine-worker/launchd
+++ b/tests/__snapshots__/datamachine-worker/launchd
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>cd "/var/www/site" &amp;&amp; wp cron event run --due-now &amp;&amp; wp datamachine worker run --once</string>
+        <string>cd "/var/www/site" &amp;&amp; wp datamachine worker run --once</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
+++ b/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>cd "/var/www/site" &amp;&amp; '/tmp/datamachine-worker-studio-path/studio tools/studio' wp cron event run --due-now &amp;&amp; '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
+        <string>cd "/var/www/site" &amp;&amp; '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/__snapshots__/datamachine-worker/systemd-service
+++ b/tests/__snapshots__/datamachine-worker/systemd-service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Data Machine queue worker heartbeat (wp-coding-agents)
+Description=Optional Data Machine queue worker (wp-coding-agents)
 After=network.target
 
 [Service]
@@ -8,4 +8,4 @@ User=chubes
 WorkingDirectory=/var/www/site
 Environment=HOME=/home/chubes
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
-ExecStart=/bin/sh -lc 'cd "/var/www/site" && wp cron event run --due-now && wp datamachine worker run --once'
+ExecStart=/bin/sh -lc 'cd "/var/www/site" && wp datamachine worker run --once'

--- a/tests/__snapshots__/datamachine-worker/systemd-timer
+++ b/tests/__snapshots__/datamachine-worker/systemd-timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run Data Machine queue worker heartbeat every two minutes
+Description=Run the optional Data Machine queue worker every two minutes
 
 [Timer]
 OnBootSec=2min

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -3,6 +3,7 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export SITE_PATH=/var/www/site SERVICE_USER=chubes SERVICE_HOME=/home/chubes
 export WP_CMD=wp LOCAL_MODE=false PLATFORM=linux DRY_RUN=false
+source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/services/datamachine-worker.sh"
 
 service="$(datamachine_worker_render_systemd_service)"
@@ -15,8 +16,11 @@ diff -u "$snapshot_dir/systemd-timer" <(printf '%s\n' "$timer")
 diff -u "$snapshot_dir/launchd" <(printf '%s\n' "$plist")
 
 grep -q '^User=chubes$' <<< "$service"
-grep -q 'wp cron event run --due-now' <<< "$service"
 grep -q 'wp datamachine worker run --once' <<< "$service"
+if grep -q 'wp cron event run --due-now' <<< "$service"; then
+  echo "systemd worker must not execute generic WP-Cron" >&2
+  exit 1
+fi
 grep -q '^OnUnitActiveSec=2min$' <<< "$timer"
 grep -q '<integer>120</integer>' <<< "$plist"
 grep -q 'com.wp.datamachine-worker' <<< "$plist"
@@ -65,7 +69,11 @@ studio_plist="$(datamachine_worker_render_launchd com.wp.datamachine-worker)"
 PATH="$saved_path"
 
 diff -u "$snapshot_dir/launchd-studio-absolute-path" <(printf '%s\n' "$studio_plist")
-grep -Fq "'$studio_bin' wp cron event run --due-now &amp;&amp; '$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
+grep -Fq "'$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
+if grep -q 'wp cron event run --due-now' <<< "$studio_plist"; then
+  echo "launchd worker must not execute generic WP-Cron" >&2
+  exit 1
+fi
 
 if command -v plutil >/dev/null 2>&1; then
   plist_file="$studio_root/datamachine-worker.plist"
@@ -77,4 +85,58 @@ if command -v plutil >/dev/null 2>&1; then
     exit 1
   }
 fi
+
+# Legacy installs have no opt-in marker. Reconciliation must remove their
+# managed service, while explicit enablement persists across later upgrades.
+state_root="$studio_root/state"
+SERVICE_HOME="$state_root/home"
+SITE_PATH="$state_root/site"
+DATAMACHINE_WORKER_LAUNCHD_DIR="$state_root/LaunchAgents"
+DATAMACHINE_WORKER_SYSTEMD_DIR="$state_root/systemd"
+calls="$state_root/service-calls"
+mkdir -p "$SERVICE_HOME" "$SITE_PATH" "$DATAMACHINE_WORKER_LAUNCHD_DIR" "$DATAMACHINE_WORKER_SYSTEMD_DIR"
+launchctl() { printf 'launchctl %s\n' "$*" >> "$calls"; }
+systemctl() { printf 'systemctl %s\n' "$*" >> "$calls"; }
+
+WP_CMD=wp
+LOCAL_MODE=true
+PLATFORM=mac
+unset DATAMACHINE_WORKER_REQUEST WP_CODING_AGENTS_DATAMACHINE_WORKER_ENABLED
+legacy_plist="$DATAMACHINE_WORKER_LAUNCHD_DIR/com.wp.datamachine-worker.plist"
+printf 'legacy\n' > "$legacy_plist"
+datamachine_worker_reconcile >/dev/null
+[ ! -e "$legacy_plist" ]
+[ ! -e "$(datamachine_worker_state_file)" ]
+grep -q 'launchctl bootout' "$calls"
+
+WP_CODING_AGENTS_DATAMACHINE_WORKER_ENABLED=true
+[ "$(datamachine_worker_desired_state)" = enabled ]
+WP_CODING_AGENTS_DATAMACHINE_WORKER_ENABLED=false
+[ "$(datamachine_worker_desired_state)" = disabled ]
+unset WP_CODING_AGENTS_DATAMACHINE_WORKER_ENABLED
+
+DATAMACHINE_WORKER_REQUEST=enabled
+datamachine_worker_reconcile >/dev/null
+[ -f "$legacy_plist" ]
+[ "$(cat "$(datamachine_worker_state_file)")" = enabled ]
+grep -q 'launchctl bootstrap' "$calls"
+
+unset DATAMACHINE_WORKER_REQUEST
+datamachine_worker_reconcile >/dev/null
+[ -f "$legacy_plist" ]
+
+DATAMACHINE_WORKER_REQUEST=disabled
+datamachine_worker_reconcile >/dev/null
+[ ! -e "$legacy_plist" ]
+[ ! -e "$(datamachine_worker_state_file)" ]
+
+LOCAL_MODE=false
+printf 'service\n' > "$DATAMACHINE_WORKER_SYSTEMD_DIR/datamachine-worker.service"
+printf 'timer\n' > "$DATAMACHINE_WORKER_SYSTEMD_DIR/datamachine-worker.timer"
+datamachine_worker_reconcile >/dev/null
+[ ! -e "$DATAMACHINE_WORKER_SYSTEMD_DIR/datamachine-worker.service" ]
+[ ! -e "$DATAMACHINE_WORKER_SYSTEMD_DIR/datamachine-worker.timer" ]
+grep -q 'systemctl disable --now datamachine-worker.timer' "$calls"
+grep -q 'systemctl daemon-reload' "$calls"
+
 echo "PASS: tests/datamachine-worker.sh"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -153,6 +153,8 @@ while [[ $# -gt 0 ]]; do
     --repair-opencode-json) REPAIR_OPENCODE_JSON=true; shift ;;
     --skip-plugins)  SKIP_PLUGINS=true; shift ;;
     --with-ai-gateway) WITH_AI_GATEWAY=true; shift ;;
+    --with-datamachine-worker) DATAMACHINE_WORKER_REQUEST=enabled; shift ;;
+    --no-datamachine-worker) DATAMACHINE_WORKER_REQUEST=disabled; shift ;;
     --with-claude-code-auth) WITH_CLAUDE_CODE_AUTH=true; shift ;;
     --no-claude-code-auth) WITH_CLAUDE_CODE_AUTH=false; shift ;;
     --ai-gateway-provider) AI_GATEWAY_ROUTE_PROVIDER="$2"; shift 2 ;;
@@ -258,7 +260,13 @@ USAGE:
                                 for OpenCode: install/activate gateway stack,
                                 configure route, reuse existing token env, and
                                 merge a wp-ai-gateway OpenAI-compatible provider
-                                into opencode.json.
+                                 into opencode.json.
+  ./upgrade.sh --with-datamachine-worker
+                                 Opt in to the managed bounded Data Machine
+                                 worker. The choice persists across upgrades.
+  ./upgrade.sh --no-datamachine-worker
+                                 Disable the worker and remove its managed
+                                 launchd or systemd service.
   ./upgrade.sh --with-ai-gateway --rotate-ai-gateway-token
                                 Explicitly mint a replacement gateway token.
   ./upgrade.sh --with-ai-gateway --ai-gateway-provider openai --ai-gateway-model gpt-4o-mini
@@ -1304,13 +1312,13 @@ update_chat_bridge_launchd() {
   bridge_update_launchd
 }
 
-update_datamachine_worker_service() {
+reconcile_datamachine_worker_service() {
   _run_filter_active systemd || return 0
   if [ "$LOCAL_MODE" = false ] && [ "$EUID" -ne 0 ]; then
     warn "Skipping Data Machine worker unit refresh because upgrade is running non-root"
     return 0
   fi
-  datamachine_worker_update
+  datamachine_worker_reconcile
 }
 
 # ============================================================================
@@ -1528,7 +1536,7 @@ sync_runtime_instructions
 opencode_project_subagents_optional
 update_chat_bridge_systemd
 update_chat_bridge_launchd
-update_datamachine_worker_service
+reconcile_datamachine_worker_service
 refresh_opencode_runtime_signature_phase
 print_summary
 if [ "$PLUGINS_ONLY" = true ]; then


### PR DESCRIPTION
## Summary
- disable the managed Data Machine worker by default and remove unmarked legacy launchd/systemd services during setup or upgrade
- persist explicit enablement from `--with-datamachine-worker` or `WP_CODING_AGENTS_DATAMACHINE_WORKER_ENABLED=1`, with an explicit disable/removal path
- run only one bounded `wp datamachine worker run --once` pass and stop invoking unrestricted due WP-Cron events
- cover launchd/systemd desired-state reconciliation and document the operator contract

The original issue assumed a generic WP-Cron heartbeat was the right scheduler substrate. Operational evidence showed that coupling the managed worker to every due WP-Cron event was unsafe, so this narrows the service to its owning Data Machine queue and makes unattended execution explicit.

Closes #262

## Testing
- `bash tests/datamachine-worker.sh`
- `bash tests/ci-coverage.sh`
- `bash -n` across every tracked shell script
- `shellcheck -e SC1091 services/datamachine-worker.sh tests/datamachine-worker.sh`
- `git diff --check origin/main...HEAD`

The complete local shell loop also exposed pre-existing environment/platform failures in unrelated suites, including `tests/kimaki-install-existing.sh`; the focused worker and repository syntax gates pass.

## AI Assistance
GPT-5.6 Sol via OpenCode was used to investigate the existing service lifecycle, implement the desired-state reconciliation, add deterministic tests, and run verification.