### PR TITLE
Fail closed on unusable WordPress CLI transports

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -89,6 +89,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests/cli-transport-install.sh
         run: ./tests/cli-transport-install.sh
+      - name: Run tests/wp-cli-transport-resolution.sh
+        run: ./tests/wp-cli-transport-resolution.sh
       - name: Run tests/smoke-cli-transport.php
         run: php tests/smoke-cli-transport.php
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -105,7 +105,8 @@ PY
 }
 
 wp_cli_transport_resolve_candidates() {
-  local index name json
+  local index name json executable probe_output
+  local failures=()
   if [ -n "${WP_CLI_TRANSPORT_JSON:-}" ]; then
     wp_cli_transport_set_json "$WP_CLI_TRANSPORT_JSON"
     log "Using configured WordPress CLI transport: $(wp_cli_transport_display)"
@@ -122,20 +123,26 @@ wp_cli_transport_resolve_candidates() {
     name="${WP_CLI_TRANSPORT_CANDIDATE_NAMES[$index]}"
     json="${WP_CLI_TRANSPORT_CANDIDATE_JSON[$index]}"
     wp_cli_transport_parse_json "$json" || error "Invalid registered WordPress CLI transport candidate: $name"
-    if command -v "${WP_CLI_TRANSPORT[0]}" >/dev/null 2>&1 && {
-      [ "${DRY_RUN:-false}" = true ] ||
-        (cd "$SITE_PATH" && "${WP_CLI_TRANSPORT[@]}" eval 'return;' ${WP_ROOT_FLAG:-} --path="$SITE_PATH" >/dev/null 2>&1)
-    }; then
+    executable="${WP_CLI_TRANSPORT[0]}"
+    if ! command -v "$executable" >/dev/null 2>&1; then
+      failures+=("$name: executable '$executable' not found")
+    elif [ "${DRY_RUN:-false}" = true ]; then
       wp_cli_transport_set "${WP_CLI_TRANSPORT[@]}"
       log "Using WordPress CLI transport candidate '$name': $(wp_cli_transport_display)"
       return
+    elif probe_output="$(cd "$SITE_PATH" && "${WP_CLI_TRANSPORT[@]}" eval 'return;' ${WP_ROOT_FLAG:-} --path="$SITE_PATH" 2>&1)"; then
+      wp_cli_transport_set "${WP_CLI_TRANSPORT[@]}"
+      log "Using WordPress CLI transport candidate '$name': $(wp_cli_transport_display)"
+      return
+    else
+      probe_output="${probe_output//$'\n'/ }"
+      failures+=("$name: runtime probe failed${probe_output:+: ${probe_output:0:500}}")
     fi
     WP_CLI_TRANSPORT=()
     index=$((index + 1))
   done
 
-  wp_cli_transport_set wp
-  log "Using default WordPress CLI transport: $(wp_cli_transport_display)"
+  error "No usable WordPress CLI transport found. ${failures[*]:-No candidates were registered.} Set WP_CLI_TRANSPORT_JSON to an executable argv array."
 }
 
 wp_cli() {

--- a/tests/wp-cli-transport-resolution.sh
+++ b/tests/wp-cli-transport-resolution.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+
+log() { :; }
+error() {
+  printf 'ERROR: %s\n' "$1" >&2
+  return 1
+}
+
+export SITE_PATH="$TMP/site"
+mkdir -p "$SITE_PATH" "$TMP/bin"
+export PATH="$TMP/bin:/usr/bin:/bin"
+export DRY_RUN=false
+
+cat > "$TMP/bin/studio" <<'SH'
+#!/bin/bash
+printf 'fixture database unavailable\n' >&2
+exit 17
+SH
+chmod +x "$TMP/bin/studio"
+
+WP_CLI_TRANSPORT_CANDIDATE_NAMES=()
+WP_CLI_TRANSPORT_CANDIDATE_JSON=()
+WP_CLI_TRANSPORT=()
+wp_cli_transport_register_candidate direct missing-wp
+wp_cli_transport_register_candidate studio studio wp
+if wp_cli_transport_resolve_candidates 2> "$TMP/failure.log"; then
+  echo "FAIL: unusable transport candidates resolved successfully"
+  exit 1
+fi
+grep -F "direct: executable 'missing-wp' not found" "$TMP/failure.log" >/dev/null || {
+  echo "FAIL: missing executable diagnostic was not preserved"
+  exit 1
+}
+grep -F "studio: runtime probe failed: fixture database unavailable" "$TMP/failure.log" >/dev/null || {
+  echo "FAIL: Studio probe diagnostic was not preserved"
+  exit 1
+}
+[ "${#WP_CLI_TRANSPORT[@]}" -eq 0 ] || {
+  echo "FAIL: failed resolution retained an unusable transport"
+  exit 1
+}
+
+cat > "$TMP/bin/studio" <<'SH'
+#!/bin/bash
+[ "$1" = wp ] && [ "$2" = eval ] && exit 0
+exit 2
+SH
+chmod +x "$TMP/bin/studio"
+WP_CLI_TRANSPORT_CANDIDATE_NAMES=()
+WP_CLI_TRANSPORT_CANDIDATE_JSON=()
+wp_cli_transport_register_candidate direct missing-wp
+wp_cli_transport_register_candidate studio studio wp
+wp_cli_transport_resolve_candidates
+[ "${WP_CLI_TRANSPORT[*]}" = "studio wp" ] || {
+  echo "FAIL: usable Studio transport was not selected"
+  exit 1
+}
+
+WP_CLI_TRANSPORT=()
+WP_CLI_TRANSPORT_JSON='["configured-wp","--flag"]'
+wp_cli_transport_resolve_candidates
+[ "${WP_CLI_TRANSPORT[*]}" = "configured-wp --flag" ] || {
+  echo "FAIL: explicit transport was not authoritative"
+  exit 1
+}
+
+echo "OK: WordPress CLI transport resolution fails closed"


### PR DESCRIPTION
## Summary
- select only WordPress CLI transports whose executable and runtime probe succeed
- report bounded, candidate-specific discovery failures instead of synthesizing bare `wp`
- preserve successful Studio selection and authoritative explicit transport configuration

## Verification
- `bash -n lib/common.sh`
- `bash -n tests/wp-cli-transport-resolution.sh`
- `bash tests/wp-cli-transport-resolution.sh`
- `bash tests/homeboy-dmc-provider.sh`
- `bash tests/cli-transport-install.sh`
- `bash tests/ci-coverage.sh`

Closes #512.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode reproduced the Studio fallback failure, implemented bounded candidate diagnostics and fail-closed selection, and added portable regression coverage under Chris Huber's direction.