### PR TITLE
Fix bounded DMC lookup budget for Studio

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -161,7 +161,7 @@ homeboy_dmc_command_json() {
 homeboy_dmc_worktree_provider_json() {
   local provider="$1"
   local task_attachment_supported="${2:-false}"
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":12000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":14000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s' \
     "$(homeboy_dmc_command_json resolve_identity "$provider")" \
     "$(homeboy_dmc_command_json attest_safety "$provider")" \
     "$(homeboy_dmc_command_json resolve "$provider")" \

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -9,9 +9,9 @@ const HOMEBOY_DMC_TASK_MAX_FIELD_BYTES = 4096;
 const HOMEBOY_DMC_TASK_MAX_OUTPUT_BYTES = 131072;
 const HOMEBOY_DMC_TASK_MAX_DMC_STDOUT_BYTES = 1048576;
 const HOMEBOY_DMC_TASK_MAX_DMC_STDERR_BYTES = 65536;
-// Leave enough of Homeboy's 12-second supervision window to reap the DMC session
+// Leave enough of Homeboy's 14-second supervision window to reap the DMC session
 // and report a typed adapter failure instead of being terminated externally.
-const HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = 8;
+const HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = 10;
 const HOMEBOY_DMC_TASK_TERMINATION_GRACE_SECONDS = 1;
 const HOMEBOY_DMC_ATTACHMENT_TIMEOUT_SECONDS = 30;
 

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -79,7 +79,7 @@ expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "sa
 expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", sys.argv[5], sys.argv[4], "{identity}", "{base}"]
 expected_attachment_preview = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "task_attachment_preview", sys.argv[5], sys.argv[4], "{handle}", "{task_url}"]
 expected_attachment_apply = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "task_attachment_apply", "{handle}", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "attach-tracker", "{handle}", "--task-url={task_url}", "--format=json", f"--path={sys.argv[3]}"]
-if provider.get("lookup_timeout_ms") != 12000:
+if provider.get("lookup_timeout_ms") != 14000:
     raise SystemExit("FAIL: Homeboy must reserve a supervision margin beyond the DMC adapter budget")
 adapter = open(commands["resolve_task"][1], encoding="utf-8").read()
 adapter_budget = int(re.search(r"HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = (\d+)", adapter).group(1))
@@ -319,7 +319,7 @@ if http_zero_padded_port.returncode or json.loads(http_zero_padded_port.stdout) 
 started = time.monotonic()
 large_inventory = run("large_inventory")
 elapsed = time.monotonic() - started
-if large_inventory.returncode or json.loads(large_inventory.stdout) != expected or elapsed >= 12:
+if large_inventory.returncode or json.loads(large_inventory.stdout) != expected or elapsed >= 14:
     raise SystemExit(f"FAIL: exact-task projection did not complete within Homeboy's declared supervision budget: {large_inventory!r}, elapsed={elapsed}")
 largest_success = run("largest_success")
 largest_rows = json.loads(largest_success.stdout) if largest_success.returncode == 0 else []
@@ -359,7 +359,7 @@ def assert_descendant_stopped(mode, expected_error, timeout):
             raise SystemExit(f"FAIL: {mode} lookup left process {pid} alive")
 
 assert_descendant_stopped("descendant_both", "bounded ", 5)
-assert_descendant_stopped("descendant_silent", "execution exceeded the adapter budget", 11)
+assert_descendant_stopped("descendant_silent", "execution exceeded the adapter budget", 13)
 PY
 }
 
@@ -584,8 +584,8 @@ if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree list" ]; then
       safety='{"dirty":false,"unpushed":false,"primary":false}'
       [ "${DMC_TASK_LOOKUP_MODE:-}" = incomplete_safety ] && safety='{"dirty":false,"primary":false}'
       if [ "${DMC_TASK_LOOKUP_MODE:-}" = large_inventory ]; then
-        i=1
-        while [ "$i" -le 5000 ]; do i=$((i + 1)); done
+        # Model the process-startup floor observed through WordPress Studio.
+        sleep 9
       fi
       [ "${DMC_TASK_LOOKUP_MODE:-}" = diagnostic_prefix ] && printf '\nDeprecated: Case statements followed by a semicolon are deprecated.\n'
       [ "${DMC_TASK_LOOKUP_MODE:-}" = arbitrary_prefix ] && printf 'unexpected output\n'


### PR DESCRIPTION
## Summary

- raise the bounded DMC child lookup budget from 8 to 10 seconds for observed WordPress Studio startup time
- raise Homeboy provider supervision from 12 to 14 seconds, preserving the existing three-second cleanup and reporting margin
- make the realistic transport timing fixture prove that a 9-second startup floor succeeds
- retain deterministic timeout and descendant process-group reaping coverage

Closes #468.

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `git diff --check`
- Real WordPress Studio `resolve_task` replay returned typed `worktree_not_found` in 6.71 seconds against active Data Machine Code `0.71.1`.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the layered Homeboy/DMC failures, measured the supported Studio transport floor, implemented the bounded timeout adjustment and regression, and ran the verification. Chris Huber directed the control-plane recovery and reviewed the scope.
