### PR TITLE
Fix plugin upgrade terminal verification

### DIFF
--- a/lib/plugin-upgrade.sh
+++ b/lib/plugin-upgrade.sh
@@ -151,7 +151,24 @@ import json
 import os
 
 slug = os.environ['PLUGIN_STATE_SLUG']
-for plugin in json.loads(os.environ['PLUGIN_STATES_JSON']):
+raw = os.environ['PLUGIN_STATES_JSON']
+decoder = json.JSONDecoder()
+plugins = None
+for offset, character in enumerate(raw):
+    if character != '[':
+        continue
+    try:
+        candidate, _ = decoder.raw_decode(raw[offset:])
+    except json.JSONDecodeError:
+        continue
+    if isinstance(candidate, list):
+        plugins = candidate
+        break
+if plugins is None:
+    raise SystemExit(2)
+for plugin in plugins:
+    if not isinstance(plugin, dict):
+        continue
     if plugin.get('name') == slug:
         print('%s\t%s' % (plugin.get('version', ''), plugin.get('status', '')))
         raise SystemExit(0)
@@ -238,7 +255,7 @@ plugin_update_pointer_changed() {
 }
 
 plugin_update_verify_installed_plugins() {
-  local slugs=("$@") slug plugin_dir tuple version status file_version phase_status=0 failed=false
+  local slugs=("$@") slug plugin_dir tuple version status active file_version phase_status=0 failed=false
   if [ "${DRY_RUN:-false}" = true ]; then
     for slug in "${slugs[@]}"; do
       [ -d "$SITE_PATH/wp-content/plugins/$slug" ] || continue
@@ -280,7 +297,8 @@ plugin_update_verify_installed_plugins() {
       version=""; status="missing"
     fi
     file_version="$(plugin_update_local_version "$slug" 2>/dev/null || true)"
-    log "[$slug] installed-after version=${version:-missing} active=$( case "$status" in active|active-network) printf yes ;; *) printf no ;; esac ) file_version=${file_version:-missing}"
+    case "$status" in active|active-network) active=yes ;; *) active=no ;; esac
+    log "[$slug] installed-after version=${version:-missing} active=$active file_version=${file_version:-missing}"
     if [ -z "$version" ] || [ "$version" != "$file_version" ] || [ "$status" = missing ]; then
       plugin_update_record_failure "$slug" verification 1
       failed=true

--- a/tests/plugin-upgrade-bounds.sh
+++ b/tests/plugin-upgrade-bounds.sh
@@ -29,6 +29,13 @@ slow="$ROOT_DIR/tests/fixtures/plugin-updates/slow.sh"
 hung="$ROOT_DIR/tests/fixtures/plugin-updates/hung.sh"
 partial="$ROOT_DIR/tests/fixtures/plugin-updates/partial-pointer-hung.sh"
 
+# WordPress Studio may emit a PHP preamble on stdout before valid WP-CLI JSON.
+plugin_update_state_from_json $'\nDeprecated: fixture warning\n[{"name":"data-machine-code","status":"active","version":"1.2.3"}]' data-machine-code || fail "preamble-bearing plugin JSON was refused"
+[ "$PLUGIN_STATE_TUPLE" = $'1.2.3\tactive' ] || fail "preamble-bearing plugin JSON returned the wrong state"
+if plugin_update_state_from_json $'Deprecated: no JSON follows' data-machine-code; then
+  fail "malformed plugin output was accepted"
+fi
+
 # A slow child emits progress and still completes under its deadline.
 PLUGIN_FIXTURE_SLEEP_SECONDS=2 plugin_update_run_phase fixture slow-sync "$slow" || fail "slow fixture timed out"
 [ "$PLUGIN_PHASE_OUTPUT" = slow-fixture-complete ] || fail "slow fixture output was not retained"


### PR DESCRIPTION
## Summary

- decode the first valid plugin-state JSON array after bounded WP-CLI stdout preambles
- reject output without a valid array or requested plugin object
- replace malformed inline `case` command substitution with valid active-status rendering
- cover preamble acceptance and malformed-payload refusal in the bounded upgrade harness

Closes #471.

## Verification

- `bash -n lib/plugin-upgrade.sh tests/plugin-upgrade-bounds.sh`
- `shellcheck lib/plugin-upgrade.sh tests/plugin-upgrade-bounds.sh`
- `bash tests/plugin-upgrade-bounds.sh`
- real WordPress Studio no-op convergence: DMC `0.72.1` active, release pointer verified, `PLUGIN_UPGRADE_RESULT=complete`
- `git diff --check`

## AI assistance

OpenCode with `openai/gpt-5.6-sol` reproduced the false deployment failure, implemented the parser and shell corrections, and ran deterministic plus real Studio verification under human direction.