### PR TITLE
Route DMC planning through standalone provider

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -143,6 +143,9 @@ homeboy_dmc_command_json() {
       # generic provider result without creating the planned checkout.
       homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" plan "${wp_argv[@]}" datamachine-code workspace worktree plan '{repo}' '{head}' '--from={base}' '--task-url={task_url}' '--reuse-policy=isolated' '--purpose={purpose}' '--owner-run-ref={owner_run_ref}' '--cleanup-policy={cleanup_policy}' --format=json "${wp_flags[@]}"
       ;;
+    plan_standalone)
+      homeboy_json_array php "$SCRIPT_DIR/scripts/homeboy-dmc-provider.php" plan_standalone "$provider" "$DM_WORKSPACE_DIR" '{repo}' '{head}' '{base}' '{task_url}' '{purpose}' '{owner_run_ref}' '{cleanup_policy}'
+      ;;
     cleanup_preview)
       homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --dry-run --format=json "${wp_flags[@]}"
       ;;
@@ -156,11 +159,17 @@ homeboy_dmc_worktree_provider_json() {
   local provider="$1"
   local task_attachment_supported="${2:-false}"
   local task_resolution_supported="${3:-false}"
-  local resolve_task
+  local plan_supported="${4:-false}"
+  local resolve_task plan
   if [ "$task_resolution_supported" = true ]; then
     resolve_task="$(homeboy_dmc_command_json resolve_task_standalone "$provider")"
   else
     resolve_task="$(homeboy_dmc_command_json resolve_task "$provider")"
+  fi
+  if [ "$plan_supported" = true ]; then
+    plan="$(homeboy_dmc_command_json plan_standalone "$provider")"
+  else
+    plan="$(homeboy_dmc_command_json plan "$provider")"
   fi
   printf '{"enabled":true,"kind":"command","apply_enabled":true,"lookup_timeout_ms":60000,"lookup_output_limit_bytes":262144,"mutation_timeout_ms":120000,"list_result_mapping":{"items":"$","handle":"$.handle","path":"$.path","branch":"$.branch","task_url":"$.task_url","dirty":"$.safety.dirty","unpushed":"$.safety.unpushed","primary":"$.safety.primary"},"commands":{"resolve_identity":%s,"attest_safety":%s,"resolve":%s,"resolve_path":%s,"resolve_task":%s' \
     "$(homeboy_dmc_command_json resolve_identity "$provider")" \
@@ -176,7 +185,7 @@ homeboy_dmc_worktree_provider_json() {
   printf ',"resolve_not_found_exit_codes":[42],"resolve_task_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
     "$(homeboy_dmc_command_json ensure "$provider")" \
     "$(homeboy_dmc_command_json converge "$provider")" \
-    "$(homeboy_dmc_command_json plan "$provider")" \
+    "$plan" \
     "$(homeboy_dmc_command_json cleanup_preview "$provider")" \
     "$(homeboy_dmc_command_json cleanup_apply "$provider")"
 }
@@ -220,6 +229,28 @@ sys.exit(0 if (
     and "task" in payload["operations"]
     and payload.get("task_resolution_schema") == "datamachine-code/worktree-task-resolution/v1"
     and payload.get("task_resolution_limit") == 200
+) else 1)
+' >/dev/null 2>&1
+}
+
+homeboy_dmc_plan_capable() {
+  local provider="$1" response
+  response="$(php "$provider" capabilities 2>/dev/null)" || return 1
+  printf '%s' "$response" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+sys.exit(0 if (
+    payload.get("schema") == "datamachine-code/worktree-provider-capabilities/v1"
+    and isinstance(payload.get("operations"), list)
+    and "plan" in payload["operations"]
+    and payload.get("plan_schema") == "datamachine-code/worktree-plan/v1"
+    and payload.get("plan_mutating") is False
 ) else 1)
 ' >/dev/null 2>&1
 }
@@ -752,7 +783,7 @@ configure_homeboy_dmc_worktree_provider() {
     return 0
   fi
 
-  local provider provider_json task_attachment_supported=false task_resolution_supported=false
+  local provider provider_json task_attachment_supported=false task_resolution_supported=false plan_supported=false
   local dmc_task_attachment_supported=false homeboy_task_attachment_supported=false
   provider="$(homeboy_dmc_worktree_provider_executable)" || {
     homeboy_handle_failure "Data Machine Code standalone worktree provider source contract is unavailable; skipping Homeboy DMC worktree provider setup."
@@ -771,7 +802,10 @@ configure_homeboy_dmc_worktree_provider() {
   if homeboy_dmc_task_resolution_capable "$provider"; then
     task_resolution_supported=true
   fi
-  provider_json="$(homeboy_dmc_worktree_provider_json "$provider" "$task_attachment_supported" "$task_resolution_supported")"
+  if homeboy_dmc_plan_capable "$provider"; then
+    plan_supported=true
+  fi
+  provider_json="$(homeboy_dmc_worktree_provider_json "$provider" "$task_attachment_supported" "$task_resolution_supported" "$plan_supported")"
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} homeboy config set /worktree_providers/dmc '$provider_json'"

--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -14,6 +14,7 @@ const HOMEBOY_DMC_TASK_MAX_DMC_STDERR_BYTES = 65536;
 const HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = 8;
 const HOMEBOY_DMC_TASK_TERMINATION_GRACE_SECONDS = 1;
 const HOMEBOY_DMC_ATTACHMENT_TIMEOUT_SECONDS = 30;
+const HOMEBOY_DMC_PLAN_TIMEOUT_SECONDS = 30;
 
 if ( '_session_exec' === $operation ) {
 	$command = array_slice($argv, 2);
@@ -503,28 +504,80 @@ if ( 'resolve_task' === $operation ) {
 	exit(0);
 }
 
-if ( 'plan' === $operation ) {
-	$command = array_slice($argv, 2);
-	if ( array() === $command ) {
-		fwrite(STDERR, "Usage: homeboy-dmc-provider.php plan <dmc-worktree-plan-command...>\n");
-		exit(2);
+if ( in_array($operation, array( 'plan', 'plan_standalone' ), true) ) {
+	if ( 'plan_standalone' === $operation ) {
+		$provider  = (string) ( $argv[2] ?? '' );
+		$workspace = (string) ( $argv[3] ?? '' );
+		$repo      = (string) ( $argv[4] ?? '' );
+		$branch    = (string) ( $argv[5] ?? '' );
+		$base      = (string) ( $argv[6] ?? '' );
+		$task_url  = (string) ( $argv[7] ?? '' );
+		$purpose   = (string) ( $argv[8] ?? '' );
+		$owner     = (string) ( $argv[9] ?? '' );
+		$cleanup   = (string) ( $argv[10] ?? '' );
+		if ( '' === $provider || '' === $workspace || '' === $repo || '' === $branch || '' === $base || '' === $task_url || '' === $purpose || '' === $owner || '' === $cleanup ) {
+			fwrite(STDERR, "Usage: homeboy-dmc-provider.php plan_standalone <provider> <workspace> <repo> <branch> <base> <task-url> <purpose> <owner-run-ref> <cleanup-policy>\n");
+			exit(2);
+		}
+		$intent = json_encode(
+			array(
+				'repo'           => $repo,
+				'branch'         => $branch,
+				'from'           => $base,
+				'task_url'       => $task_url,
+				'reuse_policy'   => 'isolated',
+				'purpose'        => $purpose,
+				'owner_run_ref'  => $owner,
+				'cleanup_policy' => $cleanup,
+			),
+			JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+		);
+		try {
+			$capture = $run_bounded_command(array( PHP_BINARY, $provider, 'plan', $workspace, $intent ), HOMEBOY_DMC_TASK_MAX_OUTPUT_BYTES, HOMEBOY_DMC_TASK_MAX_DMC_STDERR_BYTES, HOMEBOY_DMC_PLAN_TIMEOUT_SECONDS);
+		} catch (Throwable $error) {
+			fwrite(STDERR, $error->getMessage() . "\n");
+			exit(1);
+		}
+		if ( null !== $capture['failure'] ) {
+			fwrite(STDERR, "DMC standalone worktree planning exceeded its bounded execution or capture.\n");
+			exit(1);
+		}
+		$status = $capture['status'];
+		$stdout = $capture['stdout'];
+		$stderr = $capture['stderr'];
+	} else {
+		$command = array_slice($argv, 2);
+		if ( array() === $command ) {
+			fwrite(STDERR, "Usage: homeboy-dmc-provider.php plan <dmc-worktree-plan-command...>\n");
+			exit(2);
+		}
+		$process = proc_open($command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
+		if ( ! is_resource($process) ) {
+			fwrite(STDERR, "Could not start the DMC worktree plan command.\n");
+			exit(1);
+		}
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
 	}
-	$process = proc_open($command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes);
-	if ( ! is_resource($process) ) {
-		fwrite(STDERR, "Could not start the DMC worktree plan command.\n");
-		exit(1);
-	}
-	$stdout = stream_get_contents($pipes[1]);
-	$stderr = stream_get_contents($pipes[2]);
-	fclose($pipes[1]);
-	fclose($pipes[2]);
-	$status = proc_close($process);
 	if ( 0 !== $status ) {
 		$evidence = trim($stdout . "\n" . $stderr);
 		if ( preg_match('/Disposition:\s*(unsafe|owner(?:ship)?[ _-]conflict)/i', $evidence, $matches) ) {
 			$normalized = strtolower(str_replace(array( ' ', '-' ), '_', $matches[1]));
 			$disposition = in_array($normalized, array( 'owner_conflict', 'ownership_conflict' ), true) ? 'owner_conflict' : 'unsafe';
 			fwrite(STDERR, 'DMC worktree plan disposition: ' . $disposition . "\n");
+			exit($status > 0 && $status < 256 ? $status : 1);
+		}
+		try {
+			$failure = $decode_json_output($stdout);
+		} catch (Throwable $error) {
+			$failure = null;
+		}
+		if ( is_array($failure) && is_string($failure['code'] ?? null) ) {
+			$message = is_string($failure['message'] ?? null) ? ': ' . $failure['message'] : '';
+			fwrite(STDERR, 'DMC worktree plan failed: ' . $failure['code'] . $message . "\n");
 			exit($status > 0 && $status < 256 ? $status : 1);
 		}
 		fwrite(STDERR, 'DMC worktree plan failed: ' . trim($stderr) . "\n");
@@ -536,7 +589,7 @@ if ( 'plan' === $operation ) {
 		fwrite(STDERR, 'DMC worktree plan returned invalid JSON: ' . $error->getMessage() . "\n");
 		exit(1);
 	}
-	if ( ! is_array($plan) || 1 !== ( $plan['version'] ?? null ) || ! is_string($plan['digest'] ?? null) || '' === $plan['digest'] ) {
+	if ( ! is_array($plan) || ( 'plan_standalone' === $operation && 'datamachine-code/worktree-plan/v1' !== ( $plan['schema'] ?? null ) ) || 1 !== ( $plan['version'] ?? null ) || ! is_string($plan['digest'] ?? null) || '' === $plan['digest'] ) {
 		fwrite(STDERR, "DMC worktree plan returned an unsupported typed envelope.\n");
 		exit(1);
 	}

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -97,7 +97,9 @@ expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php
 if sys.argv[6] == "fallback":
     expected_resolve_task = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "resolve_task", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "list", "--task-ref={task_url}", "--with-status", "--limit=200", "--envelope", "--format=json", f"--path={sys.argv[3]}"]
 expected_ensure = ["studio", "wp", "datamachine-code", "workspace", "worktree", "add", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
-expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
+expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan_standalone", sys.argv[5], sys.argv[4], "{repo}", "{head}", "{base}", "{task_url}", "{purpose}", "{owner_run_ref}", "{cleanup_policy}"]
+if sys.argv[6] == "fallback":
+    expected_plan = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "plan", "studio", "wp", "datamachine-code", "workspace", "worktree", "plan", "{repo}", "{head}", "--from={base}", "--task-url={task_url}", "--reuse-policy=isolated", "--purpose={purpose}", "--owner-run-ref={owner_run_ref}", "--cleanup-policy={cleanup_policy}", "--format=json", f"--path={sys.argv[3]}"]
 expected_identity = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "identity", sys.argv[5], sys.argv[4], "{handle}"]
 expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "safety", sys.argv[5], sys.argv[4], "{identity}"]
 expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", sys.argv[5], sys.argv[4], "{identity}", "{base}"]
@@ -108,10 +110,13 @@ if provider.get("lookup_timeout_ms") != 60000:
 adapter = open(commands["resolve_task"][1], encoding="utf-8").read()
 adapter_budget = int(re.search(r"HOMEBOY_DMC_TASK_LOOKUP_TIMEOUT_SECONDS = (\d+)", adapter).group(1))
 adapter_grace = int(re.search(r"HOMEBOY_DMC_TASK_TERMINATION_GRACE_SECONDS = (\d+)", adapter).group(1))
+plan_budget = int(re.search(r"HOMEBOY_DMC_PLAN_TIMEOUT_SECONDS = (\d+)", adapter).group(1))
 if adapter_budget != 8:
     raise SystemExit("FAIL: DMC task lookup must retain its inner execution deadline")
 if (adapter_budget + adapter_grace) * 1000 >= provider["lookup_timeout_ms"]:
     raise SystemExit("FAIL: DMC execution and adapter cleanup must finish before Homeboy supervision")
+if plan_budget != 30 or (plan_budget + adapter_grace) * 1000 >= provider["lookup_timeout_ms"]:
+    raise SystemExit("FAIL: standalone planning must retain a bounded inner deadline below Homeboy supervision")
 if provider.get("lookup_output_limit_bytes") != 262144:
     raise SystemExit("FAIL: DMC task lookup output must have an explicit finite Homeboy cap")
 if provider.get("mutation_timeout_ms") != 120000:
@@ -578,12 +583,46 @@ if ('capabilities' === $operation) {
     }
     echo json_encode(array(
         'schema' => 'datamachine-code/worktree-provider-capabilities/v1',
-        'operations' => 'task_legacy' === getenv('DMC_CAPABILITIES_MODE') ? array('identity', 'safety', 'converge', 'capabilities') : array('identity', 'task', 'safety', 'converge', 'capabilities'),
+        'operations' => 'task_legacy' === getenv('DMC_CAPABILITIES_MODE') ? array('identity', 'safety', 'converge', 'capabilities') : array('identity', 'task', 'safety', 'converge', 'plan', 'capabilities'),
         'tracker_fields' => array('task_url', 'task_ref'),
         'attachment_operation' => 'datamachine-code/workspace-worktree-attach-tracker',
         'attachment_standalone' => false,
         'task_resolution_schema' => 'datamachine-code/worktree-task-resolution/v1',
         'task_resolution_limit' => 200,
+        'plan_schema' => 'datamachine-code/worktree-plan/v1',
+        'plan_mutating' => false,
+    )) . "\n";
+    exit(0);
+}
+if ('plan' === $operation) {
+    $intent = json_decode($argv[3] ?? '', true);
+    $expected = array(
+        'repo' => 'blocks-engine',
+        'branch' => 'fix/406-dmc-provider-plan',
+        'from' => 'origin/main',
+        'task_url' => 'https://github.com/Extra-Chill/wp-coding-agents/issues/406',
+        'reuse_policy' => 'isolated',
+        'purpose' => 'agent-task-cook',
+        'owner_run_ref' => 'homeboy://agent-task/run/cook-406',
+        'cleanup_policy' => 'remove_on_success',
+    );
+    if ($intent !== $expected) {
+        fwrite(STDERR, "standalone plan intent mismatch\n");
+        exit(2);
+    }
+    file_put_contents(getenv('DMC_ENSURE_LOG'), "plan\n", FILE_APPEND);
+    if ('' !== (string) getenv('DMC_PLAN_TEXT_DISPOSITION')) {
+        fwrite(STDOUT, 'Disposition: ' . getenv('DMC_PLAN_TEXT_DISPOSITION') . "\n");
+        exit(9);
+    }
+    echo json_encode(array(
+        'schema' => 'datamachine-code/worktree-plan/v1',
+        'version' => 1,
+        'digest' => 'fixture-plan-digest',
+        'handle' => 'blocks-engine@fix-406-dmc-provider-plan',
+        'path' => getenv('DMC_PLAN_PATH'),
+        'branch' => 'fix/406-dmc-provider-plan',
+        'disposition' => getenv('DMC_PLAN_DISPOSITION') ?: 'create',
     )) . "\n";
     exit(0);
 }
@@ -868,7 +907,7 @@ assert_contains "\"task_attachment_apply\":[\"php\",\"$SCRIPT_DIR/scripts/homebo
 assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"resolve_task_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
-assert_contains "\"plan\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"plan\",\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"plan\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"plan\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"plan_standalone\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{repo}\",\"{head}\",\"{base}\",\"{task_url}\",\"{purpose}\",\"{owner_run_ref}\",\"{cleanup_policy}\"]" "$TMP/dry-run.log"
 assert_not_contains '"list":' "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
@@ -905,6 +944,8 @@ assert_not_contains 'workspace worktree get' "$STUDIO_LOG"
 assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
+assert_not_contains 'workspace worktree plan' "$STUDIO_LOG"
+assert_contains 'plan|{' "$DMC_PROVIDER_LOG"
 assert_convergence_contract "$HOMEBOY_CONFIG_LOG"
 assert_resolution_contract "$HOMEBOY_CONFIG_LOG"
 assert_standalone_task_resolution_contract "$HOMEBOY_CONFIG_LOG"


### PR DESCRIPTION
## Summary

- detect DMC standalone planning through its typed capability contract
- generate an argv-native, bounded standalone plan command for Homeboy
- preserve the WordPress planning fallback for older DMC releases
- keep ensure/apply on the authoritative WordPress mutation surface

Closes #500.

## Verification

- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `php -l scripts/homeboy-dmc-provider.php`
- `bash tests/homeboy-dmc-provider.sh`
- `git diff --check`

`tests/homeboy-dmc-provider.sh` proves the standalone route does not invoke `studio wp ... worktree plan`, validates the exact intent projection, exercises typed dispositions, and retains the capability-gated fallback.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode implemented the capability-gated adapter, bounded execution and diagnostics, and deterministic bridge coverage. Chris Huber directed the work and is responsible for the changes.