### PR TITLE
Configure typed DMC worktree retention

### DIFF
--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -155,6 +155,9 @@ homeboy_dmc_command_json() {
     cleanup_apply)
       homeboy_json_array "${wp_argv[@]}" datamachine-code workspace cleanup safe --format=json "${wp_flags[@]}"
       ;;
+    retention)
+      homeboy_json_array "${wp_argv[@]}" datamachine-code workspace retention-provider "${wp_flags[@]}"
+      ;;
   esac
 }
 
@@ -163,6 +166,7 @@ homeboy_dmc_worktree_provider_json() {
   local task_attachment_supported="${2:-false}"
   local task_resolution_supported="${3:-false}"
   local plan_supported="${4:-false}"
+  local retention_supported="${5:-false}"
   local resolve_task plan
   if [ "$task_resolution_supported" = true ]; then
     resolve_task="$(homeboy_dmc_command_json resolve_task_standalone "$provider")"
@@ -185,10 +189,15 @@ homeboy_dmc_worktree_provider_json() {
       "$(homeboy_dmc_command_json task_attachment_preview "$provider")" \
       "$(homeboy_dmc_command_json task_attachment_apply "$provider")"
   fi
-  printf ',"resolve_not_found_exit_codes":[42],"resolve_task_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s,"cleanup_preview":%s,"cleanup_apply":%s}}' \
+  printf ',"resolve_not_found_exit_codes":[42],"resolve_task_not_found_exit_codes":[42],"ensure":%s,"converge":%s,"plan":%s' \
     "$(homeboy_dmc_command_json ensure "$provider")" \
     "$(homeboy_dmc_command_json converge "$provider")" \
-    "$plan" \
+    "$plan"
+  if [ "$retention_supported" = true ]; then
+    printf ',"retention":%s,"retention_timeout_ms":120000' \
+      "$(homeboy_dmc_command_json retention "$provider")"
+  fi
+  printf ',"cleanup_preview":%s,"cleanup_apply":%s}}' \
     "$(homeboy_dmc_command_json cleanup_preview "$provider")" \
     "$(homeboy_dmc_command_json cleanup_apply "$provider")"
 }
@@ -270,6 +279,31 @@ homeboy_task_attachment_commands_supported() {
   fi
   rm -rf "$probe_root"
   return 1
+}
+
+homeboy_retention_command_supported() {
+  local probe_root probe_provider
+  probe_root="$(mktemp -d)" || return 1
+  probe_provider='{"enabled":false,"kind":"command","apply_enabled":false,"commands":{"retention":["true"],"retention_timeout_ms":120000}}'
+  if HOMEBOY_DATA_DIR="$probe_root" homeboy_run config set /worktree_providers/wpca-retention-probe "$probe_provider" >/dev/null 2>&1 &&
+     HOMEBOY_DATA_DIR="$probe_root" homeboy_run config show /worktree_providers/wpca-retention-probe/commands/retention >/dev/null 2>&1; then
+    rm -rf "$probe_root"
+    return 0
+  fi
+  rm -rf "$probe_root"
+  return 1
+}
+
+homeboy_dmc_retention_provider_capable() {
+  local wp_argv=() wp_flags=() value
+  while IFS= read -r value; do
+    wp_argv+=("$value")
+  done < <(homeboy_dmc_wp_argv)
+  while IFS= read -r value; do
+    wp_flags+=("$value")
+  done < <(homeboy_dmc_wp_flags)
+
+  "${wp_argv[@]}" cli has-command 'datamachine-code workspace retention-provider' "${wp_flags[@]}" >/dev/null 2>&1
 }
 
 homeboy_dmc_provider_release_label() {
@@ -786,7 +820,7 @@ configure_homeboy_dmc_worktree_provider() {
     return 0
   fi
 
-  local provider provider_json finalize_json task_attachment_supported=false task_resolution_supported=false plan_supported=false
+  local provider provider_json finalize_json task_attachment_supported=false task_resolution_supported=false plan_supported=false retention_supported=false
   local dmc_task_attachment_supported=false homeboy_task_attachment_supported=false
   provider="$(homeboy_dmc_worktree_provider_executable)" || {
     homeboy_handle_failure "Data Machine Code standalone worktree provider source contract is unavailable; skipping Homeboy DMC worktree provider setup."
@@ -808,7 +842,10 @@ configure_homeboy_dmc_worktree_provider() {
   if homeboy_dmc_plan_capable "$provider"; then
     plan_supported=true
   fi
-  provider_json="$(homeboy_dmc_worktree_provider_json "$provider" "$task_attachment_supported" "$task_resolution_supported" "$plan_supported")"
+  if homeboy_retention_command_supported && homeboy_dmc_retention_provider_capable; then
+    retention_supported=true
+  fi
+  provider_json="$(homeboy_dmc_worktree_provider_json "$provider" "$task_attachment_supported" "$task_resolution_supported" "$plan_supported" "$retention_supported")"
   finalize_json="$(homeboy_dmc_command_json finalize "$provider")"
 
   if [ "${DRY_RUN:-false}" = true ]; then

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -128,6 +128,11 @@ if mapping != {"items": "$", "handle": "$.handle", "path": "$.path", "branch": "
     raise SystemExit(f"FAIL: DMC resolve mapping must explicitly project tracker ownership: {mapping!r}")
 if commands.get("resolve") != expected_resolve:
     raise SystemExit(f"FAIL: DMC resolve adapter mapping mismatch: {commands.get('resolve')!r}")
+expected_retention = ["studio", "wp", "datamachine-code", "workspace", "retention-provider", f"--path={sys.argv[3]}"]
+if commands.get("retention") != expected_retention:
+    raise SystemExit(f"FAIL: typed retention command mismatch: {commands.get('retention')!r}")
+if commands.get("retention_timeout_ms") != 120000:
+    raise SystemExit("FAIL: typed retention command must have a bounded timeout")
 if commands.get("resolve_path") != expected_resolve_path:
     raise SystemExit(f"FAIL: DMC path resolve adapter mapping mismatch: {commands.get('resolve_path')!r}")
 if commands.get("resolve_task") != expected_resolve_task:
@@ -785,6 +790,10 @@ if [ "$1 $2" = "config set" ]; then
     [ "${HOMEBOY_ATTACHMENT_COMMANDS:-true}" = true ] && : > "$HOMEBOY_DATA_DIR/task-attachment-supported"
     exit 0
   fi
+  if [ "$3" = "/worktree_providers/wpca-retention-probe" ]; then
+    [ "${HOMEBOY_RETENTION_COMMANDS:-true}" = true ] && : > "$HOMEBOY_DATA_DIR/retention-supported"
+    exit 0
+  fi
   printf '%s|%s\n' "$3" "$4" >> "$HOMEBOY_CONFIG_LOG"
   exit 0
 fi
@@ -792,6 +801,10 @@ if [ "$1 $2" = "config show" ]; then
   if [ "$3" = "/settings/worktree_provider_lifecycle/dmc/finalize" ]; then
     grep -qF -- "$3|" "$HOMEBOY_CONFIG_LOG"
     exit $?
+  fi
+  if [ "$3" = "/worktree_providers/wpca-retention-probe/commands/retention" ]; then
+    [ "${HOMEBOY_RETENTION_COMMANDS:-true}" = true ] && [ -f "$HOMEBOY_DATA_DIR/retention-supported" ] && exit 0
+    exit 2
   fi
   [ "${HOMEBOY_ATTACHMENT_COMMANDS:-true}" = true ] && [ -f "$HOMEBOY_DATA_DIR/task-attachment-supported" ] && exit 0
   exit 2
@@ -803,6 +816,10 @@ chmod +x "$FAKE_BIN/homeboy"
 cat > "$FAKE_BIN/studio" <<'SH'
 #!/bin/sh
 printf '%s\n' "$*" >> "$STUDIO_LOG"
+if [ "$1 $2 $3" = "wp cli has-command" ] && [ "$4" = "datamachine-code workspace retention-provider" ]; then
+  [ "${DMC_RETENTION_COMMAND:-true}" = true ]
+  exit $?
+fi
 if [ "$1 $2 $3 $4 $5" = "wp datamachine-code workspace worktree list" ]; then
   case "$*" in
     *--task-ref=https://github.com/Extra-Chill/wp-coding-agents/issues/425*--with-status*--limit=200*--envelope*--format=json*|*--task-ref=https://github.com/Extra-Chill/WP-Coding-Agents/issues/425*--with-status*--limit=200*--envelope*--format=json*|*--task-ref=http://github.com/Extra-Chill/wp-coding-agents/issues/425*--with-status*--limit=200*--envelope*--format=json*) ;;
@@ -980,6 +997,7 @@ assert_contains "homeboy config set /settings/worktree_provider_lifecycle/dmc/fi
 assert_not_contains '"list":' "$TMP/dry-run.log"
 assert_contains "\"cleanup_preview\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--dry-run\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$TMP/dry-run.log"
+assert_contains "\"retention\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"retention-provider\",\"--path=$SITE_PATH\"],\"retention_timeout_ms\":120000" "$TMP/dry-run.log"
 if [ -f "$HOMEBOY_CONFIG_LOG" ]; then
   echo "FAIL: dry-run should not call homeboy config set"
   cat "$HOMEBOY_CONFIG_LOG"
@@ -1023,6 +1041,28 @@ assert_standalone_task_resolution_contract "$HOMEBOY_CONFIG_LOG"
 assert_task_attachment_contract "$HOMEBOY_CONFIG_LOG"
 assert_not_contains 'wp datamachine-code workspace worktree list fixture --all --full --format=json' "$STUDIO_LOG"
 assert_contains "\"cleanup_apply\":[\"studio\",\"wp\",\"datamachine-code\",\"workspace\",\"cleanup\",\"safe\",\"--format=json\",\"--path=$SITE_PATH\"]" "$HOMEBOY_CONFIG_LOG"
+
+# Typed retention is emitted only when both installed contracts support it;
+# mixed-version installations retain the legacy cleanup commands.
+DMC_RETENTION_COMMAND=false
+export DMC_RETENTION_COMMAND
+: > "$HOMEBOY_CONFIG_LOG"
+rm -f "$DMC_STATE"
+configure_homeboy_dmc_worktree_provider > "$TMP/legacy-retention-dmc.log"
+assert_not_contains '"retention":' "$HOMEBOY_CONFIG_LOG"
+assert_contains '"cleanup_preview":' "$HOMEBOY_CONFIG_LOG"
+assert_contains '"cleanup_apply":' "$HOMEBOY_CONFIG_LOG"
+unset DMC_RETENTION_COMMAND
+
+HOMEBOY_RETENTION_COMMANDS=false
+export HOMEBOY_RETENTION_COMMANDS
+: > "$HOMEBOY_CONFIG_LOG"
+rm -f "$DMC_STATE"
+configure_homeboy_dmc_worktree_provider > "$TMP/legacy-retention-homeboy.log"
+assert_not_contains '"retention":' "$HOMEBOY_CONFIG_LOG"
+assert_contains '"cleanup_preview":' "$HOMEBOY_CONFIG_LOG"
+assert_contains '"cleanup_apply":' "$HOMEBOY_CONFIG_LOG"
+unset HOMEBOY_RETENTION_COMMANDS
 
 # Older DMC capability payloads keep the bounded WordPress lookup adapter.
 DMC_CAPABILITIES_MODE=task_legacy


### PR DESCRIPTION
## Summary
- configure Homeboy's versioned DMC retention command when both installed contracts support it
- preserve legacy cleanup preview/apply commands for mixed-version installations
- verify the canonical WP-CLI command, timeout, and both compatibility fallback paths

Tracks Extra-Chill/homeboy#13813.

## Verification
- `bash tests/homeboy-dmc-provider.sh`
- `bash tests/homeboy-dmc-provider-stability.sh`
- `bash tests/homeboy-verification-guidance.sh`
- `bash tests/ci-coverage.sh`
- `bash -n lib/homeboy.sh`
- `bash -n tests/homeboy-dmc-provider.sh`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode inspected the existing provider capability probes, implemented the gated configuration and compatibility tests, and ran the listed verification. Chris directed the architecture and integration workflow.