### PR TITLE
fix(homeboy): negotiate standalone DMC task lookup

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -130,6 +130,9 @@ homeboy_dmc_command_json() {
       # probing its safety fields; the adapter refuses any continuation.
       homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve_task '{task_url}' "${wp_argv[@]}" datamachine-code workspace worktree list '--task-ref={task_url}' --with-status --limit=200 --envelope --format=json "${wp_flags[@]}"
       ;;
+    resolve_task_standalone)
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" resolve_task_standalone '{task_url}' "$provider" "$DM_WORKSPACE_DIR"
+      ;;
     task_attachment_preview)
       homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" task_attachment_preview "$provider" "$DM_WORKSPACE_DIR" '{handle}' '{task_url}'
       ;;
@@ -161,12 +164,19 @@ homeboy_dmc_command_json() {
 homeboy_dmc_worktree_provider_json() {
   local provider="$1"
   local task_attachment_supported="${2:-false}"
+  local task_resolution_supported="${3:-false}"
+  local resolve_task
+  if [ "$task_resolution_supported" = true ]; then
+    resolve_task="$(homeboy_dmc_command_json resolve_task_standalone "$provider")"
+  else
+    resolve_task="$(homeboy_dmc_command_json resolve_task "$provider")"
+  fi
   printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":12000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s' \
     "$(homeboy_dmc_command_json resolve_identity "$provider")" \
     "$(homeboy_dmc_command_json attest_safety "$provider")" \
     "$(homeboy_dmc_command_json resolve "$provider")" \
     "$(homeboy_dmc_command_json resolve_path "$provider")" \
-    "$(homeboy_dmc_command_json resolve_task "$provider")"
+    "$resolve_task"
   if [ "$task_attachment_supported" = true ]; then
     printf ',"task_attachment_preview":%s,"task_attachment_apply":%s' \
       "$(homeboy_dmc_command_json task_attachment_preview "$provider")" \
@@ -197,6 +207,28 @@ sys.exit(0 if (
     and "task_url" in payload.get("tracker_fields", [])
     and payload.get("attachment_operation") == "datamachine-code/workspace-worktree-attach-tracker"
     and payload.get("attachment_standalone") is False
+) else 1)
+' >/dev/null 2>&1
+}
+
+homeboy_dmc_task_resolution_capable() {
+  local provider="$1" response
+  response="$(php "$provider" capabilities 2>/dev/null)" || return 1
+  printf '%s' "$response" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+sys.exit(0 if (
+    payload.get("schema") == "datamachine-code/worktree-provider-capabilities/v1"
+    and isinstance(payload.get("operations"), list)
+    and "task" in payload["operations"]
+    and payload.get("task_resolution_schema") == "datamachine-code/worktree-task-resolution/v1"
+    and payload.get("task_resolution_limit") == 200
 ) else 1)
 ' >/dev/null 2>&1
 }
@@ -663,7 +695,7 @@ configure_homeboy_dmc_worktree_provider() {
     return 0
   fi
 
-  local provider provider_json task_attachment_supported=false
+  local provider provider_json task_attachment_supported=false task_resolution_supported=false
   provider="$(homeboy_dmc_worktree_provider_executable)" || {
     homeboy_handle_failure "Data Machine Code standalone worktree provider source contract is unavailable; skipping Homeboy DMC worktree provider setup."
     return 0
@@ -671,7 +703,10 @@ configure_homeboy_dmc_worktree_provider() {
   if homeboy_dmc_task_attachment_capable "$provider" && homeboy_task_attachment_commands_supported; then
     task_attachment_supported=true
   fi
-  provider_json="$(homeboy_dmc_worktree_provider_json "$provider" "$task_attachment_supported")"
+  if homeboy_dmc_task_resolution_capable "$provider"; then
+    task_resolution_supported=true
+  fi
+  provider_json="$(homeboy_dmc_worktree_provider_json "$provider" "$task_attachment_supported" "$task_resolution_supported")"
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} homeboy config set /worktree_providers/dmc '$provider_json'"

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -332,6 +332,84 @@ if ( 'task_attachment_apply' === $operation ) {
 	exit(0);
 }
 
+if ( 'resolve_task_standalone' === $operation ) {
+	$task_url = $canonical_task_url((string) ( $argv[2] ?? '' ));
+	$provider = (string) ( $argv[3] ?? '' );
+	$workspace = (string) ( $argv[4] ?? '' );
+	if ( '' === $task_url || '' === $provider || '' === $workspace ) {
+		fwrite(STDERR, "Usage: homeboy-dmc-provider.php resolve_task_standalone <task-url> <dmc-provider> <workspace-root>\n");
+		exit(2);
+	}
+	try {
+		$capture = $run_bounded_command(array( PHP_BINARY, $provider, 'task', $workspace, $task_url ), HOMEBOY_DMC_TASK_MAX_DMC_STDOUT_BYTES, HOMEBOY_DMC_TASK_MAX_DMC_STDERR_BYTES);
+	} catch (Throwable $error) {
+		fwrite(STDERR, $error->getMessage() . "\n");
+		exit(1);
+	}
+	if ( null !== $capture['failure'] ) {
+		fwrite(STDERR, "DMC standalone task resolution exceeded its bounded execution or capture.\n");
+		exit(1);
+	}
+	if ( 0 !== $capture['status'] ) {
+		fwrite(STDERR, 'DMC standalone task resolution failed: ' . trim($capture['stderr']) . "\n");
+		exit($capture['status'] > 0 && $capture['status'] < 256 ? $capture['status'] : 1);
+	}
+	try {
+		$payload = $decode_json_output($capture['stdout']);
+	} catch (Throwable $error) {
+		fwrite(STDERR, "DMC standalone task resolution returned invalid JSON.\n");
+		exit(1);
+	}
+	$candidates = is_array($payload) ? ( $payload['candidates'] ?? null ) : null;
+	if (
+		! is_array($payload) || 'datamachine-code/worktree-task-resolution/v1' !== ( $payload['schema'] ?? null )
+		|| 'complete' !== ( $payload['status'] ?? null ) || $task_url !== $canonical_task_url((string) ( $payload['task_url'] ?? '' ))
+		|| ! is_array($candidates) || ! array_is_list($candidates) || ! is_int($payload['total'] ?? null)
+		|| $payload['total'] !== count($candidates) || count($candidates) > HOMEBOY_DMC_TASK_MAX_CANDIDATES
+	) {
+		fwrite(STDERR, "DMC standalone task resolution returned an incomplete contract.\n");
+		exit(1);
+	}
+	$result = array();
+	foreach ( $candidates as $candidate ) {
+		$safety = is_array($candidate) && is_array($candidate['safety'] ?? null) ? $candidate['safety'] : null;
+		if (
+			! is_array($candidate) || ! is_string($candidate['handle'] ?? null) || '' === $candidate['handle']
+			|| ! is_string($candidate['path'] ?? null) || '' === $candidate['path']
+			|| ! is_string($candidate['branch'] ?? null) || '' === $candidate['branch']
+			|| $task_url !== $canonical_task_url((string) ( $candidate['task_url'] ?? '' ))
+			|| ! is_array($safety) || ! is_bool($safety['dirty'] ?? null) || ! is_bool($safety['unpushed'] ?? null) || ! is_bool($safety['primary'] ?? null)
+		) {
+			fwrite(STDERR, "DMC standalone task resolution returned an incomplete or mismatched candidate.\n");
+			exit(1);
+		}
+		foreach ( array( 'handle', 'path', 'branch', 'task_url' ) as $field ) {
+			if ( strlen($candidate[ $field ]) > HOMEBOY_DMC_TASK_MAX_FIELD_BYTES ) {
+				fwrite(STDERR, "DMC standalone task resolution field exceeds its bounded limit.\n");
+				exit(1);
+			}
+		}
+		$result[] = array(
+			'handle'   => $candidate['handle'],
+			'path'     => $candidate['path'],
+			'branch'   => $candidate['branch'],
+			'task_url' => $task_url,
+			'safety'   => $safety,
+		);
+	}
+	if ( array() === $result ) {
+		fwrite(STDOUT, json_encode(array( 'success' => false, 'error' => array( 'code' => 'worktree_not_found', 'message' => 'DMC has no worktrees for the requested task.' ) ), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n");
+		exit(42);
+	}
+	$serialized = json_encode($result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+	if ( strlen($serialized) > HOMEBOY_DMC_TASK_MAX_OUTPUT_BYTES ) {
+		fwrite(STDERR, "DMC standalone task resolution exceeded its bounded output.\n");
+		exit(1);
+	}
+	fwrite(STDOUT, $serialized . "\n");
+	exit(0);
+}
+
 if ( 'resolve_task' === $operation ) {
 	$task_url = $canonical_task_url((string) ( $argv[2] ?? '' ));
 	$command  = array_slice($argv, 3);

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -58,7 +58,7 @@ assert_not_contains() {
 }
 
 assert_provider_contract() {
-  python3 - "$1" "$2" "$3" "$DM_WORKSPACE_DIR" "$DMC_PROVIDER_EXECUTABLE" <<'PY'
+  python3 - "$1" "$2" "$3" "$DM_WORKSPACE_DIR" "$DMC_PROVIDER_EXECUTABLE" "${4:-standalone}" <<'PY'
 import json
 import re
 import sys
@@ -71,7 +71,9 @@ provider = json.loads(payload)
 commands = provider["commands"]
 expected_resolve = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{handle}"]
 expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve", sys.argv[5], sys.argv[4], "{path}"]
-expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "--task-ref={task_url}", "--with-status", "--limit=200", "--envelope", "--format=json", f"--path={sys.argv[3]}"]
+expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task_standalone", "{task_url}", sys.argv[5], sys.argv[4]]
+if sys.argv[6] == "fallback":
+    expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "--task-ref={task_url}", "--with-status", "--limit=200", "--envelope", "--format=json", f"--path={sys.argv[3]}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", sys.argv[5], sys.argv[4], "{handle}"]
@@ -363,6 +365,42 @@ assert_descendant_stopped("descendant_silent", "execution exceeded the adapter b
 PY
 }
 
+assert_standalone_task_resolution_contract() {
+  python3 - "$1" "$STUDIO_LOG" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+lines = [line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/worktree_providers/dmc|")]
+_, payload = lines[-1].split("|", 1)
+command = json.loads(payload)["commands"]["resolve_task"]
+task = "https://github.com/Extra-Chill/wp-coding-agents/issues/425"
+
+def run(mode):
+    env = os.environ.copy()
+    env["DMC_TASK_LOOKUP_MODE"] = mode
+    return subprocess.run([part.replace("{task_url}", task) for part in command], text=True, capture_output=True, env=env)
+
+missing = run("zero")
+if missing.returncode != 42 or json.loads(missing.stdout).get("error", {}).get("code") != "worktree_not_found":
+    raise SystemExit(f"FAIL: standalone task absence was not typed: {missing!r}")
+
+resolved = run("one")
+rows = json.loads(resolved.stdout) if resolved.returncode == 0 else []
+if len(rows) != 1 or rows[0].get("handle") != "fixture@task-425" or rows[0].get("task_url") != task:
+    raise SystemExit(f"FAIL: standalone task resolution was not preserved: {resolved!r}")
+
+for mode in ("malformed", "mismatched_task", "incomplete_safety", "failure"):
+    failed = run(mode)
+    if failed.returncode == 0 or failed.stdout:
+        raise SystemExit(f"FAIL: standalone {mode} response did not fail closed: {failed!r}")
+
+if "wp datamachine-code workspace worktree list" in open(sys.argv[2], encoding="utf-8").read():
+    raise SystemExit("FAIL: standalone task resolution invoked studio wp")
+PY
+}
+
 assert_task_attachment_contract() {
   python3 - "$1" <<'PY'
 import json
@@ -487,9 +525,41 @@ if ('capabilities' === $operation) {
     }
     echo json_encode(array(
         'schema' => 'datamachine-code/worktree-provider-capabilities/v1',
+        'operations' => 'task_legacy' === getenv('DMC_CAPABILITIES_MODE') ? array('identity', 'safety', 'converge', 'capabilities') : array('identity', 'task', 'safety', 'converge', 'capabilities'),
         'tracker_fields' => array('task_url', 'task_ref'),
         'attachment_operation' => 'datamachine-code/workspace-worktree-attach-tracker',
         'attachment_standalone' => false,
+        'task_resolution_schema' => 'datamachine-code/worktree-task-resolution/v1',
+        'task_resolution_limit' => 200,
+    )) . "\n";
+    exit(0);
+}
+if ('task' === $operation) {
+    $task_url = $argv[3] ?? '';
+    $mode = getenv('DMC_TASK_LOOKUP_MODE') ?: 'zero';
+    if ('failure' === $mode) {
+        fwrite(STDERR, "standalone task failure\n");
+        exit(17);
+    }
+    if ('malformed' === $mode) {
+        echo "not-json\n";
+        exit(0);
+    }
+    $candidate_task = 'mismatched_task' === $mode ? 'https://github.com/Extra-Chill/wp-coding-agents/issues/other' : $task_url;
+    $safety = 'incomplete_safety' === $mode ? array('dirty' => false, 'primary' => false) : array('dirty' => false, 'unpushed' => false, 'primary' => false);
+    $candidates = 'zero' === $mode ? array() : array(array(
+        'handle' => 'fixture@task-425',
+        'path' => getenv('DMC_STATE'),
+        'branch' => 'fix/425-resolve-task',
+        'task_url' => $candidate_task,
+        'safety' => $safety,
+    ));
+    echo json_encode(array(
+        'schema' => 'datamachine-code/worktree-task-resolution/v1',
+        'status' => 'complete',
+        'task_url' => $task_url,
+        'total' => count($candidates),
+        'candidates' => $candidates,
     )) . "\n";
     exit(0);
 }
@@ -723,7 +793,7 @@ assert_contains "\"attest_safety\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-pr
 assert_contains "\"converge\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"converge\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{identity}\",\"{base}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_path\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{path}\"]" "$TMP/dry-run.log"
-assert_contains "\"resolve_task\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve_task\",\"{task_url}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"list\",\"--task-ref={task_url}\",\"--with-status\",\"--limit=200\",\"--envelope\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"resolve_task\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"resolve_task_standalone\",\"{task_url}\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\"]" "$TMP/dry-run.log"
 assert_contains "\"task_attachment_preview\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"task_attachment_preview\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{handle}\",\"{task_url}\"]" "$TMP/dry-run.log"
 assert_contains "\"task_attachment_apply\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"task_attachment_apply\",\"{handle}\",\"{task_url}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"attach-tracker\",\"{handle}\",\"--task-url={task_url}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
@@ -768,10 +838,22 @@ assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
 assert_convergence_contract "$HOMEBOY_CONFIG_LOG"
 assert_resolution_contract "$HOMEBOY_CONFIG_LOG"
-assert_task_resolution_contract "$HOMEBOY_CONFIG_LOG"
+assert_standalone_task_resolution_contract "$HOMEBOY_CONFIG_LOG"
 assert_task_attachment_contract "$HOMEBOY_CONFIG_LOG"
 assert_not_contains 'wp datamachine-code workspace worktree list fixture --all --full --format=json' "$STUDIO_LOG"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
+
+# Older DMC capability payloads keep the bounded WordPress lookup adapter.
+DMC_CAPABILITIES_MODE=task_legacy
+export DMC_CAPABILITIES_MODE
+: > "$HOMEBOY_CONFIG_LOG"
+: > "$STUDIO_LOG"
+rm -f "$DMC_STATE"
+configure_homeboy_dmc_worktree_provider > "$TMP/task-legacy.log"
+assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH" fallback
+assert_task_resolution_contract "$HOMEBOY_CONFIG_LOG"
+assert_contains 'wp datamachine-code workspace worktree list' "$STUDIO_LOG"
+unset DMC_CAPABILITIES_MODE
 
 # A source checkout can expose the provider outside the historical installed-plugin path.
 DMC_PROVIDER_EXECUTABLE="$TMP/dmc-source/bin/dmc-worktree-provider"


### PR DESCRIPTION
## Summary
- negotiate the standalone DMC `task` capability and route Homeboy task resolution through it
- retain the bounded WordPress lookup adapter for older DMC capability payloads
- validate the standalone response and fail closed on malformed, mismatched, incomplete, oversized, or failed results

Closes #470.

## Verification
- `bash tests/homeboy-dmc-provider.sh`
- `shellcheck -e SC2034 lib/homeboy.sh tests/homeboy-dmc-provider.sh`
- `bash tests/ci-coverage.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- all repository shell files pass `bash -n`
- real DMC standalone lookup resolved this issue worktree without invoking WordPress

## AI Assistance
GPT-5.6-sol via OpenCode implemented the capability negotiation and response validation, expanded the contract fixtures, and ran the verification above under human direction.