### PR TITLE
Route worktree guidance through Homeboy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The agent should know only what it can use.
 - **Developer orchestration layers** add guidance only when installed and verified.
 - **Unavailable tools** do not get stub instructions, fallback recipes, or negative constraints.
 
-For example, a Kimaki install should know Kimaki is the Discord surface. It should not learn generic Kimaki worktree, tunnel, or session-fanout recipes when those responsibilities belong to other installed components. Likewise, Homeboy guidance appears only when Homeboy is available, and workspace/worktree guidance comes from the Data Machine Code layer.
+For example, a Kimaki install should know Kimaki is the Discord surface. It should not learn generic Kimaki worktree, tunnel, or session-fanout recipes when those responsibilities belong to other installed components. Likewise, Homeboy guidance appears only when Homeboy is available. Data Machine Code owns the WordPress-side repository, workspace, GitHub, and data-machine capabilities; Homeboy owns its native Rust worktree lifecycle and Cook.
 
 ## What It Enables
 
@@ -92,7 +92,7 @@ SITE_DOMAIN=example.com ./setup.sh
 
 ### Repo-Aware Developer Workflows
 
-Use Data Machine Code workspace management and optional orchestration tools to keep repository work isolated, reviewable, and tied back to the WordPress agent context.
+Use Data Machine Code for WordPress-side repository, workspace, GitHub, and data-machine capabilities, with optional Homeboy orchestration for native Rust worktree lifecycle and Cook. When both are installed, wp-coding-agents' WordPress adapter maps five DMC worktree abilities to Homeboy without making either project depend on the other.
 
 ```bash
 EXISTING_WP=~/Studio/my-site ./setup.sh --local --with-homeboy
@@ -109,11 +109,11 @@ When an optional orchestrator is available, its own presence-gated AGENTS sectio
 | OpenCode | Coding runtime | Selected or auto-detected |
 | Claude Code | Coding runtime | Selected or auto-detected |
 | Codex | Coding runtime | Selected or auto-detected |
-| Data Machine Code | Workspace, git, GitHub, and worktree integration | Installed with the Data Machine stack |
+| Data Machine Code | WordPress-side repository, workspace, git, GitHub, and data-machine capabilities | Installed with the Data Machine stack |
 | Kimaki | Discord bridge for OpenCode sessions | Optional chat bridge |
 | cc-connect | Multi-platform bridge, commonly used with Claude Code | Optional chat bridge |
 | opencode-telegram | Telegram bridge for OpenCode | Optional chat bridge |
-| Homeboy | Optional repo-aware task/lab orchestration layer | Enabled with `--with-homeboy` when available |
+| Homeboy | Optional repo-aware task/lab orchestration, native Rust worktree lifecycle, and Cook | Enabled with `--with-homeboy` when available |
 | AI Provider for Claude Code | WP AI Client provider backed by Claude Code OAuth credentials | Installed when Claude Code is selected or detected |
 
 ## Installation
@@ -390,8 +390,10 @@ about WordPress here without skills or fine-tuning. Reading is never
 restricted. Everything below is about *writing*.
 
 **Workspace** is the developer setup: the installed tree is reference
-material, and every code change happens in a Data Machine Code workspace so it
-is tracked in git and reviewed through GitHub.
+material, and every code change happens in the configured repository workspace
+so it is tracked in git and reviewed through GitHub. Data Machine Code provides
+the WordPress-side repository, workspace, GitHub, and data-machine capabilities;
+when installed, Homeboy owns its native Rust worktree lifecycle and Cook.
 
 **Owned** is for managed agentic hosting, where a non-technical owner should
 never have to deal with pull requests. The agent edits the site's own theme and

--- a/guidance/homeboy.sh
+++ b/guidance/homeboy.sh
@@ -79,11 +79,8 @@ guidance_register() {
 _guidance_homeboy_live_block() {
   cat <<'PHP_BLOCK'
     // BEGIN agents-md-guidance:homeboy-cli
-    if ( ! function_exists( 'wp_coding_agents_render_homeboy_cli_section' ) ) {
-        function wp_coding_agents_render_homeboy_cli_section() {
-            // Homeboy is optional. The section is a clean no-op when the
-            // binary is not on PATH, matching the presence-gating the bash
-            // setup path applies.
+    if ( ! function_exists( 'wp_coding_agents_homeboy_binary' ) ) {
+        function wp_coding_agents_homeboy_binary() {
             $homeboy = null;
             $path_env = ( is_callable( 'getenv' ) ) ? getenv( 'PATH' ) : false;
             if ( is_string( $path_env ) && $path_env !== '' ) {
@@ -98,14 +95,20 @@ _guidance_homeboy_live_block() {
                     }
                 }
             }
-            if ( $homeboy === null ) {
+            return $homeboy;
+        }
+    }
+
+    if ( ! function_exists( 'wp_coding_agents_render_homeboy_cli_section' ) ) {
+        function wp_coding_agents_render_homeboy_cli_section() {
+            if ( wp_coding_agents_homeboy_binary() === null ) {
                 return '';
             }
 
             return <<<'MD'
 ## Homeboy
 
-Homeboy orchestrates coding agents, deterministic gates, evidence, promotion, review, releases, and deployments. Data Machine Code owns authoritative repository and worktree state; Homeboy consumes managed worktrees to execute and finalize work.
+Homeboy orchestrates coding agents, deterministic gates, evidence, promotion, review, releases, and deployments. Homeboy owns the native Rust worktree lifecycle and Cook. Data Machine Code independently provides WordPress-side repository, workspace, GitHub, and data-machine capabilities; it does not own Homeboy worktrees.
 
 **Default routing**
 - One tracked change: `homeboy agent-task cook`
@@ -124,21 +127,55 @@ MD;
         }
     }
 
-    \DataMachine\Engine\AI\SectionRegistry::register(
-        'AGENTS.md',
-        'homeboy-cli',
-        30,
-        static function () {
-            return wp_coding_agents_render_homeboy_cli_section();
-        },
-        array(
-            'label'       => 'Homeboy',
-            'description' => 'Host orchestration routing, safety, and discovery guidance.',
-            'owner'       => 'wp-coding-agents',
-            'freshness'   => 'live',
-            'conditions'  => 'Registered on hosts where the homeboy binary is installed and omitted at compose time when the binary is unavailable.',
-        )
-    );
+    if ( ! function_exists( 'wp_coding_agents_render_homeboy_datamachine_section' ) ) {
+        function wp_coding_agents_render_homeboy_datamachine_section() {
+            if ( wp_coding_agents_homeboy_binary() === null ) {
+                return '';
+            }
+
+            return <<<'MD'
+## Data Machine Code and Homeboy
+
+Use Homeboy directly for its native Rust worktree lifecycle (`homeboy worktree --help`) and Cook (`homeboy agent-task cook`). Data Machine Code independently provides WordPress-side repository, workspace, GitHub, and data-machine capabilities.
+MD;
+        }
+    }
+
+    // Gate registration itself at composition time so an absent Homeboy binary
+    // leaves Data Machine Code's standalone section intact.
+    if ( wp_coding_agents_homeboy_binary() !== null ) {
+        \DataMachine\Engine\AI\SectionRegistry::register(
+            'AGENTS.md',
+            'homeboy-cli',
+            30,
+            static function () {
+                return wp_coding_agents_render_homeboy_cli_section();
+            },
+            array(
+                'label'       => 'Homeboy',
+                'description' => 'Host orchestration routing, safety, and discovery guidance.',
+                'owner'       => 'wp-coding-agents',
+                'freshness'   => 'live',
+                'conditions'  => 'Registered only while the homeboy binary is executable at AGENTS.md compose time.',
+            )
+        );
+
+        \DataMachine\Engine\AI\SectionRegistry::register(
+            'AGENTS.md',
+            'datamachine-code',
+            20,
+            static function () {
+                return wp_coding_agents_render_homeboy_datamachine_section();
+            },
+            array(
+                'label'       => 'Data Machine Code + Homeboy',
+                'description' => 'Homeboy-present integration routing for Data Machine Code and Homeboy capabilities.',
+                'owner'       => 'wp-coding-agents',
+                'freshness'   => 'live',
+                'conditions'  => 'Replaces Data Machine Code\'s standalone section only while the homeboy binary is executable at AGENTS.md compose time.',
+            )
+        );
+    }
     // END agents-md-guidance:homeboy-cli
 PHP_BLOCK
 }

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -71,13 +71,27 @@ namespace {
     define( 'ABSPATH', '/' );
     function datamachine_agents_md_enabled(): bool { return true; }
     \$GLOBALS['actions'] = [];
-    function add_action( \$tag, \$callback, \$priority = 10 ) { \$GLOBALS['actions'][\$tag][] = \$callback; }
+    function add_action( \$tag, \$callback, \$priority = 10 ) { \$GLOBALS['actions'][\$tag][\$priority][] = \$callback; }
+    add_action( 'datamachine_sections', static function () {
+        \DataMachine\Engine\AI\SectionRegistry::register(
+            'AGENTS.md',
+            'datamachine-code',
+            20,
+            static fn() => '## Data Machine Code standalone\n\ndatamachine-code workspace worktree add',
+            [ 'label' => 'Data Machine Code', 'owner' => 'data-machine-code', 'freshness' => 'static' ]
+        );
+    }, 20 );
     require '$MU_FILE';
-    foreach ( \$GLOBALS['actions']['datamachine_sections'] ?? [] as \$callback ) { \$callback(); }
+    ksort( \$GLOBALS['actions']['datamachine_sections'] );
+    foreach ( \$GLOBALS['actions']['datamachine_sections'] as \$callbacks ) {
+        foreach ( \$callbacks as \$callback ) { \$callback(); }
+    }
     \$call = \DataMachine\Engine\AI\SectionRegistry::\$calls['homeboy-cli'] ?? null;
     \$content = \$call ? (string) call_user_func( \$call[3] ) : '';
-    if ( '1' === getenv( 'CONTENT_ONLY' ) ) { echo \$content; exit; }
+    \$dmc = \DataMachine\Engine\AI\SectionRegistry::\$calls['datamachine-code'] ?? null;
+    \$dmc_content = \$dmc ? (string) call_user_func( \$dmc[3] ) : '';
     echo json_encode([
+        'homeboy_registered' => \$call !== null,
         'filename' => \$call[0] ?? null,
         'slug' => \$call[1] ?? null,
         'priority' => \$call[2] ?? null,
@@ -85,7 +99,10 @@ namespace {
         'owner' => \$call[4]['owner'] ?? null,
         'freshness' => \$call[4]['freshness'] ?? null,
         'has_heading' => str_starts_with( \$content, '## Homeboy' ),
-        'has_boundary' => str_contains( \$content, 'Data Machine Code owns authoritative repository and worktree state' ),
+        'has_homeboy_ownership' => str_contains( \$content, 'Homeboy owns the native Rust worktree lifecycle and Cook.' ),
+        'has_dmc_boundary' => str_contains( \$content, 'Data Machine Code independently provides WordPress-side repository, workspace, GitHub, and data-machine capabilities; it does not own Homeboy worktrees.' ),
+        'no_dmc_worktree_commands' => ! str_contains( \$content, 'datamachine-code workspace worktree' ),
+        'no_legacy_dmc_ownership' => ! str_contains( \$content, 'Data Machine Code owns authoritative repository and worktree state' ),
         'has_cook' => str_contains( \$content, 'homeboy agent-task cook' ),
         'has_fanout' => str_contains( \$content, 'homeboy agent-task fanout cook-batch' ),
         'has_review' => str_contains( \$content, 'homeboy review' ),
@@ -95,12 +112,21 @@ namespace {
         'has_operator_boundary' => str_contains( \$content, 'only when the user explicitly asks' ),
         'has_discovery' => str_contains( \$content, 'homeboy --help' ) && str_contains( \$content, 'homeboy <command> --help' ),
         'no_exhaustive_map' => ! str_contains( \$content, 'Common entrypoints:' ) && ! str_contains( \$content, 'Deploy components to remote server' ),
+        'dmc_priority' => \$dmc[2] ?? null,
+        'dmc_label' => \$dmc[4]['label'] ?? null,
+        'dmc_owner' => \$dmc[4]['owner'] ?? null,
+        'dmc_freshness' => \$dmc[4]['freshness'] ?? null,
+        'dmc_live_condition' => str_contains( (string) ( \$dmc[4]['conditions'] ?? '' ), 'only while the homeboy binary is executable at AGENTS.md compose time' ),
+        'dmc_has_homeboy_worktree_route' => str_contains( \$dmc_content, 'homeboy worktree --help' ),
+        'dmc_has_cook_route' => str_contains( \$dmc_content, 'homeboy agent-task cook' ),
+        'dmc_has_dmc_boundary' => str_contains( \$dmc_content, 'Data Machine Code independently provides WordPress-side repository, workspace, GitHub, and data-machine capabilities.' ),
+        'dmc_has_no_dmc_worktree_commands' => ! str_contains( \$dmc_content, 'datamachine-code workspace worktree' ),
     ]);
 }
 PHP
 
 RESULT=$(PATH="$TMP/bin:$PATH" php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"homeboy-cli","priority":30,"label":"Homeboy","owner":"wp-coding-agents","freshness":"live","has_heading":true,"has_boundary":true,"has_cook":true,"has_fanout":true,"has_review":true,"has_runs":true,"has_stateful":true,"has_health":true,"has_operator_boundary":true,"has_discovery":true,"no_exhaustive_map":true}'
+EXPECTED='{"homeboy_registered":true,"filename":"AGENTS.md","slug":"homeboy-cli","priority":30,"label":"Homeboy","owner":"wp-coding-agents","freshness":"live","has_heading":true,"has_homeboy_ownership":true,"has_dmc_boundary":true,"no_dmc_worktree_commands":true,"no_legacy_dmc_ownership":true,"has_cook":true,"has_fanout":true,"has_review":true,"has_runs":true,"has_stateful":true,"has_health":true,"has_operator_boundary":true,"has_discovery":true,"no_exhaustive_map":true,"dmc_priority":20,"dmc_label":"Data Machine Code + Homeboy","dmc_owner":"wp-coding-agents","dmc_freshness":"live","dmc_live_condition":true,"dmc_has_homeboy_worktree_route":true,"dmc_has_cook_route":true,"dmc_has_dmc_boundary":true,"dmc_has_no_dmc_worktree_commands":true}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives concise Homeboy routing guidance"
 
 echo "==> re-sync with homeboy present (idempotent)"
@@ -109,16 +135,12 @@ PATH="$TMP/bin:$PATH" guidance_sync_unit homeboy
 HASH_AFTER=$(md5sum "$MU_FILE" | cut -d' ' -f1)
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "file unchanged on re-sync"
 
-echo "==> live callback omits guidance when homeboy disappears"
+echo "==> compose without homeboy leaves DMC standalone section intact"
 EMPTY_BIN="$TMP/empty-bin"
 mkdir -p "$EMPTY_BIN"
-ABSENT_RESULT=$(CONTENT_ONLY=1 PATH="$EMPTY_BIN" "$PHP_BIN" "$SHIM")
-if [ -n "$ABSENT_RESULT" ]; then
-  echo "  FAIL callback rendered guidance without homeboy: $ABSENT_RESULT"
-  FAILED=$((FAILED + 1))
-else
-  echo "  ok   callback omits guidance without homeboy"
-fi
+ABSENT_RESULT=$(PATH="$EMPTY_BIN" "$PHP_BIN" "$SHIM")
+ABSENT_EXPECTED='{"homeboy_registered":false,"filename":null,"slug":null,"priority":null,"label":null,"owner":null,"freshness":null,"has_heading":false,"has_homeboy_ownership":false,"has_dmc_boundary":false,"no_dmc_worktree_commands":true,"no_legacy_dmc_ownership":true,"has_cook":false,"has_fanout":false,"has_review":false,"has_runs":false,"has_stateful":false,"has_health":false,"has_operator_boundary":false,"has_discovery":false,"no_exhaustive_map":true,"dmc_priority":20,"dmc_label":"Data Machine Code","dmc_owner":"data-machine-code","dmc_freshness":"static","dmc_live_condition":false,"dmc_has_homeboy_worktree_route":false,"dmc_has_cook_route":false,"dmc_has_dmc_boundary":false,"dmc_has_no_dmc_worktree_commands":false}'
+assert_eq "$ABSENT_RESULT" "$ABSENT_EXPECTED" "Homeboy absence leaves DMC standalone section unmodified"
 
 echo "==> sync removes section when homeboy is absent"
 SANDBIN="$TMP/sandbin"


### PR DESCRIPTION
## Summary
- make wp-coding-agents the sole WordPress intersection between DMC and Homeboy
- replace DMC worktree routing at compose time only when Homeboy is executable
- route native worktree lifecycle and Cook directly to Homeboy while retaining independent DMC capabilities
- preserve the existing narrow five-ability adapter and standalone DMC guidance when Homeboy is absent

## Verification
- `bash tests/homeboy-agents-md.sh`
- `bash tests/homeboy-worktree-adapter.sh`
- `bash tests/agents-md-guidance.sh`
- `bash -n guidance/homeboy.sh tests/homeboy-agents-md.sh tests/homeboy-worktree-adapter.sh`

## AI assistance
OpenAI `gpt-5.6-terra` was used through OpenCode to inspect the WordPress section-registration boundary, implement the live integration override, and expand focused presence/absence tests. The changes and test output were reviewed before submission.