### PR TITLE
Isolate WP-CLI scalar captures from PHP diagnostic prefixes

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -279,6 +279,7 @@ jobs:
           - runtime-signature
           - upgrade-opencode-auth-plugin-sync
           - worktree-context-projections
+          - wp-cli-machine-output
           - wp-config-permissions
     steps:
       - uses: actions/checkout@v4

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -143,6 +143,24 @@ wp_cli() {
   "${WP_CLI_TRANSPORT[@]}" "$@"
 }
 
+wp_cli_strip_php_diagnostics() {
+  python3 -c '
+import re
+import sys
+
+lines = sys.stdin.read().splitlines()
+while lines and not lines[0].strip():
+    lines.pop(0)
+while lines and re.match(r"^(?:PHP )?(?:Deprecated|Warning|Notice):\s", lines[0].lstrip()):
+    lines.pop(0)
+    while lines and not lines[0].strip():
+        lines.pop(0)
+sys.stdout.write("\n".join(lines))
+if lines:
+    sys.stdout.write("\n")
+'
+}
+
 write_file() {
   local file_path="$1"
   local content="$2"

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -158,7 +158,7 @@ detect_environment() {
     if [ "$DRY_RUN" = true ]; then
       detected_site_domain="${SITE_DOMAIN:-}"
     else
-      detected_site_domain=$(cd "$SITE_PATH" && wp_cli option get siteurl $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null | sed -E 's|^https?://||' || true)
+      detected_site_domain=$(cd "$SITE_PATH" && wp_cli option get siteurl $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null | wp_cli_strip_php_diagnostics | sed -E 's|^https?://||' || true)
     fi
     SITE_DOMAIN="${SITE_DOMAIN:-${detected_site_domain:-$(basename "$SITE_PATH")}}"
     log "Existing WordPress at: $SITE_PATH ($SITE_DOMAIN)"

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -77,7 +77,7 @@ SOURCE_POLICY_LEGACY_WRITABLE_OPTION="wp_coding_agents_managed_writable"
 _source_policy_option_read() {
   local key="$1"
   [ -n "${SITE_PATH:-}" ] || return 0
-  wp_cmd option get "$key" 2>/dev/null || true
+  wp_cmd option get "$key" 2>/dev/null | wp_cli_strip_php_diagnostics || true
 }
 
 # Read an option, falling back to its pre-rename name.

--- a/tests/wp-cli-machine-output.sh
+++ b/tests/wp-cli-machine-output.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# tests/wp-cli-machine-output.sh — isolate WP-CLI scalar captures from PHP diagnostics.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/detect.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/wordpress.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/source-policy.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+DIAGNOSTIC='Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in phar:///tmp/wp-cli.phar/vendor/react/promise/src/functions.php on line 369'
+WARNING='PHP Warning: Undefined array key 0 in /tmp/example.php on line 1'
+
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: $label"
+    echo "  expected: [$expected]"
+    echo "  actual:   [$actual]"
+    exit 1
+  fi
+}
+
+normal="$(printf 'http://localhost:8881\n' | wp_cli_strip_php_diagnostics)"
+assert_eq "$normal" "http://localhost:8881" "normal scalar stdout is unchanged"
+
+contaminated="$(printf '\n%s\nhttp://localhost:8881\n' "$DIAGNOSTIC" | wp_cli_strip_php_diagnostics)"
+assert_eq "$contaminated" "http://localhost:8881" "leading PHP diagnostics are stripped from scalar stdout"
+
+warning="$(printf '%s\n/var/log/nginx\n' "$WARNING" | wp_cli_strip_php_diagnostics)"
+assert_eq "$warning" "/var/log/nginx" "leading PHP warnings are stripped from scalar stdout"
+
+empty="$(printf '%s\n\n' "$DIAGNOSTIC" | wp_cli_strip_php_diagnostics)"
+assert_eq "$empty" "" "diagnostic-only stdout becomes an empty payload"
+
+SITE_PATH="$TMP/intelligence-chubes4"
+mkdir -p "$SITE_PATH"
+touch "$SITE_PATH/wp-config.php"
+FAKE_BIN="$TMP/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/wp" <<SH
+#!/bin/sh
+if [ "\$1 \$2 \$3" = "option get siteurl" ] && [ "\$4" = "--path=\$EXPECTED_SITE_PATH" ]; then
+  printf '%s\nhttp://localhost:8881\n' "$DIAGNOSTIC"
+  exit 0
+fi
+if [ "\$1 \$2 \$3" = "option get siteurl" ]; then
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$FAKE_BIN/wp"
+PATH="$FAKE_BIN:$PATH"
+
+OS=""
+PLATFORM=""
+LOCAL_MODE=true
+MODE="existing"
+SKIP_DEPS=true
+SKIP_SSL=true
+RUN_AS_ROOT=false
+DRY_RUN=false
+EXISTING_WP="$SITE_PATH"
+RUNTIME="opencode"
+MULTISITE=false
+MULTISITE_TYPE="subdirectory"
+SITE_DOMAIN=""
+WP_CMD=""
+EXPECTED_SITE_PATH="$SITE_PATH"
+export EXPECTED_SITE_PATH
+
+detect_environment > "$TMP/detect.log"
+
+assert_eq "$SITE_DOMAIN" "localhost:8881" "SITE_DOMAIN ignores a leading PHP diagnostic"
+if grep -q "Existing WordPress at: $SITE_PATH (localhost:8881)" "$TMP/detect.log"; then
+  :
+else
+  echo "FAIL: expected clean site identity in detect log"
+  cat "$TMP/detect.log"
+  exit 1
+fi
+if grep -q "Deprecated:" "$TMP/detect.log"; then
+  echo "FAIL: detect log captured PHP diagnostic text into site identity"
+  cat "$TMP/detect.log"
+  exit 1
+fi
+
+SITE_PATH="$TMP/log-site"
+mkdir -p "$SITE_PATH"
+touch "$SITE_PATH/wp-config.php"
+DRY_RUN=false
+SOURCE_LOG_PATHS_EXPLICIT=false
+SOURCE_LOG_PATHS=""
+
+wp_cmd() {
+  if [ "$1 $2" = "option get" ] && [ "$3" = "$SOURCE_POLICY_LOG_OPTION" ]; then
+    printf '%s\n/var/log/nginx /var/log/php\n' "$DIAGNOSTIC"
+    return 0
+  fi
+  echo "unexpected wp_cmd call: $*" >&2
+  return 1
+}
+
+source_policy_resolve_log_paths 2>/dev/null
+assert_eq "$(source_policy_log_paths | tr '\n' ' ')" "/var/log/nginx /var/log/php " \
+  "recorded log paths keep absolute payloads after a diagnostic prefix"
+
+SOURCE_LOG_PATHS=""
+wp_cmd() {
+  if [ "$1 $2" = "option get" ] && [ "$3" = "$SOURCE_POLICY_LOG_OPTION" ]; then
+    printf '%s\n' "$DIAGNOSTIC"
+    return 0
+  fi
+  echo "unexpected wp_cmd call: $*" >&2
+  return 1
+}
+source_policy_resolve_log_paths 2>/dev/null
+assert_eq "$(source_policy_log_paths | tr '\n' ' ')" "" \
+  "diagnostic-only option output does not become candidate log paths"
+
+echo "OK: WP-CLI scalar captures isolate PHP diagnostics from machine payloads"


### PR DESCRIPTION
## Related issues

Fixes #494

Related, not duplicated:

- Extra-Chill/data-machine-code#1279 — DMC cannot intercept the notice; it is emitted during phar bootstrap before WordPress loads.
- Automattic/studio#4686 / #4731 — Studio WP-CLI launcher should route diagnostics to stderr.
- Automattic/studio#4734 — bundled WP-CLI 2.12.0 phar still vendors `react/promise` v2.
- wp-cli/wp-cli#6271 — closed; nightly is PHP 8.5-clean, latest stable is still 2.12.0.
- Extra-Chill/wp-coding-agents#458 — plugin-only JSON verification, a different capture path.

## How AI was used in this PR

OpenAI GPT-5.6 Sol via OpenCode general subagent investigated the PHP 8.5 `react/promise` deprecation across wp-coding-agents and Data Machine Code, searched existing trackers, identified the untracked scalar-capture gap, implemented the shared stdout isolator, added contaminated/normal fixtures, and opened this PR under human direction.

## Proposed Changes

Upgrade detection treated raw WP-CLI stdout as machine values. On PHP 8.5, Studio's bundled `wp-cli.phar` prints a `react/promise` deprecation before the payload, so `SITE_DOMAIN` became `Deprecated: ... localhost:8881` and recorded log paths were emptied after warning tokens were rejected as non-absolute paths.

This PR adds one capture helper in `lib/common.sh` and uses it for the two scalar readers that produced that failure: site URL detection and source-policy option reads. Host-runtime emission stays with Studio/WP-CLI; this defends the wp-coding-agents capture contract.

## Testing

- `bash tests/wp-cli-machine-output.sh`
- `bash tests/detect-site-domain.sh`
- `bash tests/source-mode.sh`
- `bash tests/owned-source-discovery.sh`

The new suite covers normal scalar stdout, warning-contaminated stdout, diagnostic-only stdout, `SITE_DOMAIN` detection, and recorded log-path normalization.