### PR TITLE
Deduplicate overlapping managed skill roots

### DIFF
--- a/lib/skills.sh
+++ b/lib/skills.sh
@@ -131,21 +131,42 @@ _resolve_skills_dir_for_runtime() {
   )
 }
 
+# Return whether a detected runtime discovers both skill directories. Runtime
+# discovery roots may overlap even when their native install directories differ.
+_managed_skill_dirs_overlap() {
+  local first_dir="$1" second_dir="$2"
+  local rt rt_file discovery_dir has_first has_second
+
+  for rt in "${DETECTED_RUNTIMES[@]:-$RUNTIME}"; do
+    rt_file="$SCRIPT_DIR/runtimes/${rt}.sh"
+    [ -f "$rt_file" ] || continue
+    has_first=false
+    has_second=false
+
+    while IFS= read -r discovery_dir; do
+      [ "$discovery_dir" = "$first_dir" ] && has_first=true
+      [ "$discovery_dir" = "$second_dir" ] && has_second=true
+    done < <(
+      # shellcheck disable=SC1090
+      source "$rt_file"
+      runtime_skill_discovery_dirs
+    )
+
+    [ "$has_first" = true ] && [ "$has_second" = true ] && return 0
+  done
+
+  return 1
+}
+
 # Resolve both the runtime roots that may contain managed skills and the
