### PR TITLE
Fix Homeboy worktree freshness contract

### DIFF
--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -55,10 +55,17 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		if (is_wp_error($repo) || is_wp_error($branch)) {
 			return is_wp_error($repo) ? $repo : $branch;
 		}
-		foreach (array('inject_context', 'bootstrap', 'allow_stale', 'allow_unverified_freshness', 'rebase_base', 'force', 'allow_percentage_byte_floor_exception', 'remediate_capacity', 'remediate_capacity_dry_run', 'verbose') as $unsupported) {
+		foreach (array('inject_context', 'bootstrap', 'allow_stale', 'rebase_base', 'force', 'allow_percentage_byte_floor_exception', 'remediate_capacity', 'remediate_capacity_dry_run', 'verbose') as $unsupported) {
 			if (!empty($input[$unsupported])) {
 				return self::unsupported_input($unsupported, 'Homeboy create cannot preserve this DMC-specific behavior.');
 			}
+		}
+		if (empty($input['allow_unverified_freshness'])) {
+			return new WP_Error(
+				'worktree_handoff_freshness_unverified',
+				'Homeboy does not provide DMC handoff freshness proof. Retry with allow_unverified_freshness only after accepting that limitation.',
+				array('status' => 409, 'owner' => 'homeboy', 'retryable' => true)
+			);
 		}
 		if (null !== self::optional_string($input, 'task_ref')) {
 			return self::unsupported_input('task_ref', 'Homeboy create accepts a canonical task URL, not a DMC task reference.');
@@ -110,6 +117,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			'context_injected' => false,
 			'context_files'    => array(),
 			'bootstrap'        => array('outcome' => 'not_requested', 'owner' => 'homeboy'),
+			'handoff_freshness' => array('status' => 'unverified', 'reason' => 'remote_freshness_probe_unsupported'),
 			'message'          => 'Homeboy owns this worktree lifecycle.',
 			'metadata'         => array('homeboy' => $record),
 		);

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -112,9 +112,12 @@ $ability = static function (string $slug) use ($callback): callable {
 };
 
 $add = $ability('datamachine-code/workspace-worktree-add');
-$created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success'));
+$refused = $add(array('repo' => 'fixture', 'branch' => 'fix/474'));
+expect(is_wp_error($refused) && 'worktree_handoff_freshness_unverified' === $refused->code, 'create refuses before mutation without explicit unverified freshness acceptance');
+$created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success', 'allow_unverified_freshness' => true));
 expect(!is_wp_error($created) && 'fixture@fix-474' === $created['handle'], 'create projects native Homeboy record');
-$manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'cleanup_policy' => 'manual'));
+expect('unverified' === ($created['handoff_freshness']['status'] ?? null) && 'remote_freshness_probe_unsupported' === ($created['handoff_freshness']['reason'] ?? null), 'create projects the required DMC handoff freshness decision');
+$manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'cleanup_policy' => 'manual', 'allow_unverified_freshness' => true));
 expect(!is_wp_error($manual), 'manual lifecycle intent maps to non-cleanup-eligible Homeboy policy');
 expect(is_wp_error($add(array('repo' => 'fixture', 'branch' => 'unsupported', 'bootstrap' => true))), 'explicit DMC-only create behavior returns typed refusal');
 


### PR DESCRIPTION
## Summary

- fail before Homeboy mutation unless callers explicitly accept unverified DMC handoff freshness
- project Homeboy's missing remote freshness proof as the canonical `remote_freshness_probe_unsupported` decision
- cover both fail-closed and explicit opt-in adapter paths

Closes #523.

## Verification

- `bash tests/homeboy-worktree-adapter.sh`
- `bash tests/homeboy-verification-guidance.sh`
- `bash tests/ci-coverage.sh`
- `php -l templates/wp-coding-agents-homeboy-worktrees.php`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the live DMC `0.74.1` output-schema failure, implemented the fail-closed Homeboy adapter mapping, and ran focused regression checks under Chris Huber's direction.