### PR TITLE
Allow trackerless DMC lifecycle identity resolution

### DIFF
--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -657,12 +657,11 @@ if ( 'identity' === $operation && in_array((string) ( $payload['status'] ?? '' )
 		}
 		$task_url = $canonical_task_url((string) ( $payload['task_url'] ?? '' ));
 		if (
-			( '' === $task_url && ! str_starts_with($value, '/') )
-			|| ! is_string($payload['handle'] ?? null) || '' === $payload['handle']
+			! is_string($payload['handle'] ?? null) || '' === $payload['handle']
 			|| ! is_string($payload['path'] ?? null) || '' === $payload['path']
 			|| ! is_string($payload['branch'] ?? null) || '' === $payload['branch']
 		) {
-			fwrite(STDERR, "DMC standalone identity does not provide tracker ownership.\n");
+			fwrite(STDERR, "DMC standalone identity returned an incomplete exact identity.\n");
 			exit(1);
 		}
 		$result = array(

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -280,12 +280,15 @@ canonical = run("canonical_task")
 if canonical.returncode or json.loads(canonical.stdout) != expected:
     raise SystemExit(f"FAIL: exact resolution did not canonicalize persisted task identity: {canonical!r}")
 missing = run("missing_task")
-if missing.returncode == 0 or "does not provide tracker ownership" not in missing.stderr:
-    raise SystemExit(f"FAIL: missing standalone tracker evidence must fail closed: {missing!r}")
+missing_expected = [{**expected[0], "task_url": None}]
+if missing.returncode or json.loads(missing.stdout) != missing_expected:
+    raise SystemExit(f"FAIL: lifecycle-owned handle resolution did not project a null tracker: {missing!r}")
 missing_path = run("missing_task", "resolve_path")
-missing_path_expected = [{**expected[0], "task_url": None}]
-if missing_path.returncode or json.loads(missing_path.stdout) != missing_path_expected:
+if missing_path.returncode or json.loads(missing_path.stdout) != missing_expected:
     raise SystemExit(f"FAIL: exact path resolution did not preserve an untracked worktree for negotiated attachment: {missing_path!r}")
+malformed = run("malformed")
+if malformed.returncode == 0 or "incomplete exact identity" not in malformed.stderr:
+    raise SystemExit(f"FAIL: malformed standalone identity must fail closed: {malformed!r}")
 PY
 }
 
@@ -562,7 +565,7 @@ if ('identity' === $operation) {
         'token' => 'fixture-token',
         'handle' => $value,
         'path' => getenv('DMC_STATE'),
-        'branch' => 'fix/310-dmc-cook',
+        'branch' => 'malformed' === $mode ? '' : 'fix/310-dmc-cook',
         'primary' => false,
         'task_url' => $task_url,
         'latency_ms' => 1,


### PR DESCRIPTION
## Summary

- project DMC-owned handle identity when tracker metadata is absent
- return `task_url: null` consistently for handle and path resolution
- retain strict handle, path, branch, and safety validation
- prove malformed exact identity still fails closed

Fixes #498. Companion Homeboy contract repair: Extra-Chill/homeboy#13788.

## Verification

- `php -l scripts/homeboy-dmc-provider.php`
- `bash tests/homeboy-dmc-provider.sh`
- `git diff --check`

Repository-wide ShellCheck still reports pre-existing `SC2034` warnings in the test harness; this change introduces no new warning class.

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode reproduced the trackerless handle-resolution failure, narrowed the adapter validation to exact identity fields, and extended the standalone provider contract tests under Chris Huber’s direction.