-# canonical targets to populate. OpenCode discovers Claude's skill root, so a
-# dual Claude Code + OpenCode install needs only the Claude copy.
+# canonical targets to populate. Select the first native target in each set of
+# overlapping discovery roots.
 _resolve_managed_skill_dirs() {
   local -a runtimes=("${DETECTED_RUNTIMES[@]:-$RUNTIME}")
-  local has_claude=false has_opencode=false
-  local rt dir seen_dir already
+  local rt dir seen_dir target already overlaps
 
   WP_CODING_AGENTS_SKILL_ROOTS=()
   WP_CODING_AGENTS_SKILL_TARGETS=()
-
-  for rt in "${runtimes[@]}"; do
-    [ "$rt" = "claude-code" ] && has_claude=true
-    [ "$rt" = "opencode" ] && has_opencode=true
-  done
 
   for rt in "${runtimes[@]}"; do
     dir="$(_resolve_skills_dir_for_runtime "$rt")"
@@ -157,15 +178,11 @@ _resolve_managed_skill_dirs() {
     done
     [ "$already" = true ] || WP_CODING_AGENTS_SKILL_ROOTS+=("$dir")
 
-    if [ "$rt" = "opencode" ] && [ "$has_claude" = true ] && [ "$has_opencode" = true ]; then
-      continue
-    fi
-
-    already=false
-    for seen_dir in "${WP_CODING_AGENTS_SKILL_TARGETS[@]}"; do
-      [ "$seen_dir" = "$dir" ] && { already=true; break; }
+    overlaps=false
+    for target in "${WP_CODING_AGENTS_SKILL_TARGETS[@]}"; do
+      _managed_skill_dirs_overlap "$target" "$dir" && { overlaps=true; break; }
     done
-    [ "$already" = true ] || WP_CODING_AGENTS_SKILL_TARGETS+=("$dir")
+    [ "$overlaps" = true ] || WP_CODING_AGENTS_SKILL_TARGETS+=("$dir")
   done
 
   [ ${#WP_CODING_AGENTS_SKILL_TARGETS[@]} -gt 0 ] \

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -345,6 +345,10 @@ runtime_skills_dir() {
   echo "$SITE_PATH/.claude/skills"
 }
 
+runtime_skill_discovery_dirs() {
+  runtime_skills_dir
+}
+
 runtime_print_summary() {
   echo "Claude Code:"
   echo "  Config:   $SITE_PATH/CLAUDE.md"

--- a/runtimes/codex.sh
+++ b/runtimes/codex.sh
@@ -340,6 +340,10 @@ runtime_skills_dir() {
   echo "$SITE_PATH/.agents/skills"
 }
 
+runtime_skill_discovery_dirs() {
+  runtime_skills_dir
+}
+
 runtime_start_cmd() {
   echo "cd $SITE_PATH && codex"
 }

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -485,6 +485,11 @@ runtime_skills_dir() {
   echo "$SITE_PATH/.opencode/skills"
 }
 
+runtime_skill_discovery_dirs() {
+  printf '%s\n' "$SITE_PATH/.claude/skills" "$SITE_PATH/.agents/skills"
+  runtime_skills_dir
+}
+
 runtime_print_summary() {
   echo "OpenCode:"
   echo "  Config:   $SITE_PATH/opencode.json"

--- a/tests/managed-skill-targets.sh
+++ b/tests/managed-skill-targets.sh
@@ -88,42 +88,57 @@ run_case opencode opencode opencode
 assert_present "$SITE_PATH/.opencode/skills/upgrade-wp-coding-agents/SKILL.md" "uses .opencode/skills"
 assert_missing "$SITE_PATH/.claude/skills/upgrade-wp-coding-agents" "does not create Claude target"
 
+echo "==> Codex only"
+run_case codex codex codex
+assert_present "$SITE_PATH/.agents/skills/upgrade-wp-coding-agents/SKILL.md" "uses .agents/skills"
+assert_missing "$SITE_PATH/.claude/skills/upgrade-wp-coding-agents" "does not create Claude target"
+
 echo "==> Claude Code only"
 run_case claude claude-code claude-code
 assert_present "$SITE_PATH/.claude/skills/upgrade-wp-coding-agents/SKILL.md" "uses .claude/skills"
 assert_missing "$SITE_PATH/.opencode/skills/upgrade-wp-coding-agents" "does not create OpenCode target"
 
-echo "==> dual runtime cleanup and preservation"
-SITE_PATH="$TMP/dual"
+echo "==> Claude Code, Codex, and OpenCode overlap cleanup and preservation"
+SITE_PATH="$TMP/overlap"
 seed_root "$SITE_PATH/.claude/skills"
 seed_root "$SITE_PATH/.opencode/skills"
+seed_root "$SITE_PATH/.agents/skills"
 RUNTIME=claude-code
-DETECTED_RUNTIMES=(claude-code opencode)
+DETECTED_RUNTIMES=(claude-code opencode codex)
 install_skills
 assert_present "$SITE_PATH/.claude/skills/upgrade-wp-coding-agents/SKILL.md" "keeps canonical Claude copy"
 assert_eq "$SKILLS_DIR" "$SITE_PATH/.claude/skills" "reports the canonical target"
 assert_missing "$SITE_PATH/.opencode/skills/upgrade-wp-coding-agents" "removes noncanonical OpenCode copy"
+assert_missing "$SITE_PATH/.agents/skills/upgrade-wp-coding-agents" "removes noncanonical Codex copy"
 assert_missing "$SITE_PATH/.claude/skills/wp-coding-agents-setup" "removes retired Claude copy"
 assert_missing "$SITE_PATH/.opencode/skills/wp-coding-agents-setup" "removes retired OpenCode copy"
+assert_missing "$SITE_PATH/.agents/skills/wp-coding-agents-setup" "removes retired Codex copy"
 assert_present "$SITE_PATH/.claude/skills/user-skill/SKILL.md" "preserves Claude user skill"
 assert_present "$SITE_PATH/.opencode/skills/user-skill/SKILL.md" "preserves OpenCode user skill"
+assert_present "$SITE_PATH/.agents/skills/user-skill/SKILL.md" "preserves Codex user skill"
 SUMMARY_OUTPUT="$(log() { printf '%s\n' "$1"; }; print_skills_summary)"
 assert_contains "$SUMMARY_OUTPUT" "$SITE_PATH/.claude/skills/" "summary reports canonical Claude target"
 assert_not_contains "$SUMMARY_OUTPUT" "$SITE_PATH/.opencode/skills/" "summary omits noncanonical OpenCode target"
+assert_not_contains "$SUMMARY_OUTPUT" "$SITE_PATH/.agents/skills/" "summary omits noncanonical Codex target"
 
-echo "==> dual runtime install is idempotent"
+echo "==> overlap install is idempotent"
 install_skills
 assert_present "$SITE_PATH/.claude/skills/upgrade-wp-coding-agents/SKILL.md" "canonical copy remains after rerun"
 assert_missing "$SITE_PATH/.opencode/skills/upgrade-wp-coding-agents" "duplicate remains absent after rerun"
+assert_missing "$SITE_PATH/.agents/skills/upgrade-wp-coding-agents" "Codex duplicate remains absent after rerun"
 assert_present "$SITE_PATH/.opencode/skills/user-skill/SKILL.md" "user skill remains after rerun"
+assert_present "$SITE_PATH/.agents/skills/user-skill/SKILL.md" "Codex user skill remains after rerun"
 
 echo "==> dry run preserves managed directories"
 seed_root "$SITE_PATH/.opencode/skills"
+seed_root "$SITE_PATH/.agents/skills"
 DRY_RUN=true
 install_skills >/dev/null
 DRY_RUN=false
 assert_present "$SITE_PATH/.opencode/skills/upgrade-wp-coding-agents/SKILL.md" "dry run preserves duplicate"
 assert_present "$SITE_PATH/.opencode/skills/wp-coding-agents-setup/SKILL.md" "dry run preserves retired skill"
+assert_present "$SITE_PATH/.agents/skills/upgrade-wp-coding-agents/SKILL.md" "dry run preserves Codex duplicate"
+assert_present "$SITE_PATH/.agents/skills/wp-coding-agents-setup/SKILL.md" "dry run preserves Codex retired skill"
 
 echo "==> explicit runtime narrowing"
 SITE_PATH="$TMP/narrowed"


### PR DESCRIPTION
## Summary

- declare each runtime's skill discovery roots separately from its native install target
- select one canonical managed target when detected runtimes discover overlapping roots
- cover OpenCode overlap across Claude, Codex, and OpenCode roots while preserving runtime-only behavior and user skills

Closes #477.

## Verification

- `bash tests/managed-skill-targets.sh`
- `bash -n lib/skills.sh runtimes/claude-code.sh runtimes/codex.sh runtimes/opencode.sh tests/managed-skill-targets.sh`
- `shellcheck -e SC1091,SC2034,SC2115,SC2012,SC2086,SC2001 lib/skills.sh runtimes/claude-code.sh runtimes/codex.sh runtimes/opencode.sh tests/managed-skill-targets.sh`
- `bash tests/ci-coverage.sh`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the fresh duplicate-skill startup warning, reviewed and refined an asynchronously produced generic discovery-root implementation, and ran verification under Chris Huber's direction.