### PR TITLE
fix(dmc): report a typed convergence refusal as its own reason

### DIFF
--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -630,6 +630,35 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 		'identity_token' => $value,
 		'base_sha'       => $base,
 	);
+} elseif ( 'converge' === $operation && 'datamachine-code/worktree-convergence/v1' === ( $payload['schema'] ?? null ) ) {
+	// A convergence envelope Homeboy cannot accept, but which DMC did answer.
+	//
+	// Homeboy's converge contract has no refusal channel: it takes accepted
+	// evidence or an error, and surfaces this stderr verbatim. Reporting a
+	// typed `refused`/`stale` answer as an unreadable envelope therefore threw
+	// away the only actionable part — most often `destination_ahead`, which is
+	// the ordinary state of a worktree carrying commits past the pinned base.
+	// Fail closed either way, but say which of the two happened.
+	$status = (string) ( $payload['status'] ?? '' );
+	if ( 'converged' !== $status ) {
+		$detail = array();
+		foreach ( array( 'code', 'before_head', 'after_head', 'base_sha' ) as $field ) {
+			if ( isset($payload[ $field ]) && is_scalar($payload[ $field ]) ) {
+				$detail[] = $field . '=' . $payload[ $field ];
+			}
+		}
+		fwrite(
+			STDERR,
+			sprintf(
+				"DMC refused to converge the worktree onto the pinned base: status=%s%s\n",
+				'' === $status ? 'missing' : $status,
+				empty($detail) ? '' : ' (' . implode(', ', $detail) . ')'
+			)
+		);
+		exit(1);
+	}
+	fwrite(STDERR, "DMC convergence evidence does not bind the attested identity token and pinned base.\n");
+	exit(1);
 } elseif ( 'resolve' === $operation && in_array((string) ( $payload['status'] ?? '' ), array( 'not_owned', 'not_found' ), true) ) {
 	$result = array( 'success' => false, 'error' => array( 'code' => 'worktree_not_found', 'message' => 'DMC does not own the requested worktree.' ) );
 } elseif ( 'resolve' === $operation && 'datamachine-code/worktree-identity/v1' === ( $payload['schema'] ?? null ) ) {

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -146,10 +146,26 @@ success = run("success")
 expected = {"schema": "homeboy/worktree-provider-convergence/v1", "identity_token": identity, "base_sha": base}
 if success.returncode or json.loads(success.stdout) != expected:
     raise SystemExit(f"FAIL: DMC convergence success did not preserve exact Homeboy evidence: {success!r}")
+# A typed answer Homeboy cannot accept still fails closed, but must arrive as
+# its own reason rather than as an unreadable envelope.
+reasons = {
+    "mismatched": "does not bind the attested identity token",
+    "stale": "status=stale",
+    "refused": "status=refused",
+}
 for mode in ("mismatched", "stale", "refused"):
     result = run(mode)
     if result.returncode == 0 or result.stdout:
         raise SystemExit(f"FAIL: DMC {mode} convergence response must fail closed: {result!r}")
+    if "unsupported envelope" in result.stderr:
+        raise SystemExit(f"FAIL: DMC {mode} convergence is well-formed and must not be reported as unreadable: {result.stderr!r}")
+    if reasons[mode] not in result.stderr:
+        raise SystemExit(f"FAIL: DMC {mode} convergence must name its typed reason: {result.stderr!r}")
+
+refused = run("refused")
+for field in ("code=destination_ahead", "before_head=aaaaaaa", "after_head=aaaaaaa"):
+    if field not in refused.stderr:
+        raise SystemExit(f"FAIL: DMC refusal must preserve {field}: {refused.stderr!r}")
 
 log = open(sys.argv[2], encoding="utf-8").read()
 if f"converge|{identity}|{base}" not in log:
@@ -604,7 +620,7 @@ if ('converge' === $operation && 'fixture-token' === $value) {
         exit(0);
     }
     if ('refused' === $mode) {
-        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'refused', 'identity_token' => $value, 'base_sha' => $base)) . "\n";
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'refused', 'identity_token' => $value, 'base_sha' => $base, 'code' => 'destination_ahead', 'before_head' => 'aaaaaaa', 'after_head' => 'aaaaaaa', 'changed' => false)) . "\n";
         exit(0);
     }
 }


