### PR TITLE
Restore DMC tracker adoption for exact cwd paths

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -247,6 +247,40 @@ homeboy_task_attachment_commands_supported() {
   return 1
 }
 
+homeboy_dmc_provider_release_label() {
+  local provider="$1" plugin_dir version=""
+  case "$provider" in
+    */.wp-coding-agents-releases/*)
+      version="${provider#*/.wp-coding-agents-releases/}"
+      version="${version%%/*}"
+      version="${version%%-*}"
+      ;;
+  esac
+  if [ -z "$version" ]; then
+    plugin_dir="$(cd "$(dirname -- "$provider")/.." && pwd)" || plugin_dir=""
+    if [ -n "$plugin_dir" ] && [ -f "$plugin_dir/data-machine-code.php" ]; then
+      version="$(grep -m1 -E '^[[:space:]]*\*?[[:space:]]*Version:' "$plugin_dir/data-machine-code.php" | sed -E 's/.*Version:[[:space:]]*([^[:space:]]+).*/\1/')"
+    fi
+  fi
+  printf '%s' "${version:-unknown}"
+}
+
+homeboy_dmc_task_attachment_skew_guidance() {
+  local provider="$1" dmc_supported="$2" homeboy_supported="$3"
+  local dmc_version homeboy_version
+  [ "$dmc_supported" != "$homeboy_supported" ] || return 0
+
+  dmc_version="$(homeboy_dmc_provider_release_label "$provider")"
+  homeboy_version="$(homeboy --version 2>/dev/null || printf 'unknown version')"
+
+  if [ "$dmc_supported" = true ]; then
+    warn "DMC provider $provider advertises datamachine-code/worktree-provider-capabilities/v1 tracker attachment, but $homeboy_version does not accept Homeboy's paired task-attachment commands. Copied DMC release: $dmc_version. Homeboy: $homeboy_version. Run: homeboy upgrade; then rerun: \"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\""
+    return 0
+  fi
+
+  warn "Homeboy accepts paired task-attachment commands, but DMC provider $provider does not advertise datamachine-code/worktree-provider-capabilities/v1 tracker attachment. Copied DMC release: $dmc_version. Homeboy: $homeboy_version. Rerun: \"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\". For one exact clean worktree, attach manually with: $WP_CMD datamachine-code workspace worktree attach-tracker <handle> --task-url=<task-url> --format=json${SITE_PATH:+ --path=\"$SITE_PATH\"}"
+}
+
 homeboy_dmc_worktree_provider_ready() {
   local provider="$1" provider_json="${2:-}"
 
@@ -728,13 +762,21 @@ configure_homeboy_dmc_worktree_provider() {
   fi
 
   local provider provider_json task_attachment_supported=false task_resolution_supported=false
+  local dmc_task_attachment_supported=false homeboy_task_attachment_supported=false
   provider="$(homeboy_dmc_worktree_provider_executable)" || {
     homeboy_handle_failure "Data Machine Code standalone worktree provider source contract is unavailable; skipping Homeboy DMC worktree provider setup."
     return 0
   }
-  if homeboy_dmc_task_attachment_capable "$provider" && homeboy_task_attachment_commands_supported; then
+  if homeboy_dmc_task_attachment_capable "$provider"; then
+    dmc_task_attachment_supported=true
+  fi
+  if homeboy_task_attachment_commands_supported; then
+    homeboy_task_attachment_supported=true
+  fi
+  if [ "$dmc_task_attachment_supported" = true ] && [ "$homeboy_task_attachment_supported" = true ]; then
     task_attachment_supported=true
   fi
+  homeboy_dmc_task_attachment_skew_guidance "$provider" "$dmc_task_attachment_supported" "$homeboy_task_attachment_supported"
   if homeboy_dmc_task_resolution_capable "$provider"; then
     task_resolution_supported=true
   fi

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -657,7 +657,7 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 		}
 		$task_url = $canonical_task_url((string) ( $payload['task_url'] ?? '' ));
 		if (
-			'' === $task_url
+			( '' === $task_url && ! str_starts_with($value, '/') )
 			|| ! is_string($payload['handle'] ?? null) || '' === $payload['handle']
 			|| ! is_string($payload['path'] ?? null) || '' === $payload['path']
 			|| ! is_string($payload['branch'] ?? null) || '' === $payload['branch']
@@ -670,7 +670,7 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 				'handle'  => $payload['handle'] ?? '',
 				'path'    => $payload['path'] ?? '',
 				'branch'  => $payload['branch'] ?? '',
-				'task_url' => $task_url,
+				'task_url' => '' === $task_url ? null : $task_url,
 				'safety'  => array(
 					'dirty'    => $safety['dirty'] ?? true,
 					'unpushed' => $safety['unpushed'] ?? true,

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -260,6 +260,10 @@ if canonical.returncode or json.loads(canonical.stdout) != expected:
 missing = run("missing_task")
 if missing.returncode == 0 or "does not provide tracker ownership" not in missing.stderr:
     raise SystemExit(f"FAIL: missing standalone tracker evidence must fail closed: {missing!r}")
+missing_path = run("missing_task", "resolve_path")
+missing_path_expected = [{**expected[0], "task_url": None}]
+if missing_path.returncode or json.loads(missing_path.stdout) != missing_path_expected:
+    raise SystemExit(f"FAIL: exact path resolution did not preserve an untracked worktree for negotiated attachment: {missing_path!r}")
 PY
 }
 
@@ -428,6 +432,16 @@ commands = json.loads(payload)["commands"]
 handle = "static-site-importer@refactor-1306-runtime-entity-form-materialization"
 task_url = "https://github.com/Automattic/static-site-importer/issues/1306"
 values = {"handle": handle, "task_url": task_url}
+
+path_resolution = subprocess.run(
+    [part.replace("{path}", os.environ["DMC_ATTACHMENT_PATH"]) for part in commands["resolve_path"]],
+    text=True,
+    capture_output=True,
+    env=os.environ.copy(),
+)
+path_rows = json.loads(path_resolution.stdout) if path_resolution.returncode == 0 else []
+if len(path_rows) != 1 or path_rows[0].get("handle") != handle or path_rows[0].get("path") != os.environ["DMC_ATTACHMENT_PATH"] or path_rows[0].get("task_url") is not None:
+    raise SystemExit(f"FAIL: --cwd path did not resolve the exact untracked DMC handle before attachment: {path_resolution!r}")
 
 def run(name, env=None):
     command = [part.format(**values) for part in commands[name]]
@@ -895,6 +909,12 @@ rm -f "$DMC_STATE"
 configure_homeboy_dmc_worktree_provider > "$TMP/source-contract.log"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 
+copied_release_provider="$SITE_PATH/wp-content/plugins/data-machine-code/.wp-coding-agents-releases/0.72.11-deadbeef/bin/dmc-worktree-provider"
+[ "$(homeboy_dmc_provider_release_label "$copied_release_provider")" = "0.72.11" ] || {
+  echo "FAIL: copied DMC release version was not parsed from the provider path"
+  exit 1
+}
+
 # Either missing owning contract keeps the legacy provider JSON byte shape: no
 # half-configured attachment key is written.
 DMC_CAPABILITIES_MODE=legacy
@@ -903,6 +923,10 @@ export DMC_CAPABILITIES_MODE
 configure_homeboy_dmc_worktree_provider > "$TMP/legacy-dmc.log"
 assert_not_contains 'task_attachment_preview' "$HOMEBOY_CONFIG_LOG"
 assert_not_contains 'task_attachment_apply' "$HOMEBOY_CONFIG_LOG"
+assert_contains "DMC provider $DMC_PROVIDER_EXECUTABLE does not advertise datamachine-code/worktree-provider-capabilities/v1 tracker attachment" "$TMP/legacy-dmc.log"
+assert_contains "Copied DMC release: unknown. Homeboy: unknown version." "$TMP/legacy-dmc.log"
+assert_contains "\"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\"" "$TMP/legacy-dmc.log"
+assert_contains "workspace worktree attach-tracker <handle> --task-url=<task-url> --format=json --path=\"$SITE_PATH\"" "$TMP/legacy-dmc.log"
 unset DMC_CAPABILITIES_MODE
 
 HOMEBOY_ATTACHMENT_COMMANDS=false
@@ -911,6 +935,10 @@ export HOMEBOY_ATTACHMENT_COMMANDS
 configure_homeboy_dmc_worktree_provider > "$TMP/legacy-homeboy.log"
 assert_not_contains 'task_attachment_preview' "$HOMEBOY_CONFIG_LOG"
 assert_not_contains 'task_attachment_apply' "$HOMEBOY_CONFIG_LOG"
+assert_contains "DMC provider $DMC_PROVIDER_EXECUTABLE advertises datamachine-code/worktree-provider-capabilities/v1 tracker attachment" "$TMP/legacy-homeboy.log"
+assert_contains "Copied DMC release: unknown. Homeboy: unknown version." "$TMP/legacy-homeboy.log"
+assert_contains 'homeboy upgrade' "$TMP/legacy-homeboy.log"
+assert_contains "\"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\"" "$TMP/legacy-homeboy.log"
 unset HOMEBOY_ATTACHMENT_COMMANDS
 assert_contains "$DMC_PROVIDER_EXECUTABLE" "$HOMEBOY_CONFIG_LOG"
 assert_not_contains "$SITE_PATH/wp-content/plugins/data-machine-code/bin/dmc-worktree-provider" "$HOMEBOY_CONFIG_LOG"


### PR DESCRIPTION
Closes #485.

## Summary

- allow exact canonical `resolve_path` results to retain a null tracker until negotiated attachment
- keep direct handle resolution tracker-strict
- preserve capability pairing and old-version compatibility
- provide exact Homeboy/DMC skew remediation

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `bash tests/homeboy-dmc-provider-stability.sh`
- `bash tests/homeboy-verification-guidance.sh`
- `bash tests/ci-coverage.sh`
- PHP and Bash syntax checks

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the end-to-end adapter denial, traced the DMC and Homeboy capability contracts, implemented the path-resolution bridge, and ran integration verification. Chris Huber reviewed the diff and is responsible for the submitted change.