### PR TITLE
Fix local subagent graph JSON isolation

### DIFF
--- a/lib/opencode-subagents.sh
+++ b/lib/opencode-subagents.sh
@@ -160,6 +160,28 @@ sys.stdout.buffer.write(value)
       return 1
     }
     rm -f "$reader_error"
+    agent_json="$(printf '%s' "$agent_json" | python3 -c '
+import json
+import re
+import sys
+
+lines = sys.stdin.read().splitlines()
+while lines and not lines[0].strip():
+    lines.pop(0)
+while lines and re.match(r"^(?:PHP )?(?:Deprecated|Warning|Notice):\s", lines[0].lstrip()):
+    lines.pop(0)
+    while lines and not lines[0].strip():
+        lines.pop(0)
+try:
+    value = json.loads("\n".join(lines))
+except (json.JSONDecodeError, ValueError):
+    raise SystemExit(1)
+json.dump(value, sys.stdout, separators=(",", ":"))
+')" || {
+      OPENCODE_SUBAGENT_PROJECTION_FAILURE=invalid_wp_cli_response
+      warn "Local subagent graph returned invalid or contaminated JSON"
+      return 1
+    }
   fi
   local source
   local before after

--- a/tests/opencode-subagents-optional.sh
+++ b/tests/opencode-subagents-optional.sh
@@ -28,7 +28,7 @@ if [ "${#PENDING_ITEMS[@]}" -ne 1 ] || [ "${PENDING_ITEMS[0]}" != "OpenCode suba
   exit 1
 fi
 
-for failure in missing_reader missing_projector wp_cli_read invalid_transport_response projector; do
+for failure in missing_reader missing_projector wp_cli_read invalid_transport_response invalid_wp_cli_response projector; do
   PENDING_ITEMS=()
   OPENCODE_SUBAGENT_PROJECTION_FAILURE="$failure"
   if opencode_project_subagents_optional > "$output" 2>&1; then

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -37,6 +37,14 @@ assert graph['source_mode'] == 'embedded'
 PY
       cat "$TMP/graph.json"
       ;;
+    diagnostic-graph)
+      printf '\nDeprecated: fixture diagnostic\n\n'
+      cat "$TMP/graph.json"
+      ;;
+    contaminated-graph)
+      printf '%s\n' 'unexpected bootstrap prose'
+      cat "$TMP/graph.json"
+      ;;
     unregistered) php "$SCRIPT_DIR/tests/opencode-subagents-reader.php" --payload-unregistered "$2" ;;
     read-failure) printf '%s\n' 'WP-CLI bootstrap failed' >&2; return 1 ;;
   esac
@@ -116,6 +124,14 @@ assert config['permission']['skill']['root-skill'] == 'allow'
 assert config['permission']['skill']['user-skill'] == 'ask'
 assert open(sys.argv[1].replace('.wp-coding-agents-subagents.json', 'skills/root-skill/SKILL.md'), 'rb').read().startswith(b'---\nname: root-skill\n')
 PY
+WP_CMD_MODE=diagnostic-graph
+opencode_project_subagents
+printf '  ok   recognized PHP diagnostics do not contaminate local graph JSON\n'
+WP_CMD_MODE=contaminated-graph
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+[ "${OPENCODE_SUBAGENT_PROJECTION_FAILURE:-}" = invalid_wp_cli_response ] || FAILED=$((FAILED + 1))
+WP_CMD_MODE=graph
+printf '  ok   arbitrary graph output prefixes remain hard failures\n'
 if command -v opencode >/dev/null 2>&1; then
   (cd "$SITE_PATH" && opencode agent list --pure >/dev/null)
   printf '  ok   OpenCode parses generated agent and skill files\n'


### PR DESCRIPTION
## Summary

- isolate recognized PHP diagnostic preambles before local OpenCode subagent graph projection
- reject arbitrary stdout contamination with a typed hard-failure classification
- cover accepted diagnostics and refused prefixes through the real projection path

Closes #475.

## Verification

- `bash tests/opencode-subagents.sh`
- `bash tests/opencode-subagents-optional.sh`
- `bash -n lib/opencode-subagents.sh tests/opencode-subagents.sh tests/opencode-subagents-optional.sh`
- `shellcheck -e SC1091,SC2030,SC2031,SC2034 lib/opencode-subagents.sh tests/opencode-subagents.sh tests/opencode-subagents-optional.sh`
- `bash tests/ci-coverage.sh`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the WordPress Studio upgrade failure, implemented bounded JSON isolation, added regression coverage, and ran verification under Chris Huber's direction.