### PR TITLE
fix: flag disposable task worktree in Homeboy DMC provider config

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -256,6 +256,7 @@ jobs:
           - homeboy-codebox-canary
           - homeboy-components
           - homeboy-dmc-provider
+          - homeboy-dmc-provider-stability
           - homeboy-project-id
           - homeboy-verification-guidance
           - kimaki-credential-seeding

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -684,11 +684,43 @@ setup_homeboy_project() {
   fi
 }
 
+homeboy_git_is_linked_worktree() {
+  # A linked (task) worktree shares its object store with a primary checkout
+  # but has its own per-worktree git-dir, so `--git-dir` and
+  # `--git-common-dir` diverge. The primary checkout (and any plain, non-git
+  # install such as a release payload) has no such divergence. This is the
+  # generic signal DMC's own worktree lifecycle relies on: any linked
+  # worktree is disposable and may be removed by `workspace cleanup` without
+  # notice.
+  local dir="$1" git_dir common_dir
+  git_dir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null)" || return 1
+  common_dir="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$git_dir" in /*) ;; *) git_dir="$dir/$git_dir" ;; esac
+  case "$common_dir" in /*) ;; *) common_dir="$dir/$common_dir" ;; esac
+  git_dir="$(cd "$git_dir" 2>/dev/null && pwd)" || return 1
+  common_dir="$(cd "$common_dir" 2>/dev/null && pwd)" || return 1
+  [ "$git_dir" != "$common_dir" ]
+}
+
+homeboy_dmc_guard_script_dir_stability() {
+  local dir="$1"
+  homeboy_git_is_linked_worktree "$dir" || return 0
+
+  local message="Homeboy DMC worktree provider commands would be pinned to \"$dir\", a disposable task worktree of wp-coding-agents. That checkout can be removed by workspace cleanup, breaking every DMC worktree operation at once. Rerun setup/upgrade from the primary wp-coding-agents checkout (or an installed release) so the provider config stays stable."
+  if homeboy_required; then
+    error "$message"
+  fi
+  warn "$message"
+  return 0
+}
+
 configure_homeboy_dmc_worktree_provider() {
   if [ "${HOMEBOY_MODE:-auto}" = "disabled" ]; then
     log "Skipping Homeboy DMC worktree provider setup (--no-homeboy)"
     return 0
   fi
+
+  homeboy_dmc_guard_script_dir_stability "$SCRIPT_DIR"
 
   if ! command -v homeboy >/dev/null 2>&1; then
     homeboy_handle_failure "Homeboy is not callable from this setup/runtime PATH; skipping DMC worktree provider setup."

--- a/tests/homeboy-dmc-provider-stability.sh
+++ b/tests/homeboy-dmc-provider-stability.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# tests/homeboy-dmc-provider-stability.sh — Homeboy DMC provider commands must
+# not resolve inside a disposable git worktree (#482).
+#
+# A live config was found pinning `worktree_providers.dmc.commands` at a
+# feature-branch task worktree of wp-coding-agents itself. Once that branch
+# merged and the worktree was cleaned up, every DMC worktree operation broke
+# at once, because all of them route through that one path. This asserts the
+# setup/upgrade tooling actually notices and reacts when it is about to do
+# that again, rather than asserting anything about how it notices.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/homeboy.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_contains() {
+  local needle="$1" haystack="$2"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      echo "FAIL: expected '$needle' in: $haystack"
+      exit 1
+      ;;
+  esac
+}
+
+# Build a real primary checkout and a real linked task worktree off it — the
+# same relationship `datamachine-code workspace worktree add` creates for
+# every fanout task, and the same relationship this project's own
+# contributors create by hand with `git worktree add ../repo@branch`.
+PRIMARY="$TMP/wp-coding-agents"
+mkdir -p "$PRIMARY"
+git -C "$PRIMARY" init -q
+git -C "$PRIMARY" config user.email test@example.com
+git -C "$PRIMARY" config user.name test
+: > "$PRIMARY/marker"
+git -C "$PRIMARY" add marker
+git -C "$PRIMARY" commit -q -m init
+TASK_WORKTREE="$TMP/wp-coding-agents@fix-482-provider-path-stability"
+git -C "$PRIMARY" worktree add -q -b fix-482-provider-path-stability "$TASK_WORKTREE" >/dev/null 2>&1
+
+# An installed release payload has no .git at all — nothing for `git
+# worktree` to have cleaned up, so it is inherently stable.
+PLAIN="$TMP/installed-release"
+mkdir -p "$PLAIN"
+
+HOMEBOY_MODE=auto
+WITH_HOMEBOY=false
+
+output="$(homeboy_dmc_guard_script_dir_stability "$PLAIN")"
+[ -z "$output" ] || {
+  echo "FAIL: a non-git script dir must not be flagged: $output"
+  exit 1
+}
+
+output="$(homeboy_dmc_guard_script_dir_stability "$PRIMARY")"
+[ -z "$output" ] || {
+  echo "FAIL: the primary checkout must not be flagged: $output"
+  exit 1
+}
+
+# A linked task worktree must be flagged. In auto mode (the default; setup and
+# upgrade never pass --with-homeboy unless a human asks for it) this is a
+# warning, not a hard failure — the caller still writes the provider config,
+# same as every other soft Homeboy failure in this file.
+output="$(homeboy_dmc_guard_script_dir_stability "$TASK_WORKTREE")"
+assert_contains "$TASK_WORKTREE" "$output"
+assert_contains "disposable task worktree" "$output"
+assert_contains "primary wp-coding-agents checkout" "$output"
+
+# When Homeboy is explicitly required (--with-homeboy / HOMEBOY_MODE=enabled),
+# the same condition must refuse outright rather than silently pin production
+# config to a checkout that workspace cleanup is entitled to delete.
+HOMEBOY_MODE=enabled
+set +e
+( homeboy_dmc_guard_script_dir_stability "$TASK_WORKTREE" ) > "$TMP/required.out" 2>&1
+required_status=$?
+set -e
+HOMEBOY_MODE=auto
+[ "$required_status" -ne 0 ] || {
+  echo "FAIL: --with-homeboy must refuse a task-worktree script dir"
+  cat "$TMP/required.out"
+  exit 1
+}
+assert_contains "$TASK_WORKTREE" "$(cat "$TMP/required.out")"
+
+# End-to-end: configure_homeboy_dmc_worktree_provider must reach and surface
+# the same guard before anything else, including its own unrelated soft
+# skips (exercised here with homeboy absent from PATH).
+FAKE_BIN="$TMP/sandbin"
+mkdir -p "$FAKE_BIN"
+for tool in grep cat rm git; do
+  resolved="$(command -v "$tool" 2>/dev/null || true)"
+  [ -n "$resolved" ] && ln -sf "$resolved" "$FAKE_BIN/$tool"
+done
+SCRIPT_DIR="$TASK_WORKTREE"
+PATH="$FAKE_BIN"
+apply_output="$(configure_homeboy_dmc_worktree_provider)"
+assert_contains "disposable task worktree" "$apply_output"
+assert_contains "Homeboy is not callable" "$apply_output"
+
+echo "OK: Homeboy DMC provider setup flags a disposable task worktree script dir (#482)"


### PR DESCRIPTION
Fixes #482

## Problem

`worktree_providers.dmc.commands` in Homeboy config could point at a **disposable task worktree** with nothing validating path stability. Found live, in 9 separate command entries, referencing an already-merged branch worktree.

Every DMC worktree operation — `resolve_identity`, `attest_safety`, `resolve`, `resolve_task`, `converge`, `plan`, `cleanup` — routes through that single path. When cleanup removes the worktree, all of them break at once. The control plane's own worktree provider was depending on a worktree the control plane is entitled to delete.

## Change

Setup now detects when the resolved provider script directory sits inside a disposable task worktree and flags it, so the condition is caught rather than silently armed. Primary checkouts and non-git installs are unaffected.

## Verification

Both suites pass independently:

```
bash tests/homeboy-dmc-provider.sh            exit 0
bash tests/homeboy-dmc-provider-stability.sh  exit 0
  OK: Homeboy DMC provider setup flags a disposable task worktree script dir (#482)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent. I filed the issue after finding the condition live while diagnosing an unrelated converge failure, and independently ran both test scripts against this branch to confirm the results above.*
