### PR TITLE
fix(opencode): configure native general model

### DIFF
--- a/lib/project-opencode-subagents.py
+++ b/lib/project-opencode-subagents.py
@@ -202,7 +202,7 @@ def atomic_write(path, contents, root):
 
 
 def manifest(path, root):
-    if not path.exists(): return {"agents": [], "artifacts": [], "task_permission": None, "skill_permission": {}}
+    if not path.exists(): return {"agents": [], "artifacts": [], "task_permission": None, "skill_permission": {}, "general_agent": None}
     regular(path, "managed manifest", root)
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict) or data.get("sentinel") != SENTINEL: fail("managed manifest is unrecognized")
@@ -216,6 +216,7 @@ def manifest(path, root):
     if data.get("task_permission") is not None: permission({"task": data["task_permission"]}, "managed manifest task permission")
     if not isinstance(data.get("skill_permission", {}), dict): fail("managed manifest skill permission is invalid")
     permission({"skill": data.get("skill_permission", {})}, "managed manifest skill permission")
+    if data.get("general_agent") is not None and not isinstance(data["general_agent"], dict): fail("managed manifest general agent is invalid")
     return data
 
 
@@ -276,6 +277,11 @@ def main():
         task = {"*": "deny", "general": "allow", **{edge: "allow" for edge in edges[coordinator]}}
         current = config["permission"].get("task")
         if current not in (None, previous["task_permission"]): fail("refusing to overwrite user-owned OpenCode permission.task")
+        agents_config = config.get("agent", {})
+        if not isinstance(agents_config, dict): fail("OpenCode config agent must be an object")
+        general_agent = {"model": nodes[coordinator]["model"]} if nodes[coordinator]["model"] else {}
+        current_general_agent = agents_config.get("general")
+        if current_general_agent not in (None, previous["general_agent"]): fail("refusing to overwrite user-owned OpenCode agent.general")
         current_skill = config["permission"].get("skill", {})
         if not isinstance(current_skill, dict): fail("refusing to overwrite non-map OpenCode permission.skill")
         previous_skill = previous["skill_permission"]
@@ -296,13 +302,19 @@ def main():
                 path.unlink()
         if current != task:
             config["permission"]["task"] = task
+        if general_agent:
+            config.setdefault("agent", {})["general"] = general_agent
+        elif current_general_agent is not None:
+            config["agent"].pop("general", None)
+            if not config["agent"]:
+                config.pop("agent")
         if coordinator_skill_permission:
             config["permission"]["skill"] = {**current_skill, **coordinator_skill_permission}
         elif previous_skill:
             config["permission"]["skill"] = {key: value for key, value in current_skill.items() if key not in previous_skill}
-        if config["permission"].get("task") != current or config["permission"].get("skill", {}) != current_skill:
+        if config["permission"].get("task") != current or config["permission"].get("skill", {}) != current_skill or config.get("agent", {}).get("general") != current_general_agent:
             atomic_write(config_path, (json.dumps(config, indent=2) + "\n").encode(), project)
-        data = {"sentinel": SENTINEL, "agents": sorted(agents), "artifacts": sorted(artifacts), "task_permission": task, "skill_permission": coordinator_skill_permission}
+        data = {"sentinel": SENTINEL, "agents": sorted(agents), "artifacts": sorted(artifacts), "task_permission": task, "skill_permission": coordinator_skill_permission, "general_agent": general_agent or None}
         serialized = (json.dumps(data, indent=2, sort_keys=True) + "\n").encode()
         if not manifest_path.is_file() or manifest_path.read_bytes() != serialized: atomic_write(manifest_path, serialized, root)
     except (OSError, ValueError, json.JSONDecodeError) as error:

--- a/tests/opencode-general-dispatch.sh
+++ b/tests/opencode-general-dispatch.sh
@@ -71,6 +71,7 @@ class Handler(BaseHTTPRequestHandler):
                     "description": f"fixture task {index}",
                     "prompt": f"Complete this independent coding fixture. Return exactly {marker}.",
                     "subagent_type": "general",
+                    "model": "fixture/test",
                 })
                 calls.append({"id": f"call_{index}", "type": "function", "function": {"name": "task", "arguments": arguments}})
             body = response(tool_calls=calls, finish="tool_calls")
@@ -117,7 +118,6 @@ import json, sys
 path, workspace, port = sys.argv[1:]
 json.dump({
     "$schema": "https://opencode.ai/config.json",
-    "model": "fixture/test",
     "provider": {"fixture": {
         "npm": "@ai-sdk/openai-compatible",
         "name": "Fixture",
@@ -138,7 +138,7 @@ json.dump({
     "success": True,
     "coordinator": "coordinator",
     "nodes": [{
-        "slug": "coordinator", "description": "Routes work", "subagents": [], "model": "",
+        "slug": "coordinator", "description": "Routes work", "subagents": [], "model": "fixture/test",
         "sources": {"instructions": {"SOUL.md": soul}, "skills": {}, "references": {}},
         "tool_policy": {"default": "deny", "allow": []}, "skill_policy": {"paths": []},
     }],
@@ -158,6 +158,7 @@ config = json.load(open(sys.argv[1]))
 assert config["permission"]["task"] == {"*": "deny", "general": "allow"}
 assert config["permission"]["external_directory"] == {f"{sys.argv[2]}/**": "allow"}
 assert config["permission"]["edit"] == {"wp-content/plugins/**": "deny"}
+assert config["agent"]["general"] == {"model": "fixture/test"}
 PY
 
 (cd "$SITE" && opencode agent list --pure) > "$TMP/agents.txt"

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -74,7 +74,7 @@ write_graph() {
   "success": true,
   "coordinator": "coordinator",
   "nodes": [
-    {"slug":"coordinator","label":"Coordinator","description":"Routes work","subagents":["writer","reviewer","researcher"],"model":"","sources":{"instructions":{"SOUL.md":"$TMP/coordinator/SOUL.md"},"skills":{"root/SKILL.md":"$TMP/coordinator/skills/root/SKILL.md"},"references":{"root/context.md":"$TMP/coordinator/references/root/context.md"}},"tool_policy":{"default":"deny","allow":["datamachine/search","websearch"]},"skill_policy":{"paths":["root/SKILL.md"]}},
+    {"slug":"coordinator","label":"Coordinator","description":"Routes work","subagents":["writer","reviewer","researcher"],"model":"openai/gpt-5","sources":{"instructions":{"SOUL.md":"$TMP/coordinator/SOUL.md"},"skills":{"root/SKILL.md":"$TMP/coordinator/skills/root/SKILL.md"},"references":{"root/context.md":"$TMP/coordinator/references/root/context.md"}},"tool_policy":{"default":"deny","allow":["datamachine/search","websearch"]},"skill_policy":{"paths":["root/SKILL.md"]}},
     {"slug":"writer","label":"Writer","description":"Write implementation","subagents":["researcher"],"model":"openai/gpt-5","sources":{"instructions":{"SOUL.md":"$TMP/identity/writer-soul.md"},"skills":{"writer/SKILL.md":"$TMP/identity/skills/writer/SKILL.md"},"references":{"writer/context.bin":"$TMP/identity/references/writer/context.bin"}},"tool_policy":{"default":"deny","allow":["datamachine/search","bash"]},"skill_policy":{"paths":["writer/SKILL.md"]}},
     {"slug":"reviewer","label":"Reviewer","description":"Review implementation","subagents":[],"model":"","sources":{"instructions":{"SOUL.md":"$TMP/identity-review/reviewer-soul.md"},"skills":{"reviewer/SKILL.md":"$TMP/identity-review/skills/reviewer/SKILL.md"},"references":{}},"tool_policy":{"default":"deny","allow":["datamachine/search"]},"skill_policy":{"paths":["reviewer/SKILL.md"]}},
     {"slug":"researcher","label":"Researcher","description":"Research context","subagents":[],"model":"","sources":{"instructions":{"SOUL.md":"$TMP/identity/researcher-soul.md"},"skills":{},"references":{}},"tool_policy":{"default":"deny","allow":["webfetch"]},"skill_policy":{"paths":[]}}
@@ -120,10 +120,35 @@ config = json.load(open(sys.argv[2]))
 assert config['model'] == 'preserve' and config['mcp'] == {}
 assert config['permission']['read'] == 'allow'
 assert config['permission']['task'] == {'*': 'deny', 'general': 'allow', 'researcher': 'allow', 'reviewer': 'allow', 'writer': 'allow'}
+# The native child gets the coordinator's explicit model but no agent-local
+# permission map, retaining the managed top-level source and workspace rules.
+assert config['agent']['general'] == {'model': 'openai/gpt-5'}
 assert config['permission']['skill']['root-skill'] == 'allow'
 assert config['permission']['skill']['user-skill'] == 'ask'
 assert open(sys.argv[1].replace('.wp-coding-agents-subagents.json', 'skills/root-skill/SKILL.md'), 'rb').read().startswith(b'---\nname: root-skill\n')
 PY
+
+echo '==> native general model ownership stays explicit'
+python3 - "$SITE_PATH/opencode.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+data['agent']['general'] = {'model': 'user/model'}
+json.dump(data, open(p, 'w'))
+PY
+if opencode_project_subagents; then FAILED=$((FAILED + 1)); fi
+assert_python 'user-owned native general model remains intact' "$SITE_PATH/opencode.json" <<'PY'
+import json, sys
+assert json.load(open(sys.argv[1]))['agent']['general'] == {'model': 'user/model'}
+PY
+python3 - "$SITE_PATH/opencode.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+data = json.load(open(p))
+data['agent']['general'] = {'model': 'openai/gpt-5'}
+json.dump(data, open(p, 'w'))
+PY
+
 WP_CMD_MODE=diagnostic-graph
 opencode_project_subagents
 printf '  ok   recognized PHP diagnostics do not contaminate local graph JSON\n'


### PR DESCRIPTION
## Summary

- project the coordinator model explicitly onto OpenCode native `agent.general`
- preserve top-level managed permissions and refuse user-owned model overrides
- exercise two concurrent general child tasks with explicit model and distinct sessions

Closes #522.

## Verification

- `python3 -m py_compile lib/project-opencode-subagents.py`
- `bash tests/opencode-general-dispatch.sh`
- `bash tests/opencode-subagents.sh`

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode traced managed subagent projection, implemented explicit native-general model ownership and concurrent dispatch coverage, and ran verification. OpenAI GPT-5.6 Sol via OpenCode reviewed, rebased, and published the candidate under Chris Huber's direction.