### PR TITLE
Make WordPress CLI transport capability-selected and argv-native

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -1379,12 +1379,9 @@ _kimaki_datamachine_wp_cmd() {
     external_wordpress_control_command
     return 0
   fi
-  if [ "${IS_STUDIO:-false}" = true ]; then
-    printf '%s\n' "studio wp"
-    return 0
-  fi
-
-  printf '%s\n' "${WP_CMD:-wp}"
+  wp_cli_transport_ensure
+  wp_cli_transport_display
+  printf '\n'
 }
 
 _kimaki_skill_filter_mode() {

--- a/hooks/dm-agent-sync.sh
+++ b/hooks/dm-agent-sync.sh
@@ -16,45 +16,6 @@ if [ -z "$SITE_PATH" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Detect WP-CLI command
-# ---------------------------------------------------------------------------
-
-detect_wp_cmd() {
-  # 1. Installed Studio CLI
-  if [ -f "$SITE_PATH/STUDIO.md" ] && command -v studio &>/dev/null; then
-    echo "studio wp"
-    return
-  fi
-
-  # 2. Dev CLI — site lives inside the Studio repo (developers working on Studio itself)
-  if [ -f "$SITE_PATH/STUDIO.md" ]; then
-    local search_dir="$SITE_PATH"
-    while [ "$search_dir" != "/" ]; do
-      local dev_cli="$search_dir/apps/cli/dist/cli/main.mjs"
-      if [ -f "$dev_cli" ]; then
-        echo "node $dev_cli wp"
-        return
-      fi
-      search_dir=$(dirname "$search_dir")
-    done
-  fi
-
-  # 3. System wp-cli
-  if command -v wp &>/dev/null; then
-    local cmd="wp --path=$SITE_PATH"
-    if [ "$(id -u)" -eq 0 ]; then
-      cmd="$cmd --allow-root"
-    fi
-    echo "$cmd"
-    return
-  fi
-
-  return 1
-}
-
-WP_CMD=$(detect_wp_cmd) || exit 0
-
-# ---------------------------------------------------------------------------
 # Optional single-agent scope (OpenCode parity)
 # ---------------------------------------------------------------------------
 # setup.sh / upgrade.sh write dm-agent-sync.env next to this hook with the
@@ -69,6 +30,75 @@ if [ -f "$HOOK_DIR/dm-agent-sync.env" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Resolve WP-CLI transport
+# ---------------------------------------------------------------------------
+
+WP_CLI_TRANSPORT=()
+
+load_wp_cli_transport_json() {
+  local argument
+  while IFS= read -r -d '' argument; do
+    WP_CLI_TRANSPORT+=("$argument")
+  done < <(python3 - "$1" <<'PY'
+import json, sys
+value = json.loads(sys.argv[1])
+if not isinstance(value, list) or not value or any(not isinstance(item, str) or not item or "\0" in item for item in value):
+    raise SystemExit(1)
+for item in value:
+    sys.stdout.buffer.write(item.encode() + b"\0")
+PY
+  )
+  [ "${#WP_CLI_TRANSPORT[@]}" -gt 0 ]
+}
+
+resolve_wp_cli_transport() {
+  if [ -n "${DATAMACHINE_WP_TRANSPORT_JSON:-}" ]; then
+    load_wp_cli_transport_json "$DATAMACHINE_WP_TRANSPORT_JSON"
+    return
+  fi
+
+  if command -v wp >/dev/null 2>&1 && wp eval 'return;' --path="$SITE_PATH" >/dev/null 2>&1; then
+    WP_CLI_TRANSPORT=(wp)
+    return
+  fi
+
+  if [ -f "$SITE_PATH/STUDIO.md" ]; then
+    local search_dir="$SITE_PATH" dev_cli
+    while [ "$search_dir" != "/" ]; do
+      dev_cli="$search_dir/apps/cli/dist/cli/main.mjs"
+      if [ -f "$dev_cli" ] && command -v node >/dev/null 2>&1; then
+        WP_CLI_TRANSPORT=(node "$dev_cli" wp)
+        return
+      fi
+      search_dir=$(dirname "$search_dir")
+    done
+    if command -v studio >/dev/null 2>&1; then
+      WP_CLI_TRANSPORT=(studio wp)
+      return
+    fi
+  fi
+
+  return 1
+}
+
+wp_cli() {
+  local root_args=()
+  [ "$(id -u)" -ne 0 ] || root_args=(--allow-root)
+  "${WP_CLI_TRANSPORT[@]}" "$@" "${root_args[@]}" --path="$SITE_PATH"
+}
+
+wp_cli_display() {
+  local output="" argument quoted
+  for argument in "${WP_CLI_TRANSPORT[@]}"; do
+    printf -v quoted '%q' "$argument"
+    output="${output:+$output }$quoted"
+  done
+  printf '%s' "$output"
+}
+
+resolve_wp_cli_transport || exit 0
+
+# ---------------------------------------------------------------------------
 # Refresh composable files before computing @ includes
 # ---------------------------------------------------------------------------
 # SectionRegistry callbacks can read live state (Intelligence sources, skill
@@ -79,7 +109,7 @@ fi
 # guarantees AGENTS.md (and any sibling composable files) match live state
 # at the moment the coding-agent session starts.
 
-$WP_CMD datamachine memory compose >/dev/null 2>&1 || true
+wp_cli datamachine memory compose >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
 # Resolve which agents to inject
@@ -90,7 +120,7 @@ $WP_CMD datamachine memory compose >/dev/null 2>&1 || true
 if [ -n "${DM_AGENT_SLUG:-}" ]; then
   ACTIVE_SLUGS="$DM_AGENT_SLUG"
 else
-  AGENTS_RAW=$($WP_CMD datamachine agents list --format=json 2>/dev/null) || exit 0
+  AGENTS_RAW=$(wp_cli datamachine agents list --format=json 2>/dev/null) || exit 0
 
   # Extract JSON array. WP-CLI may append summary text (e.g. "Total: 2 agent(s).")
   # on the same line as the closing bracket. Use Python to safely extract the array.
@@ -123,7 +153,7 @@ fi
 
 ALL_FILES=""
 while IFS= read -r slug; do
-  PATHS_RAW=$($WP_CMD datamachine memory paths --agent="$slug" --format=json 2>/dev/null) || continue
+  PATHS_RAW=$(wp_cli datamachine memory paths --agent="$slug" --format=json 2>/dev/null) || continue
 
   FILES=$(echo "$PATHS_RAW" | python3 -c "
 import sys, json, re
@@ -156,7 +186,7 @@ while IFS= read -r f; do
 "
 done <<< "$UNIQUE_FILES"
 
-DISCOVER_LINE="Discover DM paths: \`$WP_CMD datamachine memory paths\`"
+DISCOVER_LINE="Discover DM paths: \`$(wp_cli_display) datamachine memory paths\`"
 NEW_CONTENT="${AT_INCLUDES}
 ${DISCOVER_LINE}"
 

--- a/lib/ai-gateway.sh
+++ b/lib/ai-gateway.sh
@@ -85,7 +85,7 @@ ai_gateway_configure_wordpress() {
 
   log "Configuring WP AI Gateway route: $AI_GATEWAY_ROUTE_PROVIDER / $AI_GATEWAY_ROUTE_MODEL"
   if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD ai-gateway configure $AI_GATEWAY_ROUTE_PROVIDER $AI_GATEWAY_ROUTE_MODEL --path=$SITE_PATH $WP_ROOT_FLAG"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) ai-gateway configure $AI_GATEWAY_ROUTE_PROVIDER $AI_GATEWAY_ROUTE_MODEL --path=$SITE_PATH $WP_ROOT_FLAG"
     return 0
   fi
 

--- a/lib/carried-plugins.sh
+++ b/lib/carried-plugins.sh
@@ -38,7 +38,7 @@ sync_carried_plugins() {
     if [ "$DRY_RUN" = true ]; then
       echo -e "${BLUE}[dry-run]${NC} mkdir -p $target_dir"
       echo -e "${BLUE}[dry-run]${NC} rsync -a --no-perms --no-owner --no-group --omit-dir-times --delete $source_dir/ $target_dir/"
-      echo -e "${BLUE}[dry-run]${NC} $WP_CMD plugin activate $slug --path=$SITE_PATH $WP_ROOT_FLAG"
+      echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) plugin activate $slug --path=$SITE_PATH $WP_ROOT_FLAG"
       continue
     fi
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -20,6 +20,129 @@ run_cmd() {
   fi
 }
 
+WP_CLI_TRANSPORT=()
+WP_CLI_TRANSPORT_CANDIDATE_NAMES=()
+WP_CLI_TRANSPORT_CANDIDATE_JSON=()
+
+wp_cli_transport_parse_json() {
+  local json="$1" argument
+  WP_CLI_TRANSPORT=()
+  while IFS= read -r -d '' argument; do
+    WP_CLI_TRANSPORT+=("$argument")
+  done < <(python3 - "$json" <<'PY'
+import json, sys
+value = json.loads(sys.argv[1])
+if not isinstance(value, list) or not value or any(not isinstance(item, str) or not item or "\0" in item for item in value):
+    raise SystemExit(1)
+for item in value:
+    sys.stdout.buffer.write(item.encode() + b"\0")
+PY
+  ) || return 1
+  [ "${#WP_CLI_TRANSPORT[@]}" -gt 0 ]
+}
+
+wp_cli_transport_set() {
+  [ "$#" -gt 0 ] || error "WordPress CLI transport requires at least one argv item"
+  WP_CLI_TRANSPORT=("$@")
+}
+
+wp_cli_transport_set_json() {
+  wp_cli_transport_parse_json "$1" || error "WP_CLI_TRANSPORT_JSON must be a non-empty JSON array of non-empty strings without NUL bytes"
+}
+
+wp_cli_transport_set_legacy_command() {
+  local command="$1" argument json
+  json="$(python3 - "$command" <<'PY'
+import json, shlex, sys
+parts = shlex.split(sys.argv[1])
+if not parts:
+    raise SystemExit(1)
+print(json.dumps(parts, separators=(",", ":")))
+PY
+)" || error "WP_CMD must contain a valid command"
+  wp_cli_transport_set_json "$json"
+}
+
+wp_cli_transport_ensure() {
+  [ "${#WP_CLI_TRANSPORT[@]}" -eq 0 ] || return 0
+  if [ -n "${WP_CLI_TRANSPORT_JSON:-}" ]; then
+    wp_cli_transport_set_json "$WP_CLI_TRANSPORT_JSON"
+  elif [ -n "${WP_CMD:-}" ]; then
+    wp_cli_transport_set_legacy_command "$WP_CMD"
+  else
+    wp_cli_transport_set wp
+  fi
+}
+
+wp_cli_transport_display() {
+  local output="" argument quoted
+  wp_cli_transport_ensure
+  for argument in "${WP_CLI_TRANSPORT[@]}"; do
+    printf -v quoted '%q' "$argument"
+    output="${output:+$output }$quoted"
+  done
+  printf '%s' "$output"
+}
+
+wp_cli_transport_json() {
+  wp_cli_transport_ensure
+  python3 - "${WP_CLI_TRANSPORT[@]}" <<'PY'
+import json, sys
+print(json.dumps(sys.argv[1:], separators=(",", ":")))
+PY
+}
+
+wp_cli_transport_register_candidate() {
+  local name="$1"
+  shift
+  [ "$#" -gt 0 ] || error "WordPress CLI transport candidate '$name' has no argv"
+  WP_CLI_TRANSPORT_CANDIDATE_NAMES+=("$name")
+  WP_CLI_TRANSPORT_CANDIDATE_JSON+=("$(python3 - "$@" <<'PY'
+import json, sys
+print(json.dumps(sys.argv[1:], separators=(",", ":")))
+PY
+)")
+}
+
+wp_cli_transport_resolve_candidates() {
+  local index name json
+  if [ -n "${WP_CLI_TRANSPORT_JSON:-}" ]; then
+    wp_cli_transport_set_json "$WP_CLI_TRANSPORT_JSON"
+    log "Using configured WordPress CLI transport: $(wp_cli_transport_display)"
+    return
+  fi
+  if [ -n "${WP_CMD:-}" ]; then
+    wp_cli_transport_set_legacy_command "$WP_CMD"
+    log "Using configured WordPress CLI transport: $(wp_cli_transport_display)"
+    return
+  fi
+
+  index=0
+  while [ "$index" -lt "${#WP_CLI_TRANSPORT_CANDIDATE_JSON[@]}" ]; do
+    name="${WP_CLI_TRANSPORT_CANDIDATE_NAMES[$index]}"
+    json="${WP_CLI_TRANSPORT_CANDIDATE_JSON[$index]}"
+    wp_cli_transport_parse_json "$json" || error "Invalid registered WordPress CLI transport candidate: $name"
+    if command -v "${WP_CLI_TRANSPORT[0]}" >/dev/null 2>&1 && {
+      [ "${DRY_RUN:-false}" = true ] ||
+        (cd "$SITE_PATH" && "${WP_CLI_TRANSPORT[@]}" eval 'return;' ${WP_ROOT_FLAG:-} --path="$SITE_PATH" >/dev/null 2>&1)
+    }; then
+      wp_cli_transport_set "${WP_CLI_TRANSPORT[@]}"
+      log "Using WordPress CLI transport candidate '$name': $(wp_cli_transport_display)"
+      return
+    fi
+    WP_CLI_TRANSPORT=()
+    index=$((index + 1))
+  done
+
+  wp_cli_transport_set wp
+  log "Using default WordPress CLI transport: $(wp_cli_transport_display)"
+}
+
+wp_cli() {
+  wp_cli_transport_ensure
+  "${WP_CLI_TRANSPORT[@]}" "$@"
+}
+
 write_file() {
   local file_path="$1"
   local content="$2"

--- a/lib/data-machine.sh
+++ b/lib/data-machine.sh
@@ -7,7 +7,7 @@ install_data_machine() {
 
   if [ "$MULTISITE" = true ]; then
     log "Data Machine activated on main site. Activate on subsites with:"
-    log "  $WP_CMD plugin activate data-machine --url=subsite.$SITE_DOMAIN $WP_ROOT_FLAG"
+    log "  $(wp_cli_transport_display) plugin activate data-machine --url=subsite.$SITE_DOMAIN $WP_ROOT_FLAG"
   fi
 
   # Data Machine Code is the workspace/git/GitHub tool surface. A managed
@@ -30,7 +30,7 @@ install_data_machine() {
         log "DATAMACHINE_WORKSPACE_PATH already defined in wp-config.php"
       fi
     elif [ "$DRY_RUN" = true ]; then
-      echo -e "${BLUE}[dry-run]${NC} $WP_CMD config set DATAMACHINE_WORKSPACE_PATH $DM_WORKSPACE_DIR --type=constant"
+      echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) config set DATAMACHINE_WORKSPACE_PATH $DM_WORKSPACE_DIR --type=constant"
     fi
   else
     log "Skipping Data Machine Code (source mode: ${SOURCE_MODE:-owned} — no workspace on this install)"
@@ -60,7 +60,7 @@ set_compose_agents_md_constant() {
       log "DATAMACHINE_COMPOSE_AGENTS_MD already defined in wp-config.php"
     fi
   elif [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD config set DATAMACHINE_COMPOSE_AGENTS_MD true --raw --type=constant"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) config set DATAMACHINE_COMPOSE_AGENTS_MD true --raw --type=constant"
   fi
 }
 
@@ -119,12 +119,10 @@ create_dm_agent() {
   fi
 
   if [ "$DRY_RUN" = false ] && [ -f "$SITE_PATH/wp-config.php" ]; then
-    # shellcheck disable=SC2086
-    AGENT_NAME="${AGENT_NAME:-$($WP_CMD option get blogname $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "$AGENT_SLUG")}"
+    AGENT_NAME="${AGENT_NAME:-$(wp_cmd option get blogname 2>/dev/null || echo "$AGENT_SLUG")}"
 
     # Check if agent already exists (idempotent for re-runs)
-    # shellcheck disable=SC2086
-    EXISTING_AGENT=$($WP_CMD datamachine agents show "$AGENT_SLUG" --format=json $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "")
+    EXISTING_AGENT=$(wp_cmd datamachine agents show "$AGENT_SLUG" --format=json 2>/dev/null || echo "")
 
     if [ -z "$EXISTING_AGENT" ]; then
       log "Creating agent: $AGENT_SLUG ($AGENT_NAME)"
@@ -144,9 +142,9 @@ create_dm_agent() {
 sync_homeboy_availability() {
   if [ "$DRY_RUN" = true ]; then
     if [ "${HOMEBOY_WORDPRESS_READY:-false}" = true ] || homeboy_wordpress_extension_ready; then
-      echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update datamachine_code_homeboy_available 1"
+      echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option update datamachine_code_homeboy_available 1"
     else
-      echo -e "${BLUE}[dry-run]${NC} $WP_CMD option delete datamachine_code_homeboy_available"
+      echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option delete datamachine_code_homeboy_available"
     fi
     sync_homeboy_project_components
     return 0
@@ -182,7 +180,7 @@ discover_dm_workspace_dir() {
   workspace_file="$temp_dir/workspace"
   stderr_file="$temp_dir/stderr"
   printf -v replay_path '%q' "$SITE_PATH"
-  replay_command="${WP_CMD:-wp} datamachine-code workspace path ${WP_ROOT_FLAG:-} --path=$replay_path"
+  replay_command="$(wp_cli_transport_display) datamachine-code workspace path ${WP_ROOT_FLAG:-} --path=$replay_path"
 
   # Once authoritative discovery starts, a stale default must not survive a
   # failure and masquerade as the discovered workspace.

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -52,29 +52,13 @@ detect_root_requirement() {
 }
 
 resolve_wp_cli_transport() {
-  if [ -n "${WP_CMD:-}" ]; then
-    log "Using configured WordPress CLI transport: $WP_CMD"
-    return
+  WP_CLI_TRANSPORT_CANDIDATE_NAMES=()
+  WP_CLI_TRANSPORT_CANDIDATE_JSON=()
+  wp_cli_transport_register_candidate direct wp
+  if [ "${IS_STUDIO:-false}" = true ]; then
+    wp_cli_transport_register_candidate studio studio wp
   fi
-
-  if command -v wp >/dev/null 2>&1 && {
-    [ "${DRY_RUN:-false}" = true ] ||
-      # shellcheck disable=SC2086
-      (cd "$SITE_PATH" && wp eval 'return;' $WP_ROOT_FLAG --path="$SITE_PATH" >/dev/null 2>&1)
-  }; then
-    WP_CMD="wp"
-    log "Using direct WordPress CLI transport"
-    return
-  fi
-
-  if [ "${IS_STUDIO:-false}" = true ] && command -v studio >/dev/null 2>&1; then
-    WP_CMD="studio wp"
-    log "Using WordPress Studio CLI transport"
-    return
-  fi
-
-  WP_CMD="wp"
-  log "Using default WordPress CLI transport: wp"
+  wp_cli_transport_resolve_candidates
 }
 
 detect_environment() {
@@ -162,8 +146,8 @@ detect_environment() {
       SITE_PATH=$(cd "$SITE_PATH" 2>/dev/null && pwd || echo "$SITE_PATH")
     fi
 
-    # Detect WordPress Studio as environment metadata. WP_CMD remains the
-    # operator-selected WordPress transport.
+    # Detect WordPress Studio as environment metadata and register its CLI as
+    # one transport candidate. The generic resolver owns selection.
     if command -v studio &> /dev/null && [ -f "$SITE_PATH/STUDIO.md" ]; then
       IS_STUDIO=true
       log "Detected WordPress Studio environment"
@@ -174,17 +158,17 @@ detect_environment() {
     if [ "$DRY_RUN" = true ]; then
       detected_site_domain="${SITE_DOMAIN:-}"
     else
-      detected_site_domain=$(cd "$SITE_PATH" && $WP_CMD option get siteurl $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null | sed -E 's|^https?://||' || true)
+      detected_site_domain=$(cd "$SITE_PATH" && wp_cli option get siteurl $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null | sed -E 's|^https?://||' || true)
     fi
     SITE_DOMAIN="${SITE_DOMAIN:-${detected_site_domain:-$(basename "$SITE_PATH")}}"
     log "Existing WordPress at: $SITE_PATH ($SITE_DOMAIN)"
 
     # Detect if existing WP is multisite
     if [ "$DRY_RUN" = false ]; then
-      IS_EXISTING_MULTISITE=$(cd "$SITE_PATH" && $WP_CMD eval 'echo is_multisite() ? "yes" : "no";' $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "no")
+      IS_EXISTING_MULTISITE=$(cd "$SITE_PATH" && wp_cli eval 'echo is_multisite() ? "yes" : "no";' $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "no")
       if [ "$IS_EXISTING_MULTISITE" = "yes" ]; then
         MULTISITE=true
-        IS_SUBDOMAIN=$(cd "$SITE_PATH" && $WP_CMD eval 'echo is_subdomain_install() ? "yes" : "no";' $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "no")
+        IS_SUBDOMAIN=$(cd "$SITE_PATH" && wp_cli eval 'echo is_subdomain_install() ? "yes" : "no";' $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "no")
         if [ "$IS_SUBDOMAIN" = "yes" ]; then
           MULTISITE_TYPE="subdomain"
         fi
@@ -195,7 +179,7 @@ detect_environment() {
     SITE_DOMAIN="${SITE_DOMAIN:-example.com}"
     SITE_PATH="${SITE_PATH:-/var/www/$SITE_DOMAIN}"
   fi
-  WP_CMD="${WP_CMD:-wp}"
+  wp_cli_transport_ensure
 
   DB_NAME="${DB_NAME:-wordpress}"
   DB_USER="${DB_USER:-wordpress}"

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -51,6 +51,32 @@ detect_root_requirement() {
   fi
 }
 
+resolve_wp_cli_transport() {
+  if [ -n "${WP_CMD:-}" ]; then
+    log "Using configured WordPress CLI transport: $WP_CMD"
+    return
+  fi
+
+  if command -v wp >/dev/null 2>&1 && {
+    [ "${DRY_RUN:-false}" = true ] ||
+      # shellcheck disable=SC2086
+      (cd "$SITE_PATH" && wp eval 'return;' $WP_ROOT_FLAG --path="$SITE_PATH" >/dev/null 2>&1)
+  }; then
+    WP_CMD="wp"
+    log "Using direct WordPress CLI transport"
+    return
+  fi
+
+  if [ "${IS_STUDIO:-false}" = true ] && command -v studio >/dev/null 2>&1; then
+    WP_CMD="studio wp"
+    log "Using WordPress Studio CLI transport"
+    return
+  fi
+
+  WP_CMD="wp"
+  log "Using default WordPress CLI transport: wp"
+}
+
 detect_environment() {
   # Detect OS and platform
   PLATFORM="linux"
@@ -106,9 +132,6 @@ detect_environment() {
     WP_ROOT_FLAG="--allow-root"
   fi
 
-  # WP-CLI command: override with WP_CMD="studio wp" for WordPress Studio, etc.
-  WP_CMD="${WP_CMD:-wp}"
-
   log "Detected OS: $OS (platform: $PLATFORM, local: $LOCAL_MODE)"
   log "Mode: $MODE"
   log "Runtime: $RUNTIME"
@@ -139,38 +162,29 @@ detect_environment() {
       SITE_PATH=$(cd "$SITE_PATH" 2>/dev/null && pwd || echo "$SITE_PATH")
     fi
 
-    # Detect WordPress Studio
+    # Detect WordPress Studio as environment metadata. WP_CMD remains the
+    # operator-selected WordPress transport.
     if command -v studio &> /dev/null && [ -f "$SITE_PATH/STUDIO.md" ]; then
       IS_STUDIO=true
-      WP_CMD="studio wp"
       log "Detected WordPress Studio environment"
     fi
+    resolve_wp_cli_transport
 
     local detected_site_domain=""
     if [ "$DRY_RUN" = true ]; then
       detected_site_domain="${SITE_DOMAIN:-}"
-    elif [ "$IS_STUDIO" = true ]; then
-      detected_site_domain=$(studio wp option get siteurl --path="$SITE_PATH" 2>/dev/null | sed -E 's|^https?://||' || true)
     else
-      detected_site_domain=$(cd "$SITE_PATH" && $WP_CMD option get siteurl $WP_ROOT_FLAG 2>/dev/null | sed -E 's|^https?://||' || true)
+      detected_site_domain=$(cd "$SITE_PATH" && $WP_CMD option get siteurl $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null | sed -E 's|^https?://||' || true)
     fi
     SITE_DOMAIN="${SITE_DOMAIN:-${detected_site_domain:-$(basename "$SITE_PATH")}}"
     log "Existing WordPress at: $SITE_PATH ($SITE_DOMAIN)"
 
     # Detect if existing WP is multisite
     if [ "$DRY_RUN" = false ]; then
-      if [ "$IS_STUDIO" = true ]; then
-        IS_EXISTING_MULTISITE=$(studio wp eval 'echo is_multisite() ? "yes" : "no";' 2>/dev/null || echo "no")
-      else
-        IS_EXISTING_MULTISITE=$(cd "$SITE_PATH" && $WP_CMD eval 'echo is_multisite() ? "yes" : "no";' $WP_ROOT_FLAG 2>/dev/null || echo "no")
-      fi
+      IS_EXISTING_MULTISITE=$(cd "$SITE_PATH" && $WP_CMD eval 'echo is_multisite() ? "yes" : "no";' $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "no")
       if [ "$IS_EXISTING_MULTISITE" = "yes" ]; then
         MULTISITE=true
-        if [ "$IS_STUDIO" = true ]; then
-          IS_SUBDOMAIN=$(studio wp eval 'echo is_subdomain_install() ? "yes" : "no";' 2>/dev/null || echo "no")
-        else
-          IS_SUBDOMAIN=$(cd "$SITE_PATH" && $WP_CMD eval 'echo is_subdomain_install() ? "yes" : "no";' $WP_ROOT_FLAG 2>/dev/null || echo "no")
-        fi
+        IS_SUBDOMAIN=$(cd "$SITE_PATH" && $WP_CMD eval 'echo is_subdomain_install() ? "yes" : "no";' $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || echo "no")
         if [ "$IS_SUBDOMAIN" = "yes" ]; then
           MULTISITE_TYPE="subdomain"
         fi
@@ -181,6 +195,7 @@ detect_environment() {
     SITE_DOMAIN="${SITE_DOMAIN:-example.com}"
     SITE_PATH="${SITE_PATH:-/var/www/$SITE_DOMAIN}"
   fi
+  WP_CMD="${WP_CMD:-wp}"
 
   DB_NAME="${DB_NAME:-wordpress}"
   DB_USER="${DB_USER:-wordpress}"
@@ -216,13 +231,12 @@ detect_plugins_only_environment() {
   if [ "$LOCAL_MODE" != true ]; then
     WP_ROOT_FLAG="--allow-root"
   fi
-  WP_CMD="${WP_CMD:-wp}"
   IS_STUDIO=false
   if command -v studio >/dev/null 2>&1 && [ -f "$SITE_PATH/STUDIO.md" ]; then
     IS_STUDIO=true
-    WP_CMD="studio wp"
     log "Detected WordPress Studio environment (deferred bounded WP startup)"
   fi
+  resolve_wp_cli_transport
   SITE_DOMAIN="${SITE_DOMAIN:-$(basename "$SITE_PATH")}"
   SERVICE_USER="${USER:-$(id -un)}"
   SERVICE_HOME="${HOME:-}"

--- a/lib/external-wordpress.sh
+++ b/lib/external-wordpress.sh
@@ -22,21 +22,8 @@ external_wordpress_prepare_transport() {
   [ -n "${RUNTIME_PROJECT_ROOT:-}" ] || error "--external-wordpress requires --runtime-project-root or RUNTIME_PROJECT_ROOT"
   [ -n "${WORDPRESS_PATH:-}" ] || error "--external-wordpress requires --wordpress-path or WORDPRESS_PATH"
   [ -n "${WP_CONTROL_TRANSPORT_JSON:-}" ] || error "--external-wordpress requires WP_CONTROL_TRANSPORT_JSON, a JSON argv array"
-  python3 - "$WP_CONTROL_TRANSPORT_JSON" <<'PY' || error "WP_CONTROL_TRANSPORT_JSON must be a non-empty JSON array of non-empty strings without NUL bytes"
-import json, sys
-value = json.loads(sys.argv[1])
-if not isinstance(value, list) or not value or any(not isinstance(item, str) or not item or "\0" in item for item in value):
-    raise SystemExit(1)
-PY
-  WP_CONTROL_TRANSPORT=()
-  while IFS= read -r -d '' transport_argument; do
-    WP_CONTROL_TRANSPORT+=("$transport_argument")
-  done < <(python3 - "$WP_CONTROL_TRANSPORT_JSON" <<'PY'
-import json, sys
-for item in json.loads(sys.argv[1]):
-    sys.stdout.buffer.write(item.encode() + b"\0")
-PY
-)
+  wp_cli_transport_set_json "$WP_CONTROL_TRANSPORT_JSON"
+  WP_CONTROL_TRANSPORT=("${WP_CLI_TRANSPORT[@]}")
 
   if [ "${DRY_RUN:-false}" != true ]; then
     mkdir -p "$RUNTIME_PROJECT_ROOT"

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -71,14 +71,10 @@ homeboy_json_array() {
 
 homeboy_dmc_wp_argv() {
   local argv=()
-  if [ "${IS_STUDIO:-false}" = true ]; then
-    argv=(studio wp)
-  else
-    # WP_CMD is intentionally a command string in setup profiles (e.g. "wp" or
-    # "studio wp"). Split it the same way the existing wp_cmd helper invokes it.
-    # shellcheck disable=SC2206
-    argv=(${WP_CMD:-wp})
-  fi
+  # WP_CMD is intentionally a command string in setup profiles (e.g. "wp" or
+  # "studio wp"). Split it the same way the existing wp_cmd helper invokes it.
+  # shellcheck disable=SC2206
+  argv=(${WP_CMD:-wp})
 
   printf '%s\n' "${argv[@]}"
 }

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -70,13 +70,8 @@ homeboy_json_array() {
 }
 
 homeboy_dmc_wp_argv() {
-  local argv=()
-  # WP_CMD is intentionally a command string in setup profiles (e.g. "wp" or
-  # "studio wp"). Split it the same way the existing wp_cmd helper invokes it.
-  # shellcheck disable=SC2206
-  argv=(${WP_CMD:-wp})
-
-  printf '%s\n' "${argv[@]}"
+  wp_cli_transport_ensure
+  printf '%s\n' "${WP_CLI_TRANSPORT[@]}"
 }
 
 homeboy_dmc_wp_flags() {
@@ -274,7 +269,7 @@ homeboy_dmc_task_attachment_skew_guidance() {
     return 0
   fi
 
-  warn "Homeboy accepts paired task-attachment commands, but DMC provider $provider does not advertise datamachine-code/worktree-provider-capabilities/v1 tracker attachment. Copied DMC release: $dmc_version. Homeboy: $homeboy_version. Rerun: \"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\". For one exact clean worktree, attach manually with: $WP_CMD datamachine-code workspace worktree attach-tracker <handle> --task-url=<task-url> --format=json${SITE_PATH:+ --path=\"$SITE_PATH\"}"
+  warn "Homeboy accepts paired task-attachment commands, but DMC provider $provider does not advertise datamachine-code/worktree-provider-capabilities/v1 tracker attachment. Copied DMC release: $dmc_version. Homeboy: $homeboy_version. Rerun: \"$SCRIPT_DIR/upgrade.sh\" --wp-path \"$SITE_PATH\". For one exact clean worktree, attach manually with: $(wp_cli_transport_display) datamachine-code workspace worktree attach-tracker <handle> --task-url=<task-url> --format=json${SITE_PATH:+ --path=\"$SITE_PATH\"}"
 }
 
 homeboy_dmc_worktree_provider_ready() {
@@ -835,7 +830,7 @@ configure_homeboy_wordpress_extension() {
     echo -e "${BLUE}[dry-run]${NC} homeboy extension update wordpress  # if already installed and not linked"
     echo -e "${BLUE}[dry-run]${NC} homeboy extension setup wordpress"
     echo -e "${BLUE}[dry-run]${NC} homeboy extension list"
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update datamachine_code_homeboy_available 1"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option update datamachine_code_homeboy_available 1"
     echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy AGENTS.md CLI guidance mu-plugin"
     print_homeboy_verification_commands
     return 0
@@ -871,7 +866,7 @@ configure_homeboy_wordpress_extension() {
 
 recompose_agents_md_for_homeboy() {
   if [ "$DRY_RUN" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} (as ${SERVICE_USER:-caller}) $WP_CMD datamachine memory compose AGENTS.md"
+    echo -e "${BLUE}[dry-run]${NC} (as ${SERVICE_USER:-caller}) $(wp_cli_transport_display) datamachine memory compose AGENTS.md"
     return 0
   fi
 
@@ -902,7 +897,7 @@ print_homeboy_verification_commands() {
   echo "  homeboy config show /worktree_providers/dmc"
   echo "  homeboy project show <project-id>"
   echo "  homeboy project components list <project-id>"
-  echo "  $WP_CMD datamachine-code workspace worktree provider --format=json$verification_wp_flags"
-  echo "  $WP_CMD datamachine memory compose AGENTS.md$verification_wp_flags"
+  echo "  $(wp_cli_transport_display) datamachine-code workspace worktree provider --format=json$verification_wp_flags"
+  echo "  $(wp_cli_transport_display) datamachine memory compose AGENTS.md$verification_wp_flags"
   echo "  ./scripts/verify-homeboy-codebox-canary.sh --workspace <repo-or-worktree> --secret-env <ENV_NAME> --agents-api <path> --agent-runtime <path> --agent-runtime-tools <path> --provider-plugin-path <path>  # opt-in model-backed Codebox canary; use --provider claude-code and the carried ai-provider-for-claude-code path for Claude Code; add --run to execute"
 }

--- a/lib/owned-source-discovery.sh
+++ b/lib/owned-source-discovery.sh
@@ -97,8 +97,7 @@ owned_discovery_supported() {
 # has nothing to do with what an apply would do.
 _owned_discovery_eval() {
   owned_discovery_supported || return 1
-  # shellcheck disable=SC2086
-  $WP_CMD eval "$1" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
+  wp_cmd eval "$1" 2>/dev/null || true
 }
 
 # 0 when the wp.org signal is present and recent enough to be evidence.
@@ -201,7 +200,7 @@ owned_discovery_record_exclusions() {
   [ -n "$excluded" ] || return 0
 
   if [ "${DRY_RUN:-false}" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $OWNED_DISCOVERY_EXCLUDED_OPTION '<${excluded}>'"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option update $OWNED_DISCOVERY_EXCLUDED_OPTION '<${excluded}>'"
     return 0
   fi
   owned_discovery_supported || return 0

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -77,16 +77,7 @@ SOURCE_POLICY_LEGACY_WRITABLE_OPTION="wp_coding_agents_managed_writable"
 _source_policy_option_read() {
   local key="$1"
   [ -n "${SITE_PATH:-}" ] || return 0
-  if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
-    wp_cmd option get "$key" 2>/dev/null || true
-    return 0
-  fi
-  if [ "${IS_STUDIO:-false}" = true ]; then
-    studio wp option get "$key" --path="$SITE_PATH" 2>/dev/null || true
-    return 0
-  fi
-  # shellcheck disable=SC2086
-  $WP_CMD option get "$key" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
+  wp_cmd option get "$key" 2>/dev/null || true
 }
 
 # Read an option, falling back to its pre-rename name.
@@ -278,7 +269,7 @@ source_policy_record_mode() {
   local mode="${SOURCE_MODE:-$SOURCE_POLICY_DEFAULT_MODE}"
 
   if [ "${DRY_RUN:-false}" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $SOURCE_POLICY_OPTION $mode"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option update $SOURCE_POLICY_OPTION $mode"
     return 0
   fi
 
@@ -389,7 +380,7 @@ source_policy_record_log_paths() {
   local paths="${SOURCE_LOG_PATHS:-}"
 
   if [ "${DRY_RUN:-false}" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $SOURCE_POLICY_LOG_OPTION '<${paths}>'"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option update $SOURCE_POLICY_LOG_OPTION '<${paths}>'"
     return 0
   fi
   if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
@@ -506,7 +497,7 @@ source_policy_record_writable_paths() {
   local paths="${OWNED_WRITABLE:-}"
 
   if [ "${DRY_RUN:-false}" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $SOURCE_POLICY_WRITABLE_OPTION '<${paths}>'"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option update $SOURCE_POLICY_WRITABLE_OPTION '<${paths}>'"
     return 0
   fi
   if [ -z "${SITE_PATH:-}" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
@@ -587,7 +578,7 @@ source_policy_record_owned_sources() {
   local sources="${OWNED_SOURCES:-}"
 
   if [ "${DRY_RUN:-false}" = true ]; then
-    echo -e "${BLUE}[dry-run]${NC} $WP_CMD option update $SOURCE_POLICY_OWNED_OPTION '<${sources}>'"
+    echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) option update $SOURCE_POLICY_OWNED_OPTION '<${sources}>'"
     return 0
   fi
 

--- a/lib/source-reconcile.sh
+++ b/lib/source-reconcile.sh
@@ -120,9 +120,7 @@ source_reconcile_run() {
   fi
 
   local out
-  # shellcheck disable=SC2086
-  out="$($WP_CMD eval 'if ( function_exists( "wp_coding_agents_reconcile_sources" ) ) { $r = wp_coding_agents_reconcile_sources( true ); echo $r["status"] . ( isset( $r["reason"] ) ? ": " . $r["reason"] : "" ); } else { echo "unavailable"; }' \
-    $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true)"
+  out="$(wp_cmd eval 'if ( function_exists( "wp_coding_agents_reconcile_sources" ) ) { $r = wp_coding_agents_reconcile_sources( true ); echo $r["status"] . ( isset( $r["reason"] ) ? ": " . $r["reason"] : "" ); } else { echo "unavailable"; }' 2>/dev/null || true)"
 
   case "$out" in
     reconciled*) log "  Owned sources reconciled from site state" ;;

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -43,7 +43,7 @@ print_summary() {
   if [ -n "$AGENT_SLUG" ]; then
     echo "  Agent:       $AGENT_SLUG"
   fi
-  echo "  Discover:    $WP_CMD datamachine memory paths${AGENT_SLUG:+ --agent=$AGENT_SLUG} $WP_ROOT_FLAG"
+  echo "  Discover:    $(wp_cli_transport_display) datamachine memory paths${AGENT_SLUG:+ --agent=$AGENT_SLUG} $WP_ROOT_FLAG"
   echo "  Source mode: ${SOURCE_MODE:-workspace}"
   if source_policy_workspace_enabled; then
     echo "  Code tools:  data-machine-code (workspace, GitHub, git)"
@@ -126,9 +126,9 @@ _print_next_steps() {
   echo "  Configure Data Machine:"
   echo "    - Set AI provider API keys in WP Admin → Data Machine → Settings"
   if [ "$LOCAL_MODE" = false ]; then
-    echo "    - Or via WP-CLI: $WP_CMD datamachine settings --allow-root"
+    echo "    - Or via WP-CLI: $(wp_cli_transport_display) datamachine settings --allow-root"
   else
-    echo "    - Or via WP-CLI: $WP_CMD datamachine settings --path=$SITE_PATH"
+    echo "    - Or via WP-CLI: $(wp_cli_transport_display) datamachine settings --path=$SITE_PATH"
   fi
   echo ""
 }

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -3,16 +3,14 @@
 
 # Run a WP-CLI command with the correct flags for the current platform.
 wp_cmd() {
+  wp_cli_transport_ensure
   if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
     local user_args=()
     [ -z "${WORDPRESS_USER:-}" ] || user_args=("--user=$WORDPRESS_USER")
-    run_cmd "${WP_CONTROL_TRANSPORT[@]}" "${user_args[@]}" "--path=$WORDPRESS_PATH" "$@"
+    run_cmd "${WP_CLI_TRANSPORT[@]}" "${user_args[@]}" "--path=$WORDPRESS_PATH" "$@"
     return
   fi
-  # WP_CMD is resolved once from explicit configuration and runtime capability.
-  # Environment identity does not change it at execution time.
-  # shellcheck disable=SC2086
-  run_cmd $WP_CMD "$@" $WP_ROOT_FLAG --path="$SITE_PATH"
+  run_cmd "${WP_CLI_TRANSPORT[@]}" "$@" $WP_ROOT_FLAG --path="$SITE_PATH"
 }
 
 # Run a WP-CLI command as the SERVICE user rather than the caller.
@@ -40,13 +38,12 @@ wp_run_as_service_user() {
      { [ "${WP_CODING_AGENTS_TEST_ASSUME_ROOT:-false}" = true ] || [ "$(id -u)" -eq 0 ]; } && \
      command -v sudo >/dev/null 2>&1; then
     # No WP_ROOT_FLAG: the whole point is that this invocation is not root.
-    # shellcheck disable=SC2086
-    sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" PATH="$PATH" $WP_CMD "$@"
+    wp_cli_transport_ensure
+    sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" PATH="$PATH" "${WP_CLI_TRANSPORT[@]}" "$@"
     return $?
   fi
 
-  # shellcheck disable=SC2086
-  $WP_CMD "$@" $WP_ROOT_FLAG
+  wp_cli "$@" $WP_ROOT_FLAG
 }
 
 # Activate a plugin, handling multisite --url= branching.
@@ -278,10 +275,11 @@ install_wordpress() {
     fi
 
     if [ ! -f wp-config.php ] || [ "$DRY_RUN" = true ]; then
-      run_cmd $WP_CMD core download --allow-root
-      run_cmd $WP_CMD config create --allow-root \
+      wp_cli_transport_ensure
+      run_cmd "${WP_CLI_TRANSPORT[@]}" core download --allow-root
+      run_cmd "${WP_CLI_TRANSPORT[@]}" config create --allow-root \
         --dbname="$DB_NAME" --dbuser="$DB_USER" --dbpass="$DB_PASS" --dbhost="localhost"
-      run_cmd $WP_CMD core install --allow-root \
+      run_cmd "${WP_CLI_TRANSPORT[@]}" core install --allow-root \
         --url="https://$SITE_DOMAIN" --title="My Site" \
         --admin_user="$WP_ADMIN_USER" --admin_password="$WP_ADMIN_PASS" \
         --admin_email="$WP_ADMIN_EMAIL"
@@ -300,9 +298,11 @@ setup_multisite() {
     log "Phase 3.5: Converting to WordPress Multisite ($MULTISITE_TYPE)..."
 
     if [ "$MULTISITE_TYPE" = "subdomain" ]; then
-      run_cmd $WP_CMD core multisite-convert --subdomains --allow-root --path="$SITE_PATH"
+      wp_cli_transport_ensure
+      run_cmd "${WP_CLI_TRANSPORT[@]}" core multisite-convert --subdomains --allow-root --path="$SITE_PATH"
     else
-      run_cmd $WP_CMD core multisite-convert --allow-root --path="$SITE_PATH"
+      wp_cli_transport_ensure
+      run_cmd "${WP_CLI_TRANSPORT[@]}" core multisite-convert --allow-root --path="$SITE_PATH"
     fi
 
     log "Multisite conversion complete"

--- a/lib/wordpress.sh
+++ b/lib/wordpress.sh
@@ -9,13 +9,10 @@ wp_cmd() {
     run_cmd "${WP_CONTROL_TRANSPORT[@]}" "${user_args[@]}" "--path=$WORDPRESS_PATH" "$@"
     return
   fi
-  if [ "$IS_STUDIO" = true ]; then
-    # shellcheck disable=SC2086
-    run_cmd studio wp "$@" --path="$SITE_PATH"
-  else
-    # shellcheck disable=SC2086
-    run_cmd $WP_CMD "$@" $WP_ROOT_FLAG --path="$SITE_PATH"
-  fi
+  # WP_CMD is resolved once from explicit configuration and runtime capability.
+  # Environment identity does not change it at execution time.
+  # shellcheck disable=SC2086
+  run_cmd $WP_CMD "$@" $WP_ROOT_FLAG --path="$SITE_PATH"
 }
 
 # Run a WP-CLI command as the SERVICE user rather than the caller.

--- a/operator-entrypoints/wp-coding-agents-setup/setup.md
+++ b/operator-entrypoints/wp-coding-agents-setup/setup.md
@@ -67,7 +67,7 @@ Do not duplicate script internals in this guide. Compile commands from the setup
 - Preserve user state. Do not rewrite existing runtime config or chat auth files outside what `setup.sh` is designed to manage.
 - Keep Codebox minion provider auth separate from optional WP AI Gateway external-client setup.
 - Keep Homeboy external to wp-coding-agents. The WordPress site root is a Homeboy project, not a component.
-- Use `WP_CMD="studio wp"` for WordPress Studio installs when the compiler selects that overlay.
+- Use `WP_CLI_TRANSPORT_JSON='["studio","wp"]'` when the compiler explicitly selects the WordPress Studio transport.
 - Use `--with-homeboy` only when the operator wants the optional developer layer.
 - Use `--no-chat` when the operator wants terminal/SSH-only operation.
 - Use `--no-skills` only when the operator explicitly wants to skip installing the upgrade skill on the target runtime.

--- a/runtimes/claude-code.sh
+++ b/runtimes/claude-code.sh
@@ -152,9 +152,7 @@ runtime_install_hooks() {
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} Would copy dm-agent-sync.sh to $hooks_dir"
-    if [ -n "${AGENT_SLUG:-}" ]; then
-      echo -e "${BLUE}[dry-run]${NC} Would write dm-agent-sync.env (DM_AGENT_SLUG=$AGENT_SLUG)"
-    fi
+    echo -e "${BLUE}[dry-run]${NC} Would write dm-agent-sync.env (WordPress transport$(if [ -n "${AGENT_SLUG:-}" ]; then printf ', DM_AGENT_SLUG=%s' "$AGENT_SLUG"; fi))"
     echo -e "${BLUE}[dry-run]${NC} Would configure SessionStart hook in $settings_file"
     return
   fi
@@ -169,16 +167,15 @@ runtime_install_hooks() {
   service_file_normalize_perms "$hook_dst"
   log "Installed hook: $hook_dst"
 
-  # Persist the configured agent slug so the SessionStart hook scopes its @
-  # includes to just this install's agent — matching the OpenCode runtime,
-  # which loads only the configured agent's files. Without this sidecar the
-  # hook falls back to discovering all active agents.
+  # Persist the canonical transport and optional agent scope for this
+  # standalone SessionStart hook.
   local hook_env="$hooks_dir/dm-agent-sync.env"
+  printf 'DATAMACHINE_WP_TRANSPORT_JSON=%q\n' "$(wp_cli_transport_json)" > "$hook_env"
   if [ -n "${AGENT_SLUG:-}" ]; then
-    printf 'DM_AGENT_SLUG=%s\n' "$AGENT_SLUG" > "$hook_env"
-    service_file_normalize_perms "$hook_env"
-    log "Wrote hook agent scope: $hook_env (DM_AGENT_SLUG=$AGENT_SLUG)"
+    printf 'DM_AGENT_SLUG=%q\n' "$AGENT_SLUG" >> "$hook_env"
   fi
+  service_file_normalize_perms "$hook_env"
+  log "Wrote hook runtime context: $hook_env"
 
   # Merge SessionStart hook, workspace permissions, and disable auto-memory in settings.json.
   # additionalDirectories alone is not enough: the Bash tool is gated by explicit

--- a/runtimes/codex.sh
+++ b/runtimes/codex.sh
@@ -51,7 +51,7 @@ for f in data:
         print(path)
 " 2>/dev/null || true)
       if [ -n "$DM_AGENT_FILES" ]; then
-        log "Agent files discovered via '$WP_CMD datamachine memory injectable-files${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+        log "Agent files discovered via '$(wp_cli_transport_display) datamachine memory injectable-files${AGENT_FLAG:+ ($AGENT_FLAG)}'"
         return
       fi
     fi
@@ -66,12 +66,12 @@ for f in data.get('relative_files', []):
     print(f)
 " 2>/dev/null || true)
       if [ -n "$DM_AGENT_FILES" ]; then
-        log "Agent files discovered via '$WP_CMD datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+        log "Agent files discovered via '$(wp_cli_transport_display) datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
         return
       fi
     fi
 
-    warn "'$WP_CMD datamachine memory injectable-files' and 'memory paths' returned no JSON — Codex AGENTS.md memory block will be skipped"
+    warn "'$(wp_cli_transport_display) datamachine memory injectable-files' and 'memory paths' returned no JSON — Codex AGENTS.md memory block will be skipped"
     DM_AGENT_FILES=""
   else
     DM_DRY_SLUG="${AGENT_SLUG:-AGENT_SLUG}"

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -96,14 +96,14 @@ for f in data:
     if path:
         print(path)
 ")
-      log "Agent files discovered via '$WP_CMD datamachine memory injectable-files${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+      log "Agent files discovered via '$(wp_cli_transport_display) datamachine memory injectable-files${AGENT_FLAG:+ ($AGENT_FLAG)}'"
       return
     fi
 
     DM_PATHS_RAW=$(wp_cmd datamachine memory paths --format=json $AGENT_FLAG 2>/dev/null || echo "")
     DM_PATHS_JSON=$(echo "$DM_PATHS_RAW" | sed -n '/^{/,/^}/p')
     if [ -z "$DM_PATHS_JSON" ]; then
-      error "'$WP_CMD datamachine memory injectable-files' and '$WP_CMD datamachine memory paths' returned no JSON — is Data Machine active and agent created?"
+      error "'$(wp_cli_transport_display) datamachine memory injectable-files' and '$(wp_cli_transport_display) datamachine memory paths' returned no JSON — is Data Machine active and agent created?"
     fi
     DM_AGENT_FILES=$(echo "$DM_PATHS_JSON" | python3 -c "
 import sys, json
@@ -111,7 +111,7 @@ data = json.load(sys.stdin)
 for f in data.get('relative_files', []):
     print(f)
 ")
-    log "Agent files discovered via '$WP_CMD datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
+    log "Agent files discovered via '$(wp_cli_transport_display) datamachine memory paths${AGENT_FLAG:+ ($AGENT_FLAG)}'"
   else
     # Dry-run: use placeholder paths
     DM_DRY_SLUG="${AGENT_SLUG:-AGENT_SLUG}"

--- a/scripts/compile-setup-profile.mjs
+++ b/scripts/compile-setup-profile.mjs
@@ -158,7 +158,7 @@ function compile(profile) {
   }
 
   if (target.wordpress_studio || overlays.wordpress_studio) {
-    env.WP_CMD = "studio wp"
+    env.WP_CLI_TRANSPORT_JSON = '["studio","wp"]'
   }
 
   const runtime = normalizeRuntime(profile, availableRuntimes, warnings)
@@ -200,7 +200,7 @@ function compile(profile) {
     const runtimeOnlyEnv = {}
     const wordpressPath = target.wordpress_path || (target.domain ? `/var/www/${target.domain}` : "")
     if (wordpressPath) runtimeOnlyEnv.EXISTING_WP = wordpressPath
-    if (env.WP_CMD) runtimeOnlyEnv.WP_CMD = env.WP_CMD
+    if (env.WP_CLI_TRANSPORT_JSON) runtimeOnlyEnv.WP_CLI_TRANSPORT_JSON = env.WP_CLI_TRANSPORT_JSON
 
     for (const name of runtime.requested.slice(1)) {
       const runtimeOnlyCommand = ["./setup.sh"]

--- a/services/datamachine-worker.sh
+++ b/services/datamachine-worker.sh
@@ -2,6 +2,8 @@
 # Optional Data Machine queue worker. This service drains Data Machine work; it
 # does not act as a generic WP-Cron heartbeat.
 
+DATAMACHINE_WORKER_TRANSPORT=()
+
 datamachine_worker_systemd_units() { echo "datamachine-worker.service datamachine-worker.timer"; }
 datamachine_worker_launchd_label() { echo "com.wp.datamachine-worker"; }
 datamachine_worker_state_file() { printf '%s/.config/wp-coding-agents/datamachine-worker.enabled' "$SERVICE_HOME"; }
@@ -49,46 +51,24 @@ _datamachine_worker_xml_text() {
   printf '%s' "$value"
 }
 
-_datamachine_worker_uses_studio() {
-  [ "${WP_CMD:-wp}" = "studio wp" ]
-}
-
-_datamachine_worker_resolve_studio_bin() {
-  local candidate="${STUDIO_BIN:-}"
-  local directory
-
-  if [ -z "$candidate" ]; then
-    candidate="$(command -v studio 2>/dev/null || true)"
-  fi
-
-  if [ -z "$candidate" ] || [ ! -f "$candidate" ] || [ ! -x "$candidate" ]; then
-    printf 'Data Machine worker requires an executable Studio CLI; install it or ensure studio is on PATH during setup/upgrade.\n' >&2
-    return 1
-  fi
-
-  case "$candidate" in
-    /*) printf '%s\n' "$candidate" ;;
-    *)
-      directory="$(cd "$(dirname "$candidate")" && pwd)" || return 1
-      printf '%s/%s\n' "$directory" "$(basename "$candidate")"
-      ;;
-  esac
-}
-
 datamachine_worker_prepare_command() {
-  _datamachine_worker_uses_studio || return 0
-  STUDIO_BIN="$(_datamachine_worker_resolve_studio_bin)" || return 1
-  export STUDIO_BIN
+  local executable
+  wp_cli_transport_ensure
+  DATAMACHINE_WORKER_TRANSPORT=("${WP_CLI_TRANSPORT[@]}")
+  executable="$(command -v "${WP_CLI_TRANSPORT[0]}" 2>/dev/null || true)"
+  if [ -n "$executable" ]; then
+    DATAMACHINE_WORKER_TRANSPORT[0]="$executable"
+  fi
 }
 
 _datamachine_worker_command() {
-  if _datamachine_worker_uses_studio; then
-    [ -n "${STUDIO_BIN:-}" ] || datamachine_worker_prepare_command || return 1
-    printf 'cd "%s" && %s wp datamachine worker run --once' "$SITE_PATH" "$(_datamachine_worker_shell_quote "$STUDIO_BIN")"
-    return
-  fi
-
-  printf '%s' "cd \"$SITE_PATH\" && $WP_CMD datamachine worker run --once"
+  local command="" argument quoted
+  [ "${#DATAMACHINE_WORKER_TRANSPORT[@]}" -gt 0 ] || datamachine_worker_prepare_command || return 1
+  for argument in "${DATAMACHINE_WORKER_TRANSPORT[@]}"; do
+    printf -v quoted '%q' "$argument"
+    command="${command:+$command }$quoted"
+  done
+  printf 'cd "%s" && %s datamachine worker run --once' "$SITE_PATH" "$command"
 }
 
 datamachine_worker_render_systemd_service() {

--- a/setup.sh
+++ b/setup.sh
@@ -458,7 +458,9 @@ ENVIRONMENT VARIABLES:
   OPENCODE_MODEL_ID         Default model ID for Telegram bot (default: big-pickle)
   EXTRA_PLUGINS      Space-separated slug:url pairs for additional plugins
   MCP_SERVERS        JSON object merged into runtime config (requires jq)
-  WP_CMD             Override WP-CLI command (default: wp; e.g., "studio wp")
+  WP_CLI_TRANSPORT_JSON
+                     Explicit WP-CLI argv JSON (e.g., '["studio","wp"]')
+  WP_CMD             Legacy command-string input; parsed once into argv
   WP_CONTROL_TRANSPORT_JSON  JSON argv array used by --external-wordpress
   HOMEBOY_EXTENSIONS_SOURCE  Homeboy extensions git URL/path
                      (default: https://github.com/Extra-Chill/homeboy-extensions.git)

--- a/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
+++ b/tests/__snapshots__/datamachine-worker/launchd-studio-absolute-path
@@ -8,7 +8,7 @@
     <array>
         <string>/bin/sh</string>
         <string>-lc</string>
-        <string>cd "/var/www/site" &amp;&amp; '/tmp/datamachine-worker-studio-path/studio tools/studio' wp datamachine worker run --once</string>
+        <string>cd "/var/www/site" &amp;&amp; /tmp/datamachine-worker-studio-path/studio\ tools/studio wp datamachine worker run --once</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/var/www/site</string>

--- a/tests/bridge-render.sh
+++ b/tests/bridge-render.sh
@@ -19,6 +19,7 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$SCRIPT_DIR"
+source "$SCRIPT_DIR/lib/common.sh"
 
 UPDATE=false
 VERBOSE=false

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -57,19 +57,13 @@ trap 'rm -r "$studio_root"' EXIT
 
 saved_path="$PATH"
 PATH="$(dirname "$studio_bin"):$saved_path"
-WP_CMD="studio wp"
-STUDIO_BIN="$studio_root/missing-studio"
-if datamachine_worker_prepare_command; then
-  echo "FAIL: missing Studio executable was accepted" >&2
-  exit 1
-fi
-unset STUDIO_BIN
+wp_cli_transport_set studio wp
 datamachine_worker_prepare_command
 studio_plist="$(datamachine_worker_render_launchd com.wp.datamachine-worker)"
 PATH="$saved_path"
 
 diff -u "$snapshot_dir/launchd-studio-absolute-path" <(printf '%s\n' "$studio_plist")
-grep -Fq "'$studio_bin' wp datamachine worker run --once" <<< "$studio_plist"
+grep -Fq "${studio_bin// /\\ } wp datamachine worker run --once" <<< "$studio_plist"
 if grep -q 'wp cron event run --due-now' <<< "$studio_plist"; then
   echo "launchd worker must not execute generic WP-Cron" >&2
   exit 1
@@ -98,7 +92,7 @@ mkdir -p "$SERVICE_HOME" "$SITE_PATH" "$DATAMACHINE_WORKER_LAUNCHD_DIR" "$DATAMA
 launchctl() { printf 'launchctl %s\n' "$*" >> "$calls"; }
 systemctl() { printf 'systemctl %s\n' "$*" >> "$calls"; }
 
-WP_CMD=wp
+wp_cli_transport_set wp
 LOCAL_MODE=true
 PLATFORM=mac
 unset DATAMACHINE_WORKER_REQUEST WP_CODING_AGENTS_DATAMACHINE_WORKER_ENABLED

--- a/tests/detect-site-domain.sh
+++ b/tests/detect-site-domain.sh
@@ -72,7 +72,7 @@ WP_CMD=""
 
 detect_environment > "$TMP/output.log"
 
-if [ "$WP_CMD" != "wp" ] || [ -s "$STUDIO_LOG" ]; then
+if [ "$(wp_cli_transport_display)" != "wp" ] || [ -s "$STUDIO_LOG" ]; then
   echo "FAIL: Studio detection did not prefer the usable direct wp transport"
   cat "$TMP/output.log" "$STUDIO_LOG"
   exit 1
@@ -116,7 +116,7 @@ SITE_DOMAIN=""
 WP_CMD=""
 : > "$STUDIO_LOG"
 detect_environment > "$TMP/studio-fallback-output.log"
-if [ "$WP_CMD" != "studio wp" ] || [ "$SITE_DOMAIN" != "intelligence-chubes4.local" ] || [ ! -s "$STUDIO_LOG" ]; then
+if [ "$(wp_cli_transport_display)" != "studio wp" ] || [ "$SITE_DOMAIN" != "intelligence-chubes4.local" ] || [ ! -s "$STUDIO_LOG" ]; then
   echo "FAIL: unusable direct WP-CLI did not fall back to the Studio transport"
   cat "$TMP/studio-fallback-output.log" "$STUDIO_LOG"
   exit 1
@@ -127,7 +127,7 @@ run_cmd() {
   printf '<%s>' "$@" > "$RUN_LOG"
 }
 IS_STUDIO=true
-WP_CMD="wp"
+wp_cli_transport_set wp
 WP_ROOT_FLAG=""
 wp_cmd option get siteurl
 if [ "$(cat "$RUN_LOG")" != "<wp><option><get><siteurl><--path=$SITE_PATH>" ]; then
@@ -135,7 +135,7 @@ if [ "$(cat "$RUN_LOG")" != "<wp><option><get><siteurl><--path=$SITE_PATH>" ]; t
   cat "$RUN_LOG"
   exit 1
 fi
-WP_CMD="studio wp"
+wp_cli_transport_set studio wp
 wp_cmd option get siteurl
 if [ "$(cat "$RUN_LOG")" != "<studio><wp><option><get><siteurl><--path=$SITE_PATH>" ]; then
   echo "FAIL: wp_cmd did not preserve the explicit Studio transport"
@@ -146,14 +146,14 @@ fi
 WP_CMD=""
 EXISTING_WP="$SITE_PATH"
 detect_plugins_only_environment > "$TMP/plugins-only-output.log"
-if [ "$WP_CMD" != "studio wp" ]; then
+if [ "$(wp_cli_transport_display)" != "studio wp" ]; then
   echo "FAIL: plugin-only detection did not select the available Studio fallback"
   cat "$TMP/plugins-only-output.log"
   exit 1
 fi
 WP_CMD="wp"
 detect_plugins_only_environment > "$TMP/plugins-only-explicit-output.log"
-if [ "$WP_CMD" != "wp" ]; then
+if [ "$(wp_cli_transport_display)" != "wp" ]; then
   echo "FAIL: plugin-only detection replaced the explicit wp transport"
   cat "$TMP/plugins-only-explicit-output.log"
   exit 1

--- a/tests/detect-site-domain.sh
+++ b/tests/detect-site-domain.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/detect.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/wordpress.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -20,6 +22,7 @@ FAKE_BIN="$TMP/bin"
 mkdir -p "$FAKE_BIN"
 cat > "$FAKE_BIN/studio" <<'SH'
 #!/bin/sh
+printf '%s\n' "$*" >> "$STUDIO_LOG"
 if [ "$1 $2 $3 $4" = "wp option get siteurl" ] && [ "$5" = "--path=$EXPECTED_SITE_PATH" ]; then
   printf 'http://intelligence-chubes4.local\n'
   exit 0
@@ -34,9 +37,23 @@ fi
 exit 0
 SH
 chmod +x "$FAKE_BIN/studio"
+cat > "$FAKE_BIN/wp" <<'SH'
+#!/bin/sh
+if [ "$1 $2 $3" = "option get siteurl" ] && [ "$4" = "--path=$EXPECTED_SITE_PATH" ]; then
+  printf 'http://intelligence-chubes4.local\n'
+  exit 0
+fi
+if [ "$1 $2 $3" = "option get siteurl" ]; then
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$FAKE_BIN/wp"
 PATH="$FAKE_BIN:$PATH"
 EXPECTED_SITE_PATH="$SITE_PATH"
-export EXPECTED_SITE_PATH
+STUDIO_LOG="$TMP/studio.log"
+: > "$STUDIO_LOG"
+export EXPECTED_SITE_PATH STUDIO_LOG
 
 OS=""
 PLATFORM=""
@@ -51,12 +68,18 @@ RUNTIME="opencode"
 MULTISITE=false
 MULTISITE_TYPE="subdirectory"
 SITE_DOMAIN=""
-WP_CMD="wp"
+WP_CMD=""
 
 detect_environment > "$TMP/output.log"
 
+if [ "$WP_CMD" != "wp" ] || [ -s "$STUDIO_LOG" ]; then
+  echo "FAIL: Studio detection did not prefer the usable direct wp transport"
+  cat "$TMP/output.log" "$STUDIO_LOG"
+  exit 1
+fi
+
 if [ "$SITE_DOMAIN" != "intelligence-chubes4.local" ]; then
-  echo "FAIL: expected SITE_DOMAIN from path-scoped Studio siteurl, got '$SITE_DOMAIN'"
+  echo "FAIL: expected SITE_DOMAIN from the path-scoped wp transport, got '$SITE_DOMAIN'"
   cat "$TMP/output.log"
   exit 1
 fi
@@ -78,4 +101,62 @@ if [ "$SITE_DOMAIN" != "intelligence-chubes4" ]; then
   exit 1
 fi
 
-echo "OK: existing-site domain detection scopes Studio WP-CLI to the site path and falls back when empty"
+SITE_DOMAIN=""
+EXPECTED_SITE_PATH="$SITE_PATH"
+WP_CMD="studio wp"
+detect_environment > "$TMP/studio-output.log"
+if [ "$SITE_DOMAIN" != "intelligence-chubes4.local" ] || [ ! -s "$STUDIO_LOG" ]; then
+  echo "FAIL: explicit Studio transport was not preserved and invoked"
+  cat "$TMP/studio-output.log" "$STUDIO_LOG"
+  exit 1
+fi
+
+rm "$FAKE_BIN/wp"
+SITE_DOMAIN=""
+WP_CMD=""
+: > "$STUDIO_LOG"
+detect_environment > "$TMP/studio-fallback-output.log"
+if [ "$WP_CMD" != "studio wp" ] || [ "$SITE_DOMAIN" != "intelligence-chubes4.local" ] || [ ! -s "$STUDIO_LOG" ]; then
+  echo "FAIL: unusable direct WP-CLI did not fall back to the Studio transport"
+  cat "$TMP/studio-fallback-output.log" "$STUDIO_LOG"
+  exit 1
+fi
+
+RUN_LOG="$TMP/run-command.log"
+run_cmd() {
+  printf '<%s>' "$@" > "$RUN_LOG"
+}
+IS_STUDIO=true
+WP_CMD="wp"
+WP_ROOT_FLAG=""
+wp_cmd option get siteurl
+if [ "$(cat "$RUN_LOG")" != "<wp><option><get><siteurl><--path=$SITE_PATH>" ]; then
+  echo "FAIL: wp_cmd ignored the explicit default transport"
+  cat "$RUN_LOG"
+  exit 1
+fi
+WP_CMD="studio wp"
+wp_cmd option get siteurl
+if [ "$(cat "$RUN_LOG")" != "<studio><wp><option><get><siteurl><--path=$SITE_PATH>" ]; then
+  echo "FAIL: wp_cmd did not preserve the explicit Studio transport"
+  cat "$RUN_LOG"
+  exit 1
+fi
+
+WP_CMD=""
+EXISTING_WP="$SITE_PATH"
+detect_plugins_only_environment > "$TMP/plugins-only-output.log"
+if [ "$WP_CMD" != "studio wp" ]; then
+  echo "FAIL: plugin-only detection did not select the available Studio fallback"
+  cat "$TMP/plugins-only-output.log"
+  exit 1
+fi
+WP_CMD="wp"
+detect_plugins_only_environment > "$TMP/plugins-only-explicit-output.log"
+if [ "$WP_CMD" != "wp" ]; then
+  echo "FAIL: plugin-only detection replaced the explicit wp transport"
+  cat "$TMP/plugins-only-explicit-output.log"
+  exit 1
+fi
+
+echo "OK: WordPress transport selection is capability-first and path-scoped"

--- a/tests/dm-workspace-discovery.sh
+++ b/tests/dm-workspace-discovery.sh
@@ -21,6 +21,7 @@ CHILD_PID_FILE="$TMP/child.pid"
 DESCENDANT_PID_FILE="$TMP/descendant.pid"
 export WP_CALLS_FILE CHILD_PID_FILE DESCENDANT_PID_FILE
 
+source "$SCRIPT_DIR/lib/common.sh"
 log() { printf '%s\n' "$1"; }
 warn() { printf '%s\n' "$1"; }
 

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -39,6 +39,16 @@ WITH_HOMEBOY=false
 mkdir -p "$SITE_PATH/wp-content/plugins/data-machine-code/bin" "$TMP/dmc-source/bin" "$DM_WORKSPACE_DIR"
 touch "$SITE_PATH/wp-config.php"
 
+default_transport="$(homeboy_dmc_command_json ensure)"
+case "$default_transport" in
+  '["wp",'*) ;;
+  *)
+    echo "FAIL: Studio environment metadata replaced the explicit wp transport: $default_transport"
+    exit 1
+    ;;
+esac
+WP_CMD="studio wp"
+
 assert_contains() {
   local needle="$1" file="$2"
   if ! grep -qF -- "$needle" "$file"; then

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -47,7 +47,19 @@ case "$default_transport" in
     exit 1
     ;;
 esac
-WP_CMD="studio wp"
+WP_CMD=""
+WP_CLI_TRANSPORT_JSON='["/runtime path/php","/runtime path/wp-cli.phar"]'
+WP_CLI_TRANSPORT=()
+argv_transport="$(homeboy_dmc_command_json ensure)"
+case "$argv_transport" in
+  '["/runtime path/php","/runtime path/wp-cli.phar",'*) ;;
+  *)
+    echo "FAIL: canonical argv transport was not serialized losslessly: $argv_transport"
+    exit 1
+    ;;
+esac
+unset WP_CLI_TRANSPORT_JSON
+wp_cli_transport_set studio wp
 
 assert_contains() {
   local needle="$1" file="$2"

--- a/tests/homeboy-verification-guidance.sh
+++ b/tests/homeboy-verification-guidance.sh
@@ -15,7 +15,7 @@ SITE_PATH="/path/to/site"
 WP_ROOT_FLAG=""
 
 SUMMARY="$(print_homeboy_verification_commands)"
-WP_CMD="studio wp"
+wp_cli_transport_set studio wp
 SITE_PATH=""
 STUDIO_SUMMARY="$(print_homeboy_verification_commands)"
 SKILL="skills/upgrade-wp-coding-agents/SKILL.md"

--- a/tests/setup-profile-compiler.mjs
+++ b/tests/setup-profile-compiler.mjs
@@ -95,7 +95,7 @@ for (const selection of ["auto", "codex", "claude-code", "multiple"]) {
 
   assert.equal(
     plan.commands.dry_run,
-    'EXISTING_WP="$HOME/Studio/site" WP_CMD=\'studio wp\' ./setup.sh --local --runtime opencode --chat kimaki --with-homeboy --agent-slug site --dry-run'
+    'EXISTING_WP="$HOME/Studio/site" WP_CLI_TRANSPORT_JSON=\'["studio","wp"]\' ./setup.sh --local --runtime opencode --chat kimaki --with-homeboy --agent-slug site --dry-run'
   )
   assert.ok(plan.verification.overlays.includes("verify-wordpress-studio"))
   assert.ok(plan.verification.overlays.includes("verify-runtime-opencode"))

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -829,7 +829,7 @@ PY
 )
   if [ -n "$AGENT_FOR_INSTRUCTIONS" ]; then
     local injectable_raw injectable_json
-    injectable_raw=$($WP_CMD datamachine memory injectable-files --format=json --agent="$AGENT_FOR_INSTRUCTIONS" --path="$SITE_PATH" $WP_ROOT_FLAG 2>/dev/null || echo "")
+    injectable_raw=$(wp_cmd datamachine memory injectable-files --format=json --agent="$AGENT_FOR_INSTRUCTIONS" 2>/dev/null || echo "")
     injectable_json=$(echo "$injectable_raw" | sed -n '/^\[/,/^\]/p')
     if [ -n "$injectable_json" ]; then
       MANAGED_INSTRUCTIONS_FILE=$(mktemp)
@@ -1008,7 +1008,7 @@ regenerate_agents_md() {
     echo -e "${BLUE}[dry-run]${NC} Would backup $AGENTS_MD → $BACKUP"
     echo -e "${BLUE}[dry-run]${NC} Would sync WordPress coding-agent boundary guidance mu-plugin"
     echo -e "${BLUE}[dry-run]${NC} Would sync Homeboy AGENTS.md CLI guidance mu-plugin"
-    echo -e "${BLUE}[dry-run]${NC} Would run (as ${SERVICE_USER:-caller}): $WP_CMD datamachine memory compose AGENTS.md"
+    echo -e "${BLUE}[dry-run]${NC} Would run (as ${SERVICE_USER:-caller}): $(wp_cli_transport_display) datamachine memory compose AGENTS.md"
     if _runtime_detected opencode; then
       echo -e "${BLUE}[dry-run]${NC} Would symlink $CLAUDE_MD → AGENTS.md (Claude-model context)"
     fi
@@ -1145,8 +1145,7 @@ _resolve_claude_code_agent_slug() {
 # Return 0 if a Data Machine agent with the given slug exists.
 _dm_agent_slug_exists() {
   local slug="$1" json
-  # shellcheck disable=SC2086
-  json=$($WP_CMD datamachine agents list --format=json $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null) || return 1
+  json=$(wp_cmd datamachine agents list --format=json 2>/dev/null) || return 1
   echo "$json" | python3 -c "
 import sys, json, re
 raw = sys.stdin.read()
@@ -1496,16 +1495,16 @@ _print_verify_block() {
     fi
   fi
 
-  log "  $WP_CMD plugin get data-machine --field=version --path=$SITE_PATH $WP_ROOT_FLAG"
-  log "  $WP_CMD plugin get data-machine-code --field=version --path=$SITE_PATH $WP_ROOT_FLAG"
+  log "  $(wp_cli_transport_display) plugin get data-machine --field=version --path=$SITE_PATH $WP_ROOT_FLAG"
+  log "  $(wp_cli_transport_display) plugin get data-machine-code --field=version --path=$SITE_PATH $WP_ROOT_FLAG"
   log "  cat $SITE_PATH/AGENTS.md | head -20   # agent instructions"
   log "  ls $(runtime_skills_dir)              # installed upgrade skill"
 }
 
 _print_plugins_only_verify_block() {
   log "Verify:"
-  log "  $WP_CMD plugin get data-machine --fields=name,status,version --format=json --skip-plugins --path=$SITE_PATH $WP_ROOT_FLAG"
-  log "  $WP_CMD plugin get data-machine-code --fields=name,status,version --format=json --skip-plugins --path=$SITE_PATH $WP_ROOT_FLAG"
+  log "  $(wp_cli_transport_display) plugin get data-machine --fields=name,status,version --format=json --skip-plugins --path=$SITE_PATH $WP_ROOT_FLAG"
+  log "  $(wp_cli_transport_display) plugin get data-machine-code --fields=name,status,version --format=json --skip-plugins --path=$SITE_PATH $WP_ROOT_FLAG"
 }
 
 # ============================================================================

--- a/verify.sh
+++ b/verify.sh
@@ -37,6 +37,7 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
 
 QUIET=false
 JSON=false
@@ -101,14 +102,13 @@ if [ -z "$SITE_PATH" ] || [ ! -f "$SITE_PATH/wp-config.php" ]; then
   exit 2
 fi
 
-WP_CMD="${WP_CMD:-wp}"
-command -v "$WP_CMD" >/dev/null 2>&1 || { echo "verify: $WP_CMD not on PATH" >&2; exit 2; }
+wp_cli_transport_ensure
+command -v "${WP_CLI_TRANSPORT[0]}" >/dev/null 2>&1 || { echo "verify: $(wp_cli_transport_display) not on PATH" >&2; exit 2; }
 WP_ROOT_FLAG=""
 [ "$(id -u)" -eq 0 ] && WP_ROOT_FLAG="--allow-root"
 
 wp_opt() {
-  # shellcheck disable=SC2086
-  "$WP_CMD" option get "$1" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
+  wp_cli option get "$1" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
 }
 
 SOURCE_MODE="$(wp_opt wp_coding_agents_source_mode | tr -d '[:space:]')"


### PR DESCRIPTION
## Summary

- establish `WP_CLI_TRANSPORT_JSON` as the canonical public argv contract and `WP_CLI_TRANSPORT` as the sole resolved execution array
- resolve ordered transport candidates by capability, preferring usable direct `wp` and treating `studio wp` as one fallback option for Studio-marked sites
- preserve shipped `WP_CMD` callers through a one-time shell-string-to-argv input adapter; no production path executes `$WP_CMD`
- route WordPress helpers, external control, Homeboy DMC provider JSON, worker services, Kimaki, profile compilation, and the standalone Claude hook through resolved argv
- remove downstream `IS_STUDIO` command switching and Studio-only worker handling
- cover direct selection, Studio fallback, plugin-only selection, explicit argv with spaces, service rendering, external control, and profile compilation

Closes #487.

## Verification

- repository shell syntax gate across every `*.sh`
- `git diff --check`
- transport-focused and affected suites passed locally, including `detect-site-domain`, `homeboy-dmc-provider`, `external-wordpress-runtime`, `datamachine-worker`, `bridge-render`, `setup-profile-compiler`, `claude-code-hook-scope`, `claude-code-permissions`, `dm-workspace-discovery`, plugin-only/upgrade bounds, runtime suites, and source discovery
- broad local suite passed through all transport-affected tests
- macOS-only failures in `source-mode`, `verify`, and `service-migration` reproduced identically on untouched main and are not branch regressions; Linux CI is authoritative for those filesystem/root-sensitive suites
- direct bundled PHP/WP-CLI invocation successfully queried DMC workspace state against the Studio site

## AI assistance

- **AI assistance:** Yes
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** Traced all WordPress command execution and serialization paths, designed and implemented the canonical argv transport contract, migrated consumers, expanded regression coverage, and ran verification under Chris Huber direction.