### PR DESCRIPTION
Fixes #480.

## Problem

The `converge` branch accepted exactly one shape — schema, `status: "converged"`, matching identity token, matching base SHA. Everything else fell through to the terminal `else`:

```php
fwrite(STDERR, "DMC worktree provider returned an unsupported envelope.\n");
exit(1);
```

So a well-formed, typed answer from DMC was reported as an unreadable payload.

Against the live provider (`dmc-worktree-provider` release `0.72.2`), the inner call succeeds with exit `0` and returns:

```json
{
  "schema": "datamachine-code/worktree-convergence/v1",
  "status": "refused",
  "code": "destination_ahead",
  "before_head": "138b28acf020957758a0c2db97372e95f0c4526c",
  "after_head": "138b28acf020957758a0c2db97372e95f0c4526c",
  "changed": false
}
```

Schema matches, identity token matches, base SHA matches. The only difference from the accepted shape is `status: "refused"` with an explicit `code`.

`destination_ahead` is the ordinary state of any worktree carrying commits past the pinned base, so this reaches the operator routinely — as a contract break rather than as the plain fact that the destination is ahead.

## Why the reason goes on stderr

Homeboy's converge contract has no refusal channel. `converge_apply_enabled_worktree_provider_to_base_from_config` takes bound evidence or returns an error, and rejects any payload whose schema, identity token, or base SHA does not match. There is no success-shaped way to say "no".

It does surface this script's stderr verbatim:

```
Primary failure: provider dmc converge failed during workspace_base_ancestry_preflight (exit 1)
Provider stderr: DMC worktree provider returned an unsupported envelope.
```

So stderr is the channel that reaches the operator, and making it accurate is the fix.

## Change

Recognize a well-formed `datamachine-code/worktree-convergence/v1` envelope and fail closed with what it actually said:

- non-`converged` status → the status plus any `code`, `before_head`, `after_head`, `base_sha` it carried
- `converged` that does not bind the attested identity/base → named as a binding failure

`unsupported envelope` is now reserved for payloads that genuinely fail schema validation. Exit code stays `1` in every case; nothing that failed before succeeds now.

Before and after, same live call:

```
=== BEFORE (main) ===
DMC worktree provider returned an unsupported envelope.
exit=1

=== AFTER (patched) ===
DMC refused to converge the worktree onto the pinned base: status=refused (code=destination_ahead, before_head=138b28acf020957758a0c2db97372e95f0c4526c, after_head=138b28acf020957758a0c2db97372e95f0c4526c, base_sha=70aefb2532b643f65596bcb7041623770c4c7238)
exit=1
```

## Coverage

`assert_convergence_contract` in `tests/homeboy-dmc-provider.sh` already required `mismatched`, `stale`, and `refused` to fail closed. That is preserved, and each now additionally must:

- not be reported as an unreadable envelope, and
- name its own typed reason.

The `refused` fixture carries `code`, `before_head`, `after_head`, and `changed`, and the test asserts all three fields survive into stderr — so the evidence this issue is about cannot be dropped again silently.

## Verification

- `bash tests/homeboy-dmc-provider.sh` — passes.
- Reverted the PHP change with the new assertions in place and confirmed the suite fails, so the coverage is load-bearing rather than decorative:
  ```
  FAIL: DMC mismatched convergence is well-formed and must not be reported as unreadable:
  'DMC worktree provider returned an unsupported envelope.\n'
  ```
- `php -l scripts/homeboy-dmc-provider.php` — clean.
- `bash -n` across every shell script in the repo (CI's first job) — clean.

## Scope

This makes the refusal legible; it does not decide what to do about it. Whether Cook should rebase, refuse, or pick another destination on `destination_ahead` is Homeboy-side policy and is left alone.

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode reproduced the bridge and inner provider calls directly, read Homeboy's convergence contract to confirm no refusal channel exists, wrote the fix, and verified the new assertions fail without it. Chris Huber directed the work and remains responsible for the change.