### PR TITLE
Preserve native DMC worktree creation through Homeboy adapter

### DIFF
--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -25,7 +25,16 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			return $args;
 		}
 
-		$args['execute_callback'] = static fn(array $input): array|WP_Error => self::execute($slug, $input);
+		$native_callback = $args['execute_callback'] ?? null;
+		$args['execute_callback'] = static function (array $input) use ($slug, $native_callback): array|WP_Error {
+			if ('datamachine-code/workspace-worktree-add' === $slug && !self::can_delegate_add($input)) {
+				if (!is_callable($native_callback)) {
+					return self::contract_error('DMC native worktree creation is unavailable for this request.', $input);
+				}
+				return call_user_func($native_callback, $input);
+			}
+			return self::execute($slug, $input);
+		};
 		$args['meta'] = array_merge(
 			is_array($args['meta'] ?? null) ? $args['meta'] : array(),
 			array(
@@ -34,6 +43,22 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			)
 		);
 		return $args;
+	}
+
+	/** @param array<string,mixed> $input */
+	private static function can_delegate_add(array $input): bool {
+		if (($input['inject_context'] ?? true) || ($input['bootstrap'] ?? true)) {
+			return false;
+		}
+		foreach (array('allow_stale', 'rebase_base', 'force', 'allow_percentage_byte_floor_exception', 'remediate_capacity', 'remediate_capacity_dry_run', 'verbose') as $unsupported) {
+			if (!empty($input[$unsupported])) {
+				return false;
+			}
+		}
+		if (null !== self::optional_string($input, 'task_ref')) {
+			return false;
+		}
+		return !isset($input['reuse_policy']) || in_array($input['reuse_policy'], array('', 'isolated'), true);
 	}
 
 	/** @param array<string,mixed> $input @return array<string,mixed>|WP_Error */
@@ -73,7 +98,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			return self::unsupported_input('cleanup_policy', 'Homeboy cannot represent this DMC cleanup policy.');
 		}
 
-		$command = array(self::HOMEBOY, 'worktree', 'create', $repo, '--branch', $branch);
+		$command = array(self::HOMEBOY, 'worktree', 'create', self::repository_target($repo), '--branch', $branch);
 		if (empty($input['allow_unverified_freshness'])) {
 			$command[] = '--require-handoff-freshness';
 		}
@@ -121,6 +146,18 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			'message'          => 'Homeboy owns this worktree lifecycle.',
 			'metadata'         => array('homeboy' => $record),
 		);
+	}
+
+	private static function repository_target(string $repo): string {
+		if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
+			return $repo;
+		}
+		$root = realpath((string) DATAMACHINE_WORKSPACE_PATH);
+		$path = false === $root ? false : realpath($root . DIRECTORY_SEPARATOR . $repo);
+		if (false === $root || false === $path || dirname($path) !== $root || !is_dir($path) || !file_exists($path . DIRECTORY_SEPARATOR . '.git')) {
+			return $repo;
+		}
+		return $path;
 	}
 
 	/** @param array<string,mixed> $data @param array<string,mixed> $record @return array<string,mixed>|WP_Error */

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -11,9 +11,11 @@ source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/homeboy.sh"
 
 SITE_PATH="$TMP/site"
+WORKSPACE="$TMP/workspace"
 FAKE_BIN="$TMP/bin"
 LOG="$TMP/homeboy.log"
-mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$FAKE_BIN"
+mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$WORKSPACE/fixture/.git" "$FAKE_BIN"
+WORKSPACE_REAL="$(cd "$WORKSPACE" && pwd -P)"
 
 cat > "$FAKE_BIN/homeboy" <<'SH'
 #!/bin/bash
@@ -78,6 +80,7 @@ php -l "$ADAPTER" >/dev/null
 cat > "$TMP/adapter-harness.php" <<'PHP'
 <?php
 define('ABSPATH', __DIR__);
+define('DATAMACHINE_WORKSPACE_PATH', __DIR__ . '/workspace');
 
 final class WP_Error {
 	public function __construct(public string $code, public string $message, public array $data = array()) {}
@@ -112,15 +115,20 @@ $ability = static function (string $slug) use ($callback): callable {
 	return $args['execute_callback'];
 };
 
-$add = $ability('datamachine-code/workspace-worktree-add');
-$verified = $add(array('repo' => 'fixture', 'branch' => 'fix/474'));
+$native_add = static fn(array $input): array => array('success' => true, 'backend' => 'dmc', 'input' => $input);
+$add_args = $callback(array('execute_callback' => $native_add, 'meta' => array('show_in_rest' => false)), 'datamachine-code/workspace-worktree-add');
+$add = $add_args['execute_callback'];
+$native = $add(array('repo' => 'fixture', 'branch' => 'fix/native'));
+expect('dmc' === ($native['backend'] ?? null), 'default context and bootstrap behavior retains DMC native creation');
+$native_option = $add(array('repo' => 'fixture', 'branch' => 'fix/native-option', 'inject_context' => false, 'bootstrap' => false, 'allow_stale' => true));
+expect('dmc' === ($native_option['backend'] ?? null), 'DMC-only create options retain DMC native creation');
+$verified = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($verified) && 'verified' === ($verified['handoff_freshness']['status'] ?? null), 'create maps Homeboy remote freshness into the DMC handoff contract');
-$created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success', 'allow_unverified_freshness' => true));
+$created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($created) && 'fixture@fix-474' === $created['handle'], 'create projects native Homeboy record');
 expect('verified' === ($created['handoff_freshness']['status'] ?? null), 'create retains available Homeboy freshness when unverified fallback is allowed');
-$manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'cleanup_policy' => 'manual', 'allow_unverified_freshness' => true));
+$manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'cleanup_policy' => 'manual', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($manual), 'manual lifecycle intent maps to non-cleanup-eligible Homeboy policy');
-expect(is_wp_error($add(array('repo' => 'fixture', 'branch' => 'unsupported', 'bootstrap' => true))), 'explicit DMC-only create behavior returns typed refusal');
 
 $list = $ability('datamachine-code/workspace-worktree-list');
 $listed = $list(array('handle' => 'fixture@fix-474', 'include_status' => true, 'limit' => 1));
@@ -151,9 +159,9 @@ if grep -q 'datamachine-code' "$LOG"; then
   cat "$LOG" >&2
   exit 1
 fi
-grep -q '^worktree create fixture ' "$LOG"
-grep -q '^worktree create fixture --branch fix/474 --require-handoff-freshness --from origin/HEAD$' "$LOG"
-grep -q '^worktree create fixture --branch fix/474-manual --from origin/HEAD --cleanup-policy preserve-on-failure$' "$LOG"
+grep -q "^worktree create $WORKSPACE_REAL/fixture " "$LOG"
+grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474 --require-handoff-freshness --from origin/HEAD$" "$LOG"
+grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474-manual --from origin/HEAD --cleanup-policy preserve-on-failure$" "$LOG"
 grep -q '^worktree finalize fixture@fix-474 --owner-run-ref run-474 --disposition succeeded$' "$LOG"
 grep -q '^worktree cleanup --apply$' "$LOG"
 


### PR DESCRIPTION
## Summary
- retain DMC native creation when context injection, bootstrap, or another DMC-only option is requested
- delegate exact bare-worktree requests to Homeboy
- resolve delegated repository names to bounded authoritative `DATAMACHINE_WORKSPACE_PATH` primary checkout paths
- cover native fallback and path-based delegation deterministically

Depends on Extra-Chill/homeboy#13989.
Closes #540.

## Testing
- `bash tests/homeboy-worktree-adapter.sh`
- `bash -n tests/homeboy-worktree-adapter.sh`
- `php -l templates/wp-coding-agents-homeboy-worktrees.php`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode reproduced the adapter failures, implemented native callback fallback and bounded repository-path translation, and ran the integration and syntax checks. Chris Huber directed and reviewed the work.