### PR TITLE
fix: preserve WP CLI transport in AGENTS guidance

### DIFF
--- a/guidance/_dispatch.sh
+++ b/guidance/_dispatch.sh
@@ -184,6 +184,8 @@ guidance_call() {
 # be synced on their own (lib/homeboy.sh re-syncs the homeboy section after the
 # binary's availability is settled); both paths are idempotent.
 guidance_sync_all() {
+  agents_md_guidance_sync_wp_cli_transport
+
   local id
   for id in $(guidance_names); do
     guidance_sync_unit "$id"

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -19,6 +19,7 @@
 # Public surface:
 #   agents_md_guidance_mu_plugin_path
 #   agents_md_guidance_ensure_mu_plugin_file
+#   agents_md_guidance_sync_wp_cli_transport
 #   agents_md_guidance_register <section_id> <priority> <label> <description> <content>
 #   agents_md_guidance_unregister <section_id>
 #
@@ -180,6 +181,33 @@ agents_md_guidance_register() {
   fi
 }
 
+# Keep all core and extension-provided AGENTS.md CLI examples replayable in the
+# environment that setup detected. The core generators own their command prose;
+# their shared `datamachine_wp_cli_cmd` filter is the integration boundary.
+agents_md_guidance_sync_wp_cli_transport() {
+  local file transport new_block
+  file="$(agents_md_guidance_mu_plugin_path)" || return 1
+  agents_md_guidance_ensure_mu_plugin_file || return 1
+  transport="$(wp_cli_transport_display)"
+  new_block="$(_agents_md_guidance_render_wp_cli_transport_block "$transport")" || return 1
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would register AGENTS.md WP-CLI transport in $file"
+    return 0
+  fi
+
+  if _agents_md_guidance_block_matches "$file" "wp-cli-transport" "$new_block"; then
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp "${file}.XXXXXX")
+  _agents_md_guidance_rewrite "$file" "wp-cli-transport" "$new_block" > "$tmp"
+  mv "$tmp" "$file"
+  service_file_normalize_perms "$file"
+  log "  Registered AGENTS.md WP-CLI transport: $transport"
+}
+
 agents_md_guidance_unregister() {
   local section_id="$1"
   if [ -z "$section_id" ]; then
@@ -266,6 +294,28 @@ print(f"            'conditions'  => '{esc(conditions)}',")
 print("        )")
 print("    );")
 print(f"    // END agents-md-guidance:{section_id}")
+PY
+}
+
+_agents_md_guidance_render_wp_cli_transport_block() {
+  AGENTS_MD_GUIDANCE_WP_CLI_TRANSPORT="$1" python3 <<'PY'
+import os
+
+transport = os.environ["AGENTS_MD_GUIDANCE_WP_CLI_TRANSPORT"]
+escaped = transport.replace("\\", "\\\\").replace("'", "\\'")
+
+print("    // BEGIN agents-md-guidance:wp-cli-transport")
+print("    add_filter(")
+print("        'datamachine_wp_cli_cmd',")
+print("        static function ( $default ) {")
+print("            if ( ! is_string( $default ) || 0 !== strpos( $default, 'wp' ) || ( isset( $default[2] ) && ! ctype_space( $default[2] ) ) ) {")
+print("                return $default;")
+print("            }")
+print(f"            return '{escaped}' . substr( $default, 2 );")
+print("        },")
+print("        100")
+print("    );")
+print("    // END agents-md-guidance:wp-cli-transport")
 PY
 }
 

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -243,6 +243,12 @@ path.write_text(content)
 PY
 guidance_sync_all
 assert_php_lint "$MU_FILE" "WordPress boundary guidance parses with php -l"
+if grep -q "BEGIN agents-md-guidance:wp-cli-transport" "$MU_FILE"; then
+  echo "  ok   WordPress CLI transport filter present"
+else
+  echo "  FAIL WordPress CLI transport filter missing"
+  FAILED=$((FAILED + 1))
+fi
 if grep -q '^}, 100 );$' "$MU_FILE"; then
   echo "  ok   existing action wrapper normalized to priority 100"
 else
@@ -267,6 +273,59 @@ guidance_sync_all
 HASH_AFTER=$(file_hash "$MU_FILE")
 assert_eq "$HASH_AFTER" "$HASH_BEFORE" "WordPress boundary sync is idempotent"
 
+echo "==> generated Studio commands use the selected transport non-interactively"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/studio" <<'SH'
+#!/bin/bash
+[ "$1" = wp ] || exit 1
+shift
+case " $* " in *" datamachine memory compose AGENTS.md "*) exit 0 ;; esac
+exit 1
+SH
+chmod +x "$TMP/bin/studio"
+wp_cli_transport_set studio wp
+guidance_sync_all
+if grep -q "return 'studio wp'" "$MU_FILE"; then
+  echo "  ok   Studio transport stored in generated guidance"
+else
+  echo "  FAIL Studio transport was not stored in generated guidance"
+  FAILED=$((FAILED + 1))
+fi
+TRANSPORT_SHIM="$TMP/transport-shim.php"
+cat > "$TRANSPORT_SHIM" <<PHP
+<?php
+define( 'ABSPATH', '/' );
+\$GLOBALS['actions'] = [];
+\$GLOBALS['filters'] = [];
+class TransportSectionRegistry { public static function register( \$file, \$section, \$priority, \$callback, \$metadata = [] ): void {} }
+class_alias( 'TransportSectionRegistry', 'DataMachine\\Engine\\AI\\SectionRegistry' );
+function add_action( \$tag, \$callback, \$priority = 10 ) { \$GLOBALS['actions'][\$tag][\$priority][] = \$callback; }
+function add_filter( \$tag, \$callback, \$priority = 10 ) { \$GLOBALS['filters'][\$tag][\$priority][] = \$callback; }
+function apply_filters( \$tag, \$value ) {
+    if ( empty( \$GLOBALS['filters'][\$tag] ) ) { return \$value; }
+    ksort( \$GLOBALS['filters'][\$tag] );
+    foreach ( \$GLOBALS['filters'][\$tag] as \$callbacks ) { foreach ( \$callbacks as \$callback ) { \$value = \$callback( \$value ); } }
+    return \$value;
+}
+function datamachine_agents_md_enabled(): bool { return true; }
+require '$MU_FILE';
+ksort( \$GLOBALS['actions']['datamachine_sections'] );
+foreach ( \$GLOBALS['actions']['datamachine_sections'] as \$callbacks ) { foreach ( \$callbacks as \$callback ) { \$callback(); } }
+echo apply_filters( 'datamachine_wp_cli_cmd', 'wp --path=/path/to/site' );
+PHP
+GENERATED_PREFIX=$(php "$TRANSPORT_SHIM")
+assert_eq "$GENERATED_PREFIX" "studio wp --path=/path/to/site" "Studio AGENTS command prefix preserves path"
+if env -i PATH="$TMP/bin:/usr/bin:/bin" bash -c "$GENERATED_PREFIX datamachine memory compose AGENTS.md"; then
+  echo "  ok   generated Studio command executes without bare wp"
+else
+  echo "  FAIL generated Studio command does not execute without bare wp"
+  FAILED=$((FAILED + 1))
+fi
+wp_cli_transport_set wp
+guidance_sync_all
+GENERATED_PREFIX=$(php "$TRANSPORT_SHIM")
+assert_eq "$GENERATED_PREFIX" "wp --path=/path/to/site" "generic AGENTS command prefix retains wp"
+
 echo "==> WordPress guidance wins mixed-version registration"
 MIXED_SHIM="$TMP/mixed-section-shim.php"
 cat > "$MIXED_SHIM" <<PHP
@@ -285,8 +344,11 @@ namespace {
     function datamachine_agents_md_enabled(): bool { return true; }
     \$GLOBALS['actions'] = [];
     function add_action( \$tag, \$callback, \$priority = 10 ) {
-        \$GLOBALS['actions'][\$tag][\$priority][] = \$callback;
-    }
+    \$GLOBALS['actions'][\$tag][\$priority][] = \$callback;
+}
+function add_filter( \$tag, \$callback, \$priority = 10 ) {
+    \$GLOBALS['filters'][\$tag][\$priority][] = \$callback;
+}
     add_action( 'datamachine_sections', static function () {
         \DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'wordpress-source', 30, static fn() => 'old source', [ 'owner' => 'data-machine-code' ] );
         \DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'abilities', 20, static fn() => 'old abilities', [ 'owner' => 'data-machine-code' ] );


### PR DESCRIPTION
## Summary

- project the detected WP-CLI transport through composed AGENTS guidance
- emit runnable `studio wp` commands on Studio while retaining bare `wp` elsewhere
- prove generated commands run non-interactively without a bare `wp` binary

Closes #521.

## Verification

- `bash tests/agents-md-guidance.sh`
- `bash tests/wp-cli-transport-resolution.sh`
- `bash tests/homeboy-verification-guidance.sh`

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode traced the AGENTS composition boundary, implemented transport projection and non-interactive coverage, and ran verification. OpenAI GPT-5.6 Sol via OpenCode reviewed, rebased, and published the candidate under Chris Huber's direction.