### PR TITLE
Fix DMC planning supervision timeout

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -162,7 +162,7 @@ homeboy_dmc_worktree_provider_json() {
   else
     resolve_task="$(homeboy_dmc_command_json resolve_task "$provider")"
   fi
-  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":12000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s' \
+  printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":60000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s' \
     "$(homeboy_dmc_command_json resolve_identity "$provider")" \
     "$(homeboy_dmc_command_json attest_safety "$provider")" \
     "$(homeboy_dmc_command_json resolve "$provider")" \

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -103,11 +103,13 @@ expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "sa
 expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", sys.argv[5], sys.argv[4], "{identity}", "{base}"]
 expected_attachment_preview = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "task_attachment_preview", sys.argv[5], sys.argv[4], "{handle}", "{task_url}"]
 expected_attachment_apply = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "task_attachment_apply", "{handle}", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "attach-tracker", "{handle}", "--task-url={task_url}", "--format=json", f"--path={sys.argv[3]}"]
-if provider.get("lookup_timeout_ms") != 12000:
-    raise SystemExit("FAIL: Homeboy must reserve a supervision margin beyond the DMC adapter budget")
+if provider.get("lookup_timeout_ms") != 60000:
+    raise SystemExit("FAIL: standalone DMC planning must have a realistic bounded timeout")
 adapter = open(commands["resolve_task"][1], encoding="utf-8").read()
 adapter_budget = int(re.search(r"HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = (\d+)", adapter).group(1))
 adapter_grace = int(re.search(r"HOMEBOY_DMC_TASK_TERMINATION_GRACE_SECONDS = (\d+)", adapter).group(1))
+if adapter_budget != 8:
+    raise SystemExit("FAIL: DMC task lookup must retain its inner execution deadline")
 if (adapter_budget + adapter_grace) * 1000 >= provider["lookup_timeout_ms"]:
     raise SystemExit("FAIL: DMC execution and adapter cleanup must finish before Homeboy supervision")
 if provider.get("lookup_output_limit_bytes") != 262144:


### PR DESCRIPTION
## Summary

- restore the generated DMC provider supervision budget to 60 seconds so worktree planning can complete
- retain and explicitly test the task adapter's 8-second inner execution deadline
- preserve the ordering that lets adapter cleanup finish before outer Homeboy supervision

Closes #489

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode profiled the live timeout, recovered the Homeboy-generated candidate, applied it in the tracked worktree, and ran the listed gates. Chris Huber directed and reviewed the work and is responsible for this pull request.