### PR TITLE
Preserve DMC-owned worktree abilities

### DIFF
--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -11,10 +11,17 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 	private const HOMEBOY = '@HOMEBOY_BINARY@';
 	private const TIMEOUT_SECONDS = 120;
 	private const OUTPUT_LIMIT_BYTES = 1048576;
+	private const DELEGATED_ABILITIES = array(
+		'datamachine-code/workspace-worktree-add',
+		'datamachine-code/workspace-worktree-list',
+		'datamachine-code/workspace-worktree-finalize',
+		'datamachine-code/workspace-worktree-remove',
+		'datamachine-code/workspace-worktree-cleanup',
+	);
 
 	/** @param array<string,mixed> $args @return array<string,mixed> */
 	public static function filter_ability(array $args, string $slug): array {
-		if (!str_starts_with($slug, 'datamachine-code/workspace-worktree-')) {
+		if (!in_array($slug, self::DELEGATED_ABILITIES, true)) {
 			return $args;
 		}
 

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -100,6 +100,9 @@ $callback = $filters['datamachine_code_ability_registration_args'] ?? null;
 expect(is_callable($callback), 'adapter filter registered');
 $untouched = $callback(array('execute_callback' => 'original'), 'datamachine-code/workspace-show');
 expect('original' === $untouched['execute_callback'], 'non-worktree ability remains unchanged');
+$native = $callback(array('execute_callback' => 'dmc', 'meta' => array('show_in_rest' => false)), 'datamachine-code/workspace-worktree-reconcile-metadata');
+expect('dmc' === $native['execute_callback'], 'DMC-only worktree ability retains its native callback');
+expect(!isset($native['meta']['worktree_lifecycle_owner']), 'DMC-only worktree ability does not claim Homeboy ownership');
 
 $ability = static function (string $slug) use ($callback): callable {
 	$args = $callback(array('execute_callback' => 'dmc', 'meta' => array('show_in_rest' => false)), $slug);
@@ -136,9 +139,6 @@ expect(false === $cleanup(array('force' => true))['dry_run'], 'cleanup force rem
 $remove = $ability('datamachine-code/workspace-worktree-remove');
 expect(true === $remove(array('repo' => 'fixture', 'branch' => 'fix/474'))['success'], 'remove uses Homeboy safety path');
 
-$unsupported = $ability('datamachine-code/workspace-worktree-reconcile-metadata');
-$refusal = $unsupported(array());
-expect(is_wp_error($refusal) && 'wp_coding_agents_homeboy_worktree_unsupported' === $refusal->code, 'DMC-only operation returns typed refusal');
 PHP
 php "$TMP/adapter-harness.php" "$ADAPTER"
 


### PR DESCRIPTION
## Summary

- delegate only the five DMC worktree abilities with exact Homeboy lifecycle mappings
- preserve native DMC callbacks for planning, handoff, reconciliation, capacity recovery, and specialized cleanup abilities
- prove non-delegated worktree abilities retain their callback and do not claim Homeboy ownership

The previous prefix-wide filter replaced every `datamachine-code/workspace-worktree-*` operation, even though the adapter implements only add, list, finalize, remove, and cleanup. This made DMC-only operations return adapter refusals instead of executing their owning implementation.

## Verification

- `bash tests/homeboy-worktree-adapter.sh`
- `bash tests/homeboy-verification-guidance.sh`
- `bash tests/plugins-only-scope.sh`
- `bash tests/ci-coverage.sh`
- `php -l templates/wp-coding-agents-homeboy-worktrees.php`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode audited the merged adapter boundary, reproduced the broad-interception failure through DMC, implemented exact ability delegation, and ran the focused verification under Chris Huber's direction.