### PR TITLE
fix(dmc): report typed converge refusals faithfully

### DIFF
--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -630,6 +630,15 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 		'identity_token' => $value,
 		'base_sha'       => $base,
 	);
+} elseif ( 'converge' === $operation && 'datamachine-code/worktree-convergence/v1' === ( $payload['schema'] ?? null ) && 'refused' === ( $payload['status'] ?? null ) && $value === ( $payload['identity_token'] ?? null ) && $base === ( $payload['base_sha'] ?? null ) && is_string($payload['code'] ?? null) && '' !== $payload['code'] ) {
+	fwrite(STDERR, json_encode(array(
+		'schema'         => 'homeboy/worktree-provider-convergence-refusal/v1',
+		'identity_token' => $value,
+		'base_sha'       => $base,
+		'code'           => $payload['code'],
+		'message'        => 'DMC refused worktree convergence: ' . $payload['code'],
+	), JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n");
+	exit(1);
 } elseif ( 'resolve' === $operation && in_array((string) ( $payload['status'] ?? '' ), array( 'not_owned', 'not_found' ), true) ) {
 	$result = array( 'success' => false, 'error' => array( 'code' => 'worktree_not_found', 'message' => 'DMC does not own the requested worktree.' ) );
 } elseif ( 'resolve' === $operation && 'datamachine-code/worktree-identity/v1' === ( $payload['schema'] ?? null ) ) {

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -146,10 +146,25 @@ success = run("success")
 expected = {"schema": "homeboy/worktree-provider-convergence/v1", "identity_token": identity, "base_sha": base}
 if success.returncode or json.loads(success.stdout) != expected:
     raise SystemExit(f"FAIL: DMC convergence success did not preserve exact Homeboy evidence: {success!r}")
-for mode in ("mismatched", "stale", "refused"):
+
+refused = run("refused")
+if refused.returncode == 0 or refused.stdout:
+    raise SystemExit(f"FAIL: DMC refused convergence response must fail closed: {refused!r}")
+if "unsupported envelope" in refused.stderr:
+    raise SystemExit(f"FAIL: typed convergence refusal was misreported as an unsupported envelope: {refused!r}")
+try:
+    refusal = json.loads(refused.stderr)
+except ValueError:
+    raise SystemExit(f"FAIL: DMC convergence refusal was not a machine-readable typed envelope: {refused!r}")
+if refusal != {"schema": "homeboy/worktree-provider-convergence-refusal/v1", "identity_token": identity, "base_sha": base, "code": "destination_diverged", "message": "DMC refused worktree convergence: destination_diverged"}:
+    raise SystemExit(f"FAIL: DMC convergence refusal did not preserve the provider's typed refusal code: {refused!r}")
+
+for mode in ("mismatched", "stale", "refused_mismatched", "refused_stale", "refused_codeless", "unknown_schema"):
     result = run(mode)
     if result.returncode == 0 or result.stdout:
         raise SystemExit(f"FAIL: DMC {mode} convergence response must fail closed: {result!r}")
+    if "unsupported envelope" not in result.stderr:
+        raise SystemExit(f"FAIL: DMC {mode} convergence response must keep the unsupported-envelope contract violation diagnostic: {result!r}")
 
 log = open(sys.argv[2], encoding="utf-8").read()
 if f"converge|{identity}|{base}" not in log:
@@ -604,7 +619,23 @@ if ('converge' === $operation && 'fixture-token' === $value) {
         exit(0);
     }
     if ('refused' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'refused', 'code' => 'destination_diverged', 'identity_token' => $value, 'base_sha' => $base, 'before_head' => '1111111111111111111111111111111111111111', 'after_head' => '2222222222222222222222222222222222222222', 'changed' => false)) . "\n";
+        exit(0);
+    }
+    if ('refused_mismatched' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'refused', 'code' => 'destination_diverged', 'identity_token' => 'other-token', 'base_sha' => $base)) . "\n";
+        exit(0);
+    }
+    if ('refused_stale' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'refused', 'code' => 'destination_diverged', 'identity_token' => $value, 'base_sha' => '0000000000000000000000000000000000000000')) . "\n";
+        exit(0);
+    }
+    if ('refused_codeless' === $mode) {
         echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v1', 'status' => 'refused', 'identity_token' => $value, 'base_sha' => $base)) . "\n";
+        exit(0);
+    }
+    if ('unknown_schema' === $mode) {
+        echo json_encode(array('schema' => 'datamachine-code/worktree-convergence/v2', 'status' => 'refused', 'code' => 'destination_diverged', 'identity_token' => $value, 'base_sha' => $base)) . "\n";
         exit(0);
     }
 }


### PR DESCRIPTION
Fixes #479

## Problem

`scripts/homeboy-dmc-provider.php` accepted only `status === 'converged'` on the converge path. A well-formed envelope carrying `status: "refused"` matched the schema check, failed the status check, fell through every `elseif`, and landed in the catch-all:

```
DMC worktree provider returned an unsupported envelope.
```

The envelope was neither unsupported nor malformed — it was a legitimate refusal carrying a machine-readable `code`, which was discarded.

## Change

Adds an explicit `refused` branch, validated with the same `identity_token` / `base_sha` matching rigor the `converged` branch already applies, plus a required non-empty `code`. It emits a typed refusal envelope on stderr and exits non-zero.

Refusals that are malformed, codeless, or carry mismatched tokens still fall through to the existing unsupported-envelope path, so that message now means only what it says.

## Verification

Against the real diverged worktree that surfaced this:

**Before**
```
DMC worktree provider returned an unsupported envelope.
exit=1
```

**After**
```json
{"schema":"homeboy/worktree-provider-convergence-refusal/v1",
 "identity_token":"...","base_sha":"...",
 "code":"destination_diverged",
 "message":"DMC refused worktree convergence: destination_diverged"}
exit=1
```

Homeboy previously surfaced this condition as `worktree provider 'dmc' converge command failed with exit code 1`, which reads as provider breakage. It now reports that the destination diverged and needs reconciliation.

`tests/homeboy-dmc-provider.sh` gains coverage asserting the refusal code reaches the operator-facing diagnostic and that `"unsupported envelope"` does **not** appear, plus negative cases for `refused_mismatched`, `refused_stale`, `refused_codeless`, and `unknown_schema`. Full suite passes (`exit 0`).

---

*AI assistance: Claude Sonnet 4.5 (this PR) and opencode/glm-5.3 (initial implementation, dispatched via a Homeboy agent-task cook). The cook's provider stalled on a liveness timeout despite producing correct work — tracked separately as Extra-Chill/homeboy#13626 — so the candidate was reviewed, gate-verified, and finalized by hand. I reproduced the original failure, traced the root cause, verified the fix end to end against a live diverged worktree, and confirmed the gate passes.*
