### PR TITLE
Map Homeboy worktree freshness into DMC handoffs

### DIFF
--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -60,13 +60,6 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 				return self::unsupported_input($unsupported, 'Homeboy create cannot preserve this DMC-specific behavior.');
 			}
 		}
-		if (empty($input['allow_unverified_freshness'])) {
-			return new WP_Error(
-				'worktree_handoff_freshness_unverified',
-				'Homeboy does not provide DMC handoff freshness proof. Retry with allow_unverified_freshness only after accepting that limitation.',
-				array('status' => 409, 'owner' => 'homeboy', 'retryable' => true)
-			);
-		}
 		if (null !== self::optional_string($input, 'task_ref')) {
 			return self::unsupported_input('task_ref', 'Homeboy create accepts a canonical task URL, not a DMC task reference.');
 		}
@@ -81,6 +74,9 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		}
 
 		$command = array(self::HOMEBOY, 'worktree', 'create', $repo, '--branch', $branch);
+		if (empty($input['allow_unverified_freshness'])) {
+			$command[] = '--require-handoff-freshness';
+		}
 		$from    = self::optional_string($input, 'from') ?? 'origin/HEAD';
 		$command = array_merge($command, array('--from', $from));
 		if (null !== ($task_url = self::optional_string($input, 'task_url'))) {
@@ -101,6 +97,10 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		if (!is_array($record)) {
 			return self::contract_error('Homeboy create result omitted its native worktree record.', $data);
 		}
+		$freshness = self::handoff_freshness($data, $record, !empty($input['allow_unverified_freshness']));
+		if (is_wp_error($freshness)) {
+			return $freshness;
+		}
 
 		return array(
 			'success'          => true,
@@ -117,10 +117,51 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			'context_injected' => false,
 			'context_files'    => array(),
 			'bootstrap'        => array('outcome' => 'not_requested', 'owner' => 'homeboy'),
-			'handoff_freshness' => array('status' => 'unverified', 'reason' => 'remote_freshness_probe_unsupported'),
+			'handoff_freshness' => $freshness,
 			'message'          => 'Homeboy owns this worktree lifecycle.',
 			'metadata'         => array('homeboy' => $record),
 		);
+	}
+
+	/** @param array<string,mixed> $data @param array<string,mixed> $record @return array<string,mixed>|WP_Error */
+	private static function handoff_freshness(array $data, array $record, bool $allow_unverified): array|WP_Error {
+		$source = $data['handoff_freshness']['proof'] ?? null;
+		if (!is_array($source) || 'verified' !== ($data['handoff_freshness']['status'] ?? null)) {
+			if ($allow_unverified) {
+				return array('status' => 'unverified', 'reason' => 'remote_freshness_probe_unsupported');
+			}
+			return self::contract_error('Homeboy create result omitted required handoff freshness proof.', $data);
+		}
+		$proof = array(
+			'version'                       => 3,
+			'proof_id'                      => (string) ($source['proof_id'] ?? ''),
+			'handle'                        => (string) ($record['id'] ?? ''),
+			'worktree_sha'                  => (string) ($source['worktree_sha'] ?? ''),
+			'resolved_base_ref'             => (string) ($source['resolved_base_ref'] ?? ''),
+			'resolved_base_sha'             => (string) ($source['resolved_base_sha'] ?? ''),
+			'remote_default_ref'            => (string) ($source['remote_default_ref'] ?? ''),
+			'remote_default_sha'            => (string) ($source['remote_default_sha'] ?? ''),
+			'remote_default_advertised_sha' => (string) ($source['remote_default_advertised_sha'] ?? ''),
+			'verified_at'                   => (string) ($source['verified_at'] ?? ''),
+		);
+		if (in_array('', array_values($proof), true)) {
+			return self::contract_error('Homeboy handoff freshness proof is incomplete.', $data);
+		}
+		$proof['digest'] = hash('sha256', (string) wp_json_encode(self::canonicalize($proof)));
+		return array('status' => 'verified', 'proof' => $proof);
+	}
+
+	private static function canonicalize(mixed $value): mixed {
+		if (!is_array($value)) {
+			return $value;
+		}
+		foreach ($value as $key => $item) {
+			$value[$key] = self::canonicalize($item);
+		}
+		if (array_keys($value) !== range(0, count($value) - 1)) {
+			ksort($value, SORT_STRING);
+		}
+		return $value;
 	}
 
 	/** @param array<string,mixed> $input @return array<string,mixed>|WP_Error */

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -36,7 +36,7 @@ case "$*" in
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{}}'
     ;;
   "worktree create "*)
-    printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"create","record":{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","task_url":"https://example.test/474","run_id":"run-474","cleanup_policy":"remove_when_safe","created_at":"2026-08-30T00:00:00Z","state":"active"}}}'
+    printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"create","record":{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","task_url":"https://example.test/474","run_id":"run-474","cleanup_policy":"remove_when_safe","created_at":"2026-08-30T00:00:00Z","state":"active"},"handoff_freshness":{"status":"verified","proof":{"schema":"homeboy/worktree-handoff-freshness/v1","proof_id":"proof-474","handle":"fixture@fix-474","worktree_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","resolved_base_ref":"origin/main","resolved_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_ref":"refs/remotes/origin/main","remote_default_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_advertised_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","verified_at":"2026-08-30T00:00:00Z"}}}}'
     ;;
   "worktree list")
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"list","worktrees":[{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","task_url":"https://example.test/474","run_id":"run-474","created_at":"2026-08-30T00:00:00Z","state":"active"},{"id":"fixture@removed","component_id":"fixture","worktree_path":"/workspace/fixture@removed","branch":"removed","state":"removed"}]}}'
@@ -83,6 +83,7 @@ final class WP_Error {
 	public function __construct(public string $code, public string $message, public array $data = array()) {}
 }
 function is_wp_error(mixed $value): bool { return $value instanceof WP_Error; }
+function wp_json_encode(mixed $value): string|false { return json_encode($value); }
 $filters = array();
 function add_filter(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void {
 	global $filters;
@@ -112,11 +113,11 @@ $ability = static function (string $slug) use ($callback): callable {
 };
 
 $add = $ability('datamachine-code/workspace-worktree-add');
-$refused = $add(array('repo' => 'fixture', 'branch' => 'fix/474'));
-expect(is_wp_error($refused) && 'worktree_handoff_freshness_unverified' === $refused->code, 'create refuses before mutation without explicit unverified freshness acceptance');
+$verified = $add(array('repo' => 'fixture', 'branch' => 'fix/474'));
+expect(!is_wp_error($verified) && 'verified' === ($verified['handoff_freshness']['status'] ?? null), 'create maps Homeboy remote freshness into the DMC handoff contract');
 $created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success', 'allow_unverified_freshness' => true));
 expect(!is_wp_error($created) && 'fixture@fix-474' === $created['handle'], 'create projects native Homeboy record');
-expect('unverified' === ($created['handoff_freshness']['status'] ?? null) && 'remote_freshness_probe_unsupported' === ($created['handoff_freshness']['reason'] ?? null), 'create projects the required DMC handoff freshness decision');
+expect('verified' === ($created['handoff_freshness']['status'] ?? null), 'create retains available Homeboy freshness when unverified fallback is allowed');
 $manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'cleanup_policy' => 'manual', 'allow_unverified_freshness' => true));
 expect(!is_wp_error($manual), 'manual lifecycle intent maps to non-cleanup-eligible Homeboy policy');
 expect(is_wp_error($add(array('repo' => 'fixture', 'branch' => 'unsupported', 'bootstrap' => true))), 'explicit DMC-only create behavior returns typed refusal');
@@ -151,6 +152,7 @@ if grep -q 'datamachine-code' "$LOG"; then
   exit 1
 fi
 grep -q '^worktree create fixture ' "$LOG"
+grep -q '^worktree create fixture --branch fix/474 --require-handoff-freshness --from origin/HEAD$' "$LOG"
 grep -q '^worktree create fixture --branch fix/474-manual --from origin/HEAD --cleanup-policy preserve-on-failure$' "$LOG"
 grep -q '^worktree finalize fixture@fix-474 --owner-run-ref run-474 --disposition succeeded$' "$LOG"
 grep -q '^worktree cleanup --apply$' "$LOG"


### PR DESCRIPTION
## Summary
- request native Homeboy handoff freshness during DMC-routed worktree creation
- map generic Homeboy evidence into DMC's version-3 proof contract
- retain explicit unverified fallback only when the caller opts into it

## Verification
- `bash tests/homeboy-worktree-adapter.sh`
- `git diff --check`

Depends on Extra-Chill/homeboy#13962 and tracks Extra-Chill/homeboy#13940.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested the adapter mapping under Chris Huber's direction. Chris reviewed the integration evidence and remains responsible for the change.