### PR TITLE
Complete trackerless lifecycle planning

### DIFF
--- a/scripts/homeboy-dmc-provider.php
+++ b/scripts/homeboy-dmc-provider.php
@@ -521,14 +521,15 @@ if ( in_array($operation, array( 'plan', 'plan_standalone' ), true) ) {
 		}
 		$intent = json_encode(
 			array(
-				'repo'           => $repo,
-				'branch'         => $branch,
-				'from'           => $base,
-				'task_url'       => '' === $task_url ? null : $task_url,
-				'reuse_policy'   => 'isolated',
-				'purpose'        => $purpose,
-				'owner_run_ref'  => $owner,
-				'cleanup_policy' => $cleanup,
+				'repo'                 => $repo,
+				'branch'               => $branch,
+				'from'                 => $base,
+				'task_url'             => '' === $task_url ? null : $task_url,
+				'require_task_tracker' => '' !== $task_url,
+				'reuse_policy'         => 'isolated',
+				'purpose'              => $purpose,
+				'owner_run_ref'        => $owner,
+				'cleanup_policy'       => $cleanup,
 			),
 			JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
 		);

--- a/tests/homeboy-dmc-provider.sh
+++ b/tests/homeboy-dmc-provider.sh
@@ -661,6 +661,7 @@ if ('plan' === $operation) {
         'branch' => 'fix/406-dmc-provider-plan',
         'from' => 'origin/main',
         'task_url' => getenv('DMC_PLAN_TRACKERLESS') ? null : 'https://github.com/Extra-Chill/wp-coding-agents/issues/406',
+        'require_task_tracker' => ! getenv('DMC_PLAN_TRACKERLESS'),
         'reuse_policy' => 'isolated',
         'purpose' => getenv('DMC_PLAN_TRACKERLESS') ? 'release_staging' : 'agent-task-cook',
         'owner_run_ref' => getenv('DMC_PLAN_TRACKERLESS') ? 'release/fixture-owner' : 'homeboy://agent-task/run/cook-406',


### PR DESCRIPTION
## Summary
- explicitly disable DMC tracker enforcement when Homeboy lifecycle planning has no tracker identity
- explicitly retain tracker enforcement whenever a tracker URL is present
- keep managed apply on DMC's existing operator-local CLI contract

## Verification
- `php -l scripts/homeboy-dmc-provider.php`
- `bash tests/homeboy-dmc-provider.sh`

Closes #510.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode traced the release refusal through the standalone DMC plan intent, reduced the repair to one explicit policy field, and updated focused provider coverage under Chris Huber's direction.