### PR TITLE
Preserve opaque DMC task references

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -133,7 +133,7 @@ homeboy_dmc_command_json() {
     ensure)
       # Homeboy owns each fanout worktree lifecycle. DMC verifies this complete
       # contract on creation and on owner-identical retries.
-      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace worktree add '{repo}' '{head}' '--from={base}' '--task-url={task_url}' '--reuse-policy=isolated' '--purpose={purpose}' '--owner-run-ref={owner_run_ref}' '--cleanup-policy={cleanup_policy}' --format=json "${wp_flags[@]}"
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" ensure "${wp_argv[@]}" datamachine-code workspace worktree add '{repo}' '{head}' '--from={base}' '--task-url={task_url}' '--reuse-policy=isolated' '--purpose={purpose}' '--owner-run-ref={owner_run_ref}' '--cleanup-policy={cleanup_policy}' --format=json "${wp_flags[@]}"
       ;;
     converge)
       homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" converge "$provider" "$DM_WORKSPACE_DIR" '{identity}' '{base}'

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -201,6 +201,70 @@ $canonical_task_url = static function ( string $task_url ): string {
 	) ?? '';
 };
 
+$is_http_task_url = static function ( string $task_identity ): bool {
+	return (bool) preg_match('/^https?:\/\//i', trim($task_identity));
+};
+
+$opaque_task_ref = static function ( string $task_identity ): ?string {
+	$task_ref = trim($task_identity);
+	if ( '' === $task_ref || preg_match('/\s/', $task_ref) ) {
+		return null;
+	}
+	return $task_ref;
+};
+
+$requested_task_identity = static function ( string $task_identity ) use ( $canonical_task_url, $is_http_task_url, $opaque_task_ref ): string {
+	if ( '' === trim($task_identity) ) {
+		return '';
+	}
+	if ( $is_http_task_url($task_identity) ) {
+		return $canonical_task_url($task_identity);
+	}
+	$task_ref = $opaque_task_ref($task_identity);
+	if ( null === $task_ref ) {
+		fwrite(STDERR, "DMC tracker identity is not a valid HTTP URL or opaque task reference.\n");
+		exit(1);
+	}
+	return $task_ref;
+};
+
+$stored_task_identity = static function ( array $payload ) use ( $canonical_task_url, $is_http_task_url, $opaque_task_ref ): string {
+	$raw_url = $payload['task_url'] ?? null;
+	if ( is_string($raw_url) && '' !== trim($raw_url) ) {
+		if ( $is_http_task_url($raw_url) ) {
+			return $canonical_task_url($raw_url);
+		}
+		return $opaque_task_ref($raw_url) ?? '';
+	}
+	$raw_ref = $payload['task_ref'] ?? null;
+	if ( ! is_string($raw_ref) || '' === trim($raw_ref) ) {
+		return '';
+	}
+	if ( $is_http_task_url($raw_ref) ) {
+		return $canonical_task_url($raw_ref);
+	}
+	return $opaque_task_ref($raw_ref) ?? '';
+};
+
+$rewrite_task_identity_flags = static function ( array $command ) use ( $is_http_task_url, $opaque_task_ref ): array {
+	foreach ( $command as $index => $argument ) {
+		if ( ! is_string($argument) || ! str_starts_with($argument, '--task-url=') ) {
+			continue;
+		}
+		$raw = substr($argument, strlen('--task-url='));
+		if ( $is_http_task_url($raw) ) {
+			continue;
+		}
+		$task_ref = $opaque_task_ref($raw);
+		if ( null === $task_ref ) {
+			fwrite(STDERR, "DMC tracker identity is not a valid HTTP URL or opaque task reference.\n");
+			exit(1);
+		}
+		$command[ $index ] = '--task-ref=' . $task_ref;
+	}
+	return $command;
+};
+
 $task_attachment_result = static function ( array $identity, string $task_url, string $status ): array {
 	return array(
 		'schema'      => 'homeboy/worktree-provider-task-attachment/v1',
@@ -218,7 +282,7 @@ if ( 'task_attachment_preview' === $operation ) {
 	$provider  = (string) ( $argv[2] ?? '' );
 	$workspace = (string) ( $argv[3] ?? '' );
 	$handle    = (string) ( $argv[4] ?? '' );
-	$task_url  = $canonical_task_url((string) ( $argv[5] ?? '' ));
+	$task_url  = $requested_task_identity((string) ( $argv[5] ?? '' ));
 	if ( '' === $provider || '' === $workspace || '' === $handle || '' === $task_url ) {
 		fwrite(STDERR, "Usage: homeboy-dmc-provider.php task_attachment_preview <dmc-provider> <workspace-root> <handle> <task-url>\n");
 		exit(2);
@@ -255,7 +319,7 @@ if ( 'task_attachment_preview' === $operation ) {
 		fwrite(STDERR, "DMC tracker-attachment preview returned an incomplete exact identity.\n");
 		exit(1);
 	}
-	$existing_task_url = $canonical_task_url((string) ( $identity['task_url'] ?? '' ));
+	$existing_task_url = $stored_task_identity($identity);
 	if ( '' !== $existing_task_url && $task_url !== $existing_task_url ) {
 		fwrite(STDERR, "DMC worktree already has conflicting tracker ownership.\n");
 		exit(1);
@@ -287,7 +351,7 @@ if ( 'task_attachment_preview' === $operation ) {
 
 if ( 'task_attachment_apply' === $operation ) {
 	$handle   = (string) ( $argv[2] ?? '' );
-	$task_url = $canonical_task_url((string) ( $argv[3] ?? '' ));
+	$task_url = $requested_task_identity((string) ( $argv[3] ?? '' ));
 	$command  = array_slice($argv, 4);
 	if ( '' === $handle || '' === $task_url || array() === $command ) {
 		fwrite(STDERR, "Usage: homeboy-dmc-provider.php task_attachment_apply <handle> <task-url> <dmc-attach-tracker-command...>\n");
@@ -296,6 +360,7 @@ if ( 'task_attachment_apply' === $operation ) {
 	foreach ( $command as $index => $argument ) {
 		$command[ $index ] = str_replace(array( '{handle}', '{task_url}' ), array( $handle, $task_url ), $argument);
 	}
+	$command = $rewrite_task_identity_flags($command);
 	try {
 		$capture = $run_bounded_command($command, HOMEBOY_DMC_TASK_MAX_DMC_STDOUT_BYTES, HOMEBOY_DMC_TASK_MAX_DMC_STDERR_BYTES, HOMEBOY_DMC_ATTACHMENT_TIMEOUT_SECONDS);
 	} catch (Throwable $error) {
@@ -321,7 +386,7 @@ if ( 'task_attachment_apply' === $operation ) {
 	if (
 		! is_array($identity) || ! in_array($status, array( 'attached', 'already_attached' ), true)
 		|| $handle !== ( $attached['handle'] ?? null ) || $handle !== ( $identity['handle'] ?? null )
-		|| $task_url !== $canonical_task_url((string) ( $identity['task_url'] ?? '' ))
+		|| $task_url !== $stored_task_identity($identity)
 		|| ! is_string($identity['path'] ?? null) || '' === $identity['path'] || ! is_string($identity['branch'] ?? null) || '' === $identity['branch']
 		|| false !== ( $identity['primary'] ?? null )
 	) {
@@ -333,7 +398,7 @@ if ( 'task_attachment_apply' === $operation ) {
 }
 
 if ( 'resolve_task_standalone' === $operation ) {
-	$task_url = $canonical_task_url((string) ( $argv[2] ?? '' ));
+	$task_url = $requested_task_identity((string) ( $argv[2] ?? '' ));
 	$provider = (string) ( $argv[3] ?? '' );
 	$workspace = (string) ( $argv[4] ?? '' );
 	if ( '' === $task_url || '' === $provider || '' === $workspace ) {
@@ -363,7 +428,7 @@ if ( 'resolve_task_standalone' === $operation ) {
 	$candidates = is_array($payload) ? ( $payload['candidates'] ?? null ) : null;
 	if (
 		! is_array($payload) || 'datamachine-code/worktree-task-resolution/v1' !== ( $payload['schema'] ?? null )
-		|| 'complete' !== ( $payload['status'] ?? null ) || $task_url !== $canonical_task_url((string) ( $payload['task_url'] ?? '' ))
+		|| 'complete' !== ( $payload['status'] ?? null ) || $task_url !== $stored_task_identity($payload)
 		|| ! is_array($candidates) || ! array_is_list($candidates) || ! is_int($payload['total'] ?? null)
 		|| $payload['total'] !== count($candidates) || count($candidates) > HOMEBOY_DMC_TASK_MAX_CANDIDATES
 	) {
@@ -377,17 +442,21 @@ if ( 'resolve_task_standalone' === $operation ) {
 			! is_array($candidate) || ! is_string($candidate['handle'] ?? null) || '' === $candidate['handle']
 			|| ! is_string($candidate['path'] ?? null) || '' === $candidate['path']
 			|| ! is_string($candidate['branch'] ?? null) || '' === $candidate['branch']
-			|| $task_url !== $canonical_task_url((string) ( $candidate['task_url'] ?? '' ))
+			|| $task_url !== $stored_task_identity($candidate)
 			|| ! is_array($safety) || ! is_bool($safety['dirty'] ?? null) || ! is_bool($safety['unpushed'] ?? null) || ! is_bool($safety['primary'] ?? null)
 		) {
 			fwrite(STDERR, "DMC standalone task resolution returned an incomplete or mismatched candidate.\n");
 			exit(1);
 		}
-		foreach ( array( 'handle', 'path', 'branch', 'task_url' ) as $field ) {
+		foreach ( array( 'handle', 'path', 'branch' ) as $field ) {
 			if ( strlen($candidate[ $field ]) > HOMEBOY_DMC_TASK_MAX_FIELD_BYTES ) {
 				fwrite(STDERR, "DMC standalone task resolution field exceeds its bounded limit.\n");
 				exit(1);
 			}
+		}
+		if ( strlen($task_url) > HOMEBOY_DMC_TASK_MAX_FIELD_BYTES ) {
+			fwrite(STDERR, "DMC standalone task resolution field exceeds its bounded limit.\n");
+			exit(1);
 		}
 		$result[] = array(
 			'handle'   => $candidate['handle'],
@@ -411,7 +480,7 @@ if ( 'resolve_task_standalone' === $operation ) {
 }
 
 if ( 'resolve_task' === $operation ) {
-	$task_url = $canonical_task_url((string) ( $argv[2] ?? '' ));
+	$task_url = $requested_task_identity((string) ( $argv[2] ?? '' ));
 	$command  = array_slice($argv, 3);
 	if ( '' === $task_url || array() === $command ) {
 		fwrite(STDERR, "Usage: homeboy-dmc-provider.php resolve_task <task-url> <dmc-worktree-list-command...>\n");
@@ -469,7 +538,7 @@ if ( 'resolve_task' === $operation ) {
 			$task   = is_array($row) && is_array($row['task_full'] ?? null) ? $row['task_full'] : null;
 			$safety = is_array($row) && is_array($row['safety'] ?? null) ? $row['safety'] : null;
 			if (
-				! is_array($row) || ! is_array($task) || $task_url !== $canonical_task_url((string) ( $task['task_url'] ?? '' ))
+				! is_array($row) || ! is_array($task) || $task_url !== $stored_task_identity($task)
 				|| ! is_string($row['handle'] ?? null) || '' === $row['handle']
 				|| ! is_string($row['path'] ?? null) || '' === $row['path']
 			|| ! is_string($row['branch'] ?? null) || '' === $row['branch']
@@ -503,8 +572,32 @@ if ( 'resolve_task' === $operation ) {
 	exit(0);
 }
 
+if ( 'ensure' === $operation ) {
+	$command = $rewrite_task_identity_flags(array_slice($argv, 2));
+	if ( array() === $command ) {
+		fwrite(STDERR, "Usage: homeboy-dmc-provider.php ensure <dmc-worktree-add-command...>\n");
+		exit(2);
+	}
+	$process = proc_open($command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
+	if ( ! is_resource($process) ) {
+		fwrite(STDERR, "Could not start the DMC worktree add command.\n");
+		exit(1);
+	}
+	$stdout = stream_get_contents($pipes[1]);
+	$stderr = stream_get_contents($pipes[2]);
+	fclose($pipes[1]);
+	fclose($pipes[2]);
+	$status = proc_close($process);
+	fwrite(STDOUT, (string) $stdout);
+	fwrite(STDERR, (string) $stderr);
+	if ( 0 !== $status ) {
+		exit($status > 0 && $status < 256 ? $status : 1);
+	}
+	exit(0);
+}
+
 if ( 'plan' === $operation ) {
-	$command = array_slice($argv, 2);
+	$command = $rewrite_task_identity_flags(array_slice($argv, 2));
 	if ( array() === $command ) {
 		fwrite(STDERR, "Usage: homeboy-dmc-provider.php plan <dmc-worktree-plan-command...>\n");
 		exit(2);
@@ -655,7 +748,7 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 			fwrite(STDERR, "DMC worktree provider returned an unsupported safety envelope.\n");
 			exit(1);
 		}
-		$task_url = $canonical_task_url((string) ( $payload['task_url'] ?? '' ));
+		$task_url = $stored_task_identity($payload);
 		if (
 			( '' === $task_url && ! str_starts_with($value, '/') )
 			|| ! is_string($payload['handle'] ?? null) || '' === $payload['handle']

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -41,7 +41,7 @@ touch "$SITE_PATH/wp-config.php"
 
 default_transport="$(homeboy_dmc_command_json ensure)"
 case "$default_transport" in
-  '["wp",'*) ;;
+  *'"ensure","wp",'*) ;;
   *)
     echo "FAIL: Studio environment metadata replaced the explicit wp transport: $default_transport"
     exit 1
@@ -52,7 +52,7 @@ WP_CLI_TRANSPORT_JSON='["/runtime path/php","/runtime path/wp-cli.phar"]'
 WP_CLI_TRANSPORT=()
 argv_transport="$(homeboy_dmc_command_json ensure)"
 case "$argv_transport" in
-  '["/runtime path/php","/runtime path/wp-cli.phar",'*) ;;
+  *'"ensure","/runtime path/php","/runtime path/wp-cli.phar",'*) ;;
   *)
     echo "FAIL: canonical argv transport was not serialized losslessly: $argv_transport"
     exit 1
@@ -96,7 +96,7 @@ expected_resolve_path = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php
 expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task_standalone", "{task_url}", sys.argv[5], sys.argv[4]]
 if sys.argv[6] == "fallback":
     expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "--task-ref={task_url}", "--with-status", "--limit=200", "--envelope", "--format=json", f"--path={sys.argv[3]}"]
-expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
+expected_ensure = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "ensure", "studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", sys.argv[5], sys.argv[4], "{handle}"]
 expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", sys.argv[5], sys.argv[4], "{identity}"]
@@ -253,6 +253,51 @@ for disposition in ("unsafe", "ownership conflict"):
 PY
 }
 
+assert_opaque_task_ref_contract() {
+  python3 - "$1" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+lines = [line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/worktree_providers/dmc|")]
+if not lines:
+    raise SystemExit("FAIL: missing DMC provider config write")
+_, payload = lines[-1].split("|", 1)
+commands = json.loads(payload)["commands"]
+opaque_ref = "release/f61264c4-3e4b-4553-9ea1-de4fbb7454cc"
+intent = {"handle": "blocks-engine@fix-406-dmc-provider-plan", "repo": "blocks-engine", "base": "origin/main", "head": "fix/406-dmc-provider-plan", "task_url": opaque_ref, "idempotency_key": "blocks-engine@fix-406-dmc-provider-plan:blocks-engine:origin/main:fix/406-dmc-provider-plan", "purpose": "agent-task-cook", "owner_run_ref": "homeboy://agent-task/run/cook-406", "cleanup_policy": "remove_on_success"}
+
+def run(name, values):
+    return subprocess.run([part.format(**values) for part in commands[name]], text=True, capture_output=True, env=os.environ.copy())
+
+open(os.environ["STUDIO_LOG"], "w").close()
+planned = run("plan", intent)
+if planned.returncode or not json.loads(planned.stdout):
+    raise SystemExit(f"FAIL: opaque task_ref plan failed: {planned!r}")
+ensured = run("ensure", intent)
+if ensured.returncode or not json.loads(ensured.stdout).get("success"):
+    raise SystemExit(f"FAIL: opaque task_ref ensure failed: {ensured!r}")
+log = open(os.environ["STUDIO_LOG"], encoding="utf-8").read().splitlines()
+plan_ref = False
+ensure_ref = False
+for line in log:
+    if "workspace worktree plan" in line and f"--task-ref={opaque_ref}" in line:
+        plan_ref = True
+        if f"--task-url={opaque_ref}" in line:
+            raise SystemExit(f"FAIL: opaque plan still forwarded --task-url: {line!r}")
+    if "workspace worktree add" in line and f"--task-ref={opaque_ref}" in line:
+        ensure_ref = True
+        if f"--task-url={opaque_ref}" in line:
+            raise SystemExit(f"FAIL: opaque ensure still forwarded --task-url: {line!r}")
+if not plan_ref or not ensure_ref:
+    raise SystemExit(f"FAIL: opaque release identity did not reach plan and ensure as --task-ref: {log!r}")
+invalid = run("plan", {**intent, "task_url": "release/foo bar"})
+if invalid.returncode == 0 or "not a valid HTTP URL or opaque task reference" not in invalid.stderr:
+    raise SystemExit(f"FAIL: whitespace-bearing opaque identity must fail closed: {invalid!r}")
+PY
+}
+
 assert_resolution_contract() {
   python3 - "$1" "$DMC_STATE" <<'PY'
 import json
@@ -286,6 +331,14 @@ missing_path = run("missing_task", "resolve_path")
 missing_path_expected = [{**expected[0], "task_url": None}]
 if missing_path.returncode or json.loads(missing_path.stdout) != missing_path_expected:
     raise SystemExit(f"FAIL: exact path resolution did not preserve an untracked worktree for negotiated attachment: {missing_path!r}")
+opaque_ref = "release/f61264c4-3e4b-4553-9ea1-de4fbb7454cc"
+opaque_expected = [{**expected[0], "task_url": opaque_ref}]
+opaque = run("opaque_task_ref")
+if opaque.returncode or json.loads(opaque.stdout) != opaque_expected:
+    raise SystemExit(f"FAIL: exact handle resolution did not project DMC task_ref through task_url: {opaque!r}")
+opaque_path = run("opaque_task_ref", "resolve_path")
+if opaque_path.returncode or json.loads(opaque_path.stdout) != opaque_expected:
+    raise SystemExit(f"FAIL: exact path resolution did not project DMC task_ref through task_url: {opaque_path!r}")
 PY
 }
 
@@ -555,7 +608,8 @@ if ('identity' === $operation) {
         exit(0);
     }
     $mode = getenv('DMC_INVENTORY_MODE');
-    $task_url = 'missing_task' === $mode ? null : ('canonical_task' === $mode ? ' HTTPS://GITHUB.COM/Extra-Chill/wp-coding-agents/issues/419/?query=value#fragment ' : 'https://github.com/Extra-Chill/wp-coding-agents/issues/419');
+    $task_url = 'missing_task' === $mode || 'opaque_task_ref' === $mode ? null : ('canonical_task' === $mode ? ' HTTPS://GITHUB.COM/Extra-Chill/wp-coding-agents/issues/419/?query=value#fragment ' : 'https://github.com/Extra-Chill/wp-coding-agents/issues/419');
+    $task_ref = 'opaque_task_ref' === $mode ? 'release/f61264c4-3e4b-4553-9ea1-de4fbb7454cc' : null;
     echo json_encode(array(
         'schema' => 'datamachine-code/worktree-identity/v1',
         'status' => 'owned',
@@ -565,6 +619,7 @@ if ('identity' === $operation) {
         'branch' => 'fix/310-dmc-cook',
         'primary' => false,
         'task_url' => $task_url,
+        'task_ref' => $task_ref,
         'latency_ms' => 1,
     )) . "\n";
     exit(0);
@@ -795,7 +850,7 @@ fi
 if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree plan" ]; then
   [ "$6" = "blocks-engine" ] && [ "$7" = "fix/406-dmc-provider-plan" ] || exit 2
   case "$*" in
-    *--from=origin/main*--task-url=https://github.com/Extra-Chill/wp-coding-agents/issues/406*--reuse-policy=isolated*--purpose=agent-task-cook*--owner-run-ref=homeboy://agent-task/run/cook-406*--cleanup-policy=remove_on_success*--format=json*) ;;
+    *--from=origin/main*--task-url=https://github.com/Extra-Chill/wp-coding-agents/issues/406*--reuse-policy=isolated*--purpose=agent-task-cook*--owner-run-ref=homeboy://agent-task/run/cook-406*--cleanup-policy=remove_on_success*--format=json*|*--from=origin/main*--task-ref=release/f61264c4-3e4b-4553-9ea1-de4fbb7454cc*--reuse-policy=isolated*--purpose=agent-task-cook*--owner-run-ref=homeboy://agent-task/run/cook-406*--cleanup-policy=remove_on_success*--format=json*) ;;
     *) exit 2 ;;
   esac
   printf 'plan\n' >> "$DMC_ENSURE_LOG"
@@ -809,7 +864,7 @@ fi
 if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree add" ]; then
   [ "$6" = "blocks-engine" ] && [ "$7" = "fix/406-dmc-provider-plan" ] || exit 2
   case "$*" in
-    *--from=origin/main*--task-url=https://github.com/Extra-Chill/wp-coding-agents/issues/406*--reuse-policy=isolated*--purpose=agent-task-cook*--owner-run-ref=homeboy://agent-task/run/cook-406*--cleanup-policy=remove_on_success*--format=json*) ;;
+    *--from=origin/main*--task-url=https://github.com/Extra-Chill/wp-coding-agents/issues/406*--reuse-policy=isolated*--purpose=agent-task-cook*--owner-run-ref=homeboy://agent-task/run/cook-406*--cleanup-policy=remove_on_success*--format=json*|*--from=origin/main*--task-ref=release/f61264c4-3e4b-4553-9ea1-de4fbb7454cc*--reuse-policy=isolated*--purpose=agent-task-cook*--owner-run-ref=homeboy://agent-task/run/cook-406*--cleanup-policy=remove_on_success*--format=json*) ;;
     *) exit 2 ;;
   esac
   : > "$DMC_STATE"
@@ -865,7 +920,7 @@ assert_contains "\"task_attachment_preview\":[\"php\",\"$SCRIPT_DIR/scripts/home
 assert_contains "\"task_attachment_apply\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"task_attachment_apply\",\"{handle}\",\"{task_url}\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"attach-tracker\",\"{handle}\",\"--task-url={task_url}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"resolve_task_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
-assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"ensure\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"ensure\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"plan\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"plan\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"plan\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_not_contains '"list":' "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
@@ -903,6 +958,7 @@ assert_not_contains 'workspace worktree get' "$STUDIO_LOG"
 assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
+assert_opaque_task_ref_contract "$HOMEBOY_CONFIG_LOG"
 assert_convergence_contract "$HOMEBOY_CONFIG_LOG"
 assert_resolution_contract "$HOMEBOY_CONFIG_LOG"
 assert_standalone_task_resolution_contract "$HOMEBOY_CONFIG_LOG"


### PR DESCRIPTION
## Summary
- distinguish HTTP tracker URLs from opaque Homeboy lifecycle references
- translate opaque identities to DMC `--task-ref` during plan, ensure, and attachment
- preserve the same identity through task lookup and exact handle/path resolution
- keep existing URL canonicalization and fail closed on malformed opaque refs

## Verification
- `bash tests/homeboy-dmc-provider.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `git diff --check`

Closes #497

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the release failure across Homeboy, the wp-coding-agents bridge, and DMC; reviewed and completed an existing repair; corrected its provider-contract tests; and ran focused verification. Chris Huber directed and reviewed the work.