### PR TITLE
Fix DMC lifecycle finalizer configuration

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -185,11 +185,10 @@ homeboy_dmc_worktree_provider_json() {
       "$(homeboy_dmc_command_json task_attachment_preview "$provider")" \
       "$(homeboy_dmc_command_json task_attachment_apply "$provider")"
   fi
-  printf ',"resolve_not_found_exit_codes":[42],"resolve_task_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"finalize":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+  printf ',"resolve_not_found_exit_codes":[42],"resolve_task_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
     "$(homeboy_dmc_command_json ensure "$provider")" \
     "$(homeboy_dmc_command_json converge "$provider")" \
     "$plan" \
-    "$(homeboy_dmc_command_json finalize "$provider")" \
     "$(homeboy_dmc_command_json cleanup_preview "$provider")" \
     "$(homeboy_dmc_command_json cleanup_apply "$provider")"
 }
@@ -787,7 +786,7 @@ configure_homeboy_dmc_worktree_provider() {
     return 0
   fi
 
-  local provider provider_json task_attachment_supported=false task_resolution_supported=false plan_supported=false
+  local provider provider_json finalize_json task_attachment_supported=false task_resolution_supported=false plan_supported=false
   local dmc_task_attachment_supported=false homeboy_task_attachment_supported=false
   provider="$(homeboy_dmc_worktree_provider_executable)" || {
     homeboy_handle_failure "Data Machine Code standalone worktree provider source contract is unavailable; skipping Homeboy DMC worktree provider setup."
@@ -810,9 +809,11 @@ configure_homeboy_dmc_worktree_provider() {
     plan_supported=true
   fi
   provider_json="$(homeboy_dmc_worktree_provider_json "$provider" "$task_attachment_supported" "$task_resolution_supported" "$plan_supported")"
+  finalize_json="$(homeboy_dmc_command_json finalize "$provider")"
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} homeboy config set /worktree_providers/dmc '$provider_json'"
+    echo -e "${BLUE}[dry-run]${NC} homeboy config set /settings/worktree_provider_lifecycle/dmc/finalize '$finalize_json'"
     return 0
   fi
 
@@ -826,6 +827,10 @@ configure_homeboy_dmc_worktree_provider() {
   log "Configuring Homeboy DMC worktree provider."
   homeboy_run config set /worktree_providers/dmc "$provider_json" >/dev/null || \
     homeboy_handle_failure "Homeboy DMC worktree provider config failed."
+  if ! homeboy_run config set /settings/worktree_provider_lifecycle/dmc/finalize "$finalize_json" >/dev/null ||
+     ! homeboy_run config show /settings/worktree_provider_lifecycle/dmc/finalize >/dev/null; then
+    homeboy_handle_failure "Homeboy DMC worktree lifecycle finalizer config failed."
+  fi
 }
 
 configure_homeboy_wordpress_extension() {

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -105,7 +105,6 @@ expected_safety = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "sa
 expected_converge = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "converge", sys.argv[5], sys.argv[4], "{identity}", "{base}"]
 expected_attachment_preview = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "task_attachment_preview", sys.argv[5], sys.argv[4], "{handle}", "{task_url}"]
 expected_attachment_apply = ["php", f"{sys.argv[2]}/scripts/homeboy-dmc-provider.php", "task_attachment_apply", "{handle}", "{task_url}", "studio", "wp", "datamachine-code", "workspace", "worktree", "attach-tracker", "{handle}", "--task-url={task_url}", "--format=json", f"--path={sys.argv[3]}"]
-expected_finalize = ["studio", "wp", "datamachine-code", "workspace", "worktree", "finalize", "{handle}", "--state={lifecycle_state}", "--owner-terminal-outcome={owner_outcome}", "--format=json", f"--path={sys.argv[3]}"]
 if provider.get("lookup_timeout_ms") != 60000:
     raise SystemExit("FAIL: standalone DMC planning must have a realistic bounded timeout")
 adapter = open(commands["resolve_task"][1], encoding="utf-8").read()
@@ -149,8 +148,8 @@ if commands.get("task_attachment_preview") != expected_attachment_preview:
     raise SystemExit(f"FAIL: DMC task-attachment preview mapping mismatch: {commands.get('task_attachment_preview')!r}")
 if commands.get("task_attachment_apply") != expected_attachment_apply:
     raise SystemExit(f"FAIL: DMC task-attachment apply mapping mismatch: {commands.get('task_attachment_apply')!r}")
-if commands.get("finalize") != expected_finalize:
-    raise SystemExit(f"FAIL: DMC lifecycle finalization mapping mismatch: {commands.get('finalize')!r}")
+if "finalize" in commands:
+    raise SystemExit("FAIL: lifecycle finalization must use Homeboy's generic lifecycle settings")
 if "list" in commands:
     raise SystemExit("FAIL: DMC provider must not advertise unsupported generic list capability")
 PY
@@ -163,7 +162,7 @@ import os
 import subprocess
 import sys
 
-line = open(sys.argv[1], encoding="utf-8").read().strip()
+line = next(line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/worktree_providers/dmc|"))
 _, payload = line.split("|", 1)
 command = json.loads(payload)["commands"]["converge"]
 identity = "fixture-token"
@@ -269,8 +268,11 @@ import json
 import subprocess
 import sys
 
-_, payload = open(sys.argv[1], encoding="utf-8").read().strip().split("|", 1)
-command = json.loads(payload)["commands"]["finalize"]
+lines = [line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/settings/worktree_provider_lifecycle/dmc/finalize|")]
+if not lines:
+    raise SystemExit("FAIL: missing Homeboy DMC lifecycle finalizer config write")
+_, payload = lines[-1].split("|", 1)
+command = json.loads(payload)
 handle = "wp-codebox@release-wp-codebox-6b69fc607f7f"
 
 def run(lifecycle_state, owner_outcome):
@@ -302,7 +304,8 @@ import os
 import subprocess
 import sys
 
-_, payload = open(sys.argv[1], encoding="utf-8").read().strip().split("|", 1)
+line = next(line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/worktree_providers/dmc|"))
+_, payload = line.split("|", 1)
 commands = json.loads(payload)["commands"]
 intent = {"handle": "fixture@fix-310-dmc-cook", "path": sys.argv[2], "repo": "fixture"}
 
@@ -344,7 +347,8 @@ import sys
 import tempfile
 import time
 
-_, payload = open(sys.argv[1], encoding="utf-8").read().strip().split("|", 1)
+line = next(line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/worktree_providers/dmc|"))
+_, payload = line.split("|", 1)
 command = json.loads(payload)["commands"]["resolve_task"]
 task_url = "https://github.com/Extra-Chill/wp-coding-agents/issues/425"
 
@@ -494,7 +498,8 @@ import os
 import subprocess
 import sys
 
-_, payload = open(sys.argv[1], encoding="utf-8").read().strip().split("|", 1)
+line = next(line for line in open(sys.argv[1], encoding="utf-8").read().splitlines() if line.startswith("/worktree_providers/dmc|"))
+_, payload = line.split("|", 1)
 commands = json.loads(payload)["commands"]
 handle = "static-site-importer@refactor-1306-runtime-entity-form-materialization"
 task_url = "https://github.com/Automattic/static-site-importer/issues/1306"
@@ -772,6 +777,10 @@ if [ "$1 $2" = "config set" ]; then
   exit 0
 fi
 if [ "$1 $2" = "config show" ]; then
+  if [ "$3" = "/settings/worktree_provider_lifecycle/dmc/finalize" ]; then
+    grep -qF -- "$3|" "$HOMEBOY_CONFIG_LOG"
+    exit $?
+  fi
   [ "${HOMEBOY_ATTACHMENT_COMMANDS:-true}" = true ] && [ -f "$HOMEBOY_DATA_DIR/task-attachment-supported" ] && exit 0
   exit 2
 fi
@@ -955,7 +964,7 @@ assert_contains "\"resolve_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"resolve_task_not_found_exit_codes\":[42]" "$TMP/dry-run.log"
 assert_contains "\"ensure\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"add\",\"{repo}\",\"{head}\",\"--from={base}\",\"--task-url={task_url}\",\"--reuse-policy=isolated\",\"--purpose={purpose}\",\"--owner-run-ref={owner_run_ref}\",\"--cleanup-policy={cleanup_policy}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"plan\":[\"php\",\"$SCRIPT_DIR/scripts/homeboy-dmc-provider.php\",\"plan_standalone\",\"$DMC_PROVIDER_EXECUTABLE\",\"$DM_WORKSPACE_DIR\",\"{repo}\",\"{head}\",\"{base}\",\"{task_url}\",\"{purpose}\",\"{owner_run_ref}\",\"{cleanup_policy}\"]" "$TMP/dry-run.log"
-assert_contains "\"finalize\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"finalize\",\"{handle}\",\"--state={lifecycle_state}\",\"--owner-terminal-outcome={owner_outcome}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "homeboy config set /settings/worktree_provider_lifecycle/dmc/finalize '[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"finalize\",\"{handle}\",\"--state={lifecycle_state}\",\"--owner-terminal-outcome={owner_outcome}\",\"--format=json\",\"--path=$SITE_PATH\"]'" "$TMP/dry-run.log"
 assert_not_contains '"list":' "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
@@ -990,6 +999,7 @@ configure_homeboy_dmc_worktree_provider > "$TMP/apply.log"
 assert_contains 'identity|homeboy-readiness@probe' "$DMC_PROVIDER_LOG"
 assert_not_contains 'workspace worktree get' "$STUDIO_LOG"
 assert_contains "/worktree_providers/dmc|{\"enabled\":true,\"kind\":\"command\",\"apply_enabled\":true" "$HOMEBOY_CONFIG_LOG"
+assert_contains "/settings/worktree_provider_lifecycle/dmc/finalize|[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"worktree\",\"finalize\",\"{handle}\",\"--state={lifecycle_state}\",\"--owner-terminal-outcome={owner_outcome}\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
 assert_provider_contract "$HOMEBOY_CONFIG_LOG" "$SCRIPT_DIR" "$SITE_PATH"
 assert_provisioning_contract "$HOMEBOY_CONFIG_LOG"
 assert_finalization_contract "$HOMEBOY_CONFIG_LOG"


### PR DESCRIPTION
## Summary

- keep the DMC provider command map limited to provider operations
- configure finalization through Homeboy's generic `settings.worktree_provider_lifecycle.dmc.finalize` contract
- verify the lifecycle setting survives config readback
- exercise successful and failed owner outcomes through the separately configured finalizer

Closes #505.

## Verification

- `bash tests/homeboy-dmc-provider.sh`
- `git diff --check`
- `bash tests/verify.sh` has the same two pre-existing healthy-fixture assertions failing on untouched `origin/main`

## AI assistance

GPT-5.6 Sol via OpenCode diagnosed the runtime/schema mismatch, implemented the scoped configuration repair, and ran the focused and baseline verification.