### PR TITLE
Resolve replayable DMC-to-Cook destinations

### DIFF
--- a/guidance/homeboy.sh
+++ b/guidance/homeboy.sh
@@ -123,6 +123,9 @@ Run `homeboy release` or `homeboy deploy` only when the user explicitly asks.
 
 **Discovery**
 Use `homeboy --help` and `homeboy <command> --help` for the live command contract. Inspect active configuration with `homeboy config show` and provider readiness with `homeboy agent-task providers`.
+
+**DMC Cook handoff**
+After DMC creates or returns a workspace, pass that JSON unchanged to `wp wp-coding-agents homeboy cook-destination --workspace-result='<DMC workspace result JSON>'`. This wp-coding-agents resolver emits one machine-readable Cook destination with replayable `cook.argv`; use it rather than inferring `--repo`, `--component`, or `--cwd`. It preserves root-only repositories and refuses ambiguous component mappings or canonical-remote mismatches.
 MD;
         }
     }
@@ -136,7 +139,7 @@ MD;
             return <<<'MD'
 ## Data Machine Code and Homeboy
 
-Use Homeboy directly for its native Rust worktree lifecycle (`homeboy worktree --help`) and Cook (`homeboy agent-task cook`). Data Machine Code independently provides WordPress-side repository, workspace, GitHub, and data-machine capabilities.
+Use Homeboy directly for its native Rust worktree lifecycle (`homeboy worktree --help`) and Cook (`homeboy agent-task cook`). After a DMC workspace result, resolve the exact Cook destination with `wp wp-coding-agents homeboy cook-destination --workspace-result='<DMC workspace result JSON>'`; do not compose repository and component identities manually. Data Machine Code independently provides WordPress-side repository, workspace, GitHub, and data-machine capabilities.
 MD;
         }
     }

--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -73,6 +73,146 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		};
 	}
 
+	/**
+	 * Compose DMC's workspace result with Homeboy's component registry. Neither
+	 * upstream contract needs to know that the other exists.
+	 *
+	 * @param array<string,mixed> $workspace @return array<string,mixed>|WP_Error
+	 */
+	public static function cook_destination(array $workspace): array|WP_Error {
+		$repository = self::required_string($workspace, 'repository_prefix');
+		$path       = self::required_string($workspace, 'workspace_path');
+		if (is_wp_error($repository) || is_wp_error($path)) {
+			return is_wp_error($repository) ? $repository : $path;
+		}
+		$root = realpath($path);
+		if (false === $root || !is_dir($root)) {
+			return self::contract_error('DMC workspace_path is not an accessible directory.', $workspace);
+		}
+		$remote = self::git_remote($root);
+		if (is_wp_error($remote)) {
+			return $remote;
+		}
+		$data = self::homeboy(array(self::HOMEBOY, 'component', 'list'));
+		if (is_wp_error($data)) {
+			return $data;
+		}
+		$components = is_array($data['entities'] ?? null) ? $data['entities'] : array();
+		$candidates = array();
+		foreach ($components as $component) {
+			if (!is_array($component) || !is_string($component['id'] ?? null) || '' === trim($component['id']) || !is_string($component['local_path'] ?? null)) {
+				continue;
+			}
+			$registered = realpath($component['local_path']);
+			if (false === $registered || !is_dir($registered)) {
+				continue;
+			}
+			$registered_root = self::git_root($registered);
+			if (is_wp_error($registered_root)) {
+				continue;
+			}
+			$registered_remote = self::git_remote($registered_root);
+			if (is_wp_error($registered_remote) || $remote !== $registered_remote) {
+				continue;
+			}
+			$relative = self::registered_component_relative_path($registered_root, $registered);
+			if (null === $relative || '' === $relative) {
+				continue;
+			}
+			$candidates[] = array('id' => trim($component['id']), 'relative' => $relative, 'registered_path' => $registered, 'registered_root' => $registered_root);
+		}
+		if (count($candidates) > 1) {
+			return self::contract_error('Homeboy has multiple registered execution components for this DMC repository.', array('repository' => $repository, 'candidates' => $candidates));
+		}
+
+		$component = null;
+		$cwd       = $root;
+		if (1 === count($candidates)) {
+			$candidate = $candidates[0];
+			$cwd       = realpath($root . DIRECTORY_SEPARATOR . $candidate['relative']);
+			if (false === $cwd || !is_dir($cwd)) {
+				return self::contract_error('The registered Homeboy component is absent from the DMC workspace.', array('workspace_path' => $root, 'component' => $candidate));
+			}
+			if (null === self::registered_component_relative_path($root, $cwd)) {
+				return self::contract_error('The registered Homeboy component escapes the DMC workspace.', array('workspace_path' => $root, 'component' => $candidate, 'cwd' => $cwd));
+			}
+			$component_remote = self::git_remote($cwd);
+			if (is_wp_error($component_remote)) {
+				return $component_remote;
+			}
+			if ($remote !== $component_remote) {
+				return self::contract_error('DMC workspace and Homeboy execution component have different canonical remotes.', array('workspace_remote' => $remote, 'component_remote' => $component_remote, 'component' => $candidate));
+			}
+			$component = $candidate['id'];
+		}
+
+		$argv = array(self::HOMEBOY, 'agent-task', 'cook', '--repo', $repository);
+		if (null !== $component) {
+			$argv = array_merge($argv, array('--component', $component));
+		}
+		$argv = array_merge($argv, array('--cwd', $cwd));
+		return array(
+			'schema' => 'wp-coding-agents/dmc-cook-destination/v1',
+			'repository' => $repository,
+			'component' => $component,
+			'workspace_path' => $root,
+			'cwd' => $cwd,
+			'canonical_remote' => $remote,
+			'cook' => array('argv' => $argv, 'fields' => array('repo' => $repository, 'component' => $component, 'cwd' => $cwd)),
+		);
+	}
+
+	private static function registered_component_relative_path(string $root, string $path): ?string {
+		$prefix = rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+		return str_starts_with($path, $prefix) ? substr($path, strlen($prefix)) : null;
+	}
+
+	/** @return string|WP_Error */
+	private static function git_root(string $path): string|WP_Error {
+		$descriptors = array(1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
+		$process = proc_open(array('git', '-C', $path, 'rev-parse', '--show-toplevel'), $descriptors, $pipes, null, null, array('bypass_shell' => true));
+		if (!is_resource($process)) {
+			return self::contract_error('Git root probe could not be started.', array('path' => $path));
+		}
+		$stdout = trim((string) stream_get_contents($pipes[1]));
+		$stderr = trim((string) stream_get_contents($pipes[2]));
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		if (0 !== proc_close($process) || '' === $stdout || false === ($root = realpath($stdout)) || !is_dir($root)) {
+			return self::contract_error('Git repository root is unavailable for a registered Homeboy component.', array('path' => $path, 'stderr' => $stderr));
+		}
+		return $root;
+	}
+
+	/** @return string|WP_Error */
+	private static function git_remote(string $path): string|WP_Error {
+		$descriptors = array(1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
+		$process = proc_open(array('git', '-C', $path, 'remote', 'get-url', 'origin'), $descriptors, $pipes, null, null, array('bypass_shell' => true));
+		if (!is_resource($process)) {
+			return self::contract_error('Git remote probe could not be started.', array('path' => $path));
+		}
+		$stdout = trim((string) stream_get_contents($pipes[1]));
+		$stderr = trim((string) stream_get_contents($pipes[2]));
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		if (0 !== proc_close($process) || '' === $stdout) {
+			return self::contract_error('Git origin remote is unavailable for a Cook destination.', array('path' => $path, 'stderr' => $stderr));
+		}
+		if (!str_contains($stdout, '://') && preg_match('#^(?:[^@/:]+@)?([^/:]+):/?(.+)$#', $stdout, $matches)) {
+			$host = $matches[1];
+			$path = $matches[2];
+		} else {
+			$parts = parse_url($stdout);
+			$host = is_array($parts) && is_string($parts['host'] ?? null) ? $parts['host'] : '';
+			$path = is_array($parts) && is_string($parts['path'] ?? null) ? $parts['path'] : '';
+		}
+		$path = preg_replace('#^/+|\.git/?$#', '', $path);
+		if ('' === $host || '' === $path) {
+			return self::contract_error('Git origin remote is not a canonical repository URL.', array('path' => $path, 'remote' => $stdout));
+		}
+		return strtolower($host . '/' . $path);
+	}
+
 	/** @param array<string,mixed> $input @return array<string,mixed>|WP_Error */
 	private static function add(array $input): array|WP_Error {
 		$repo   = self::required_string($input, 'repo');
@@ -525,3 +665,20 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 }
 
 add_filter('datamachine_code_ability_registration_args', array(WP_Coding_Agents_Homeboy_Worktrees::class, 'filter_ability'), 10, 2);
+
+if (defined('WP_CLI') && WP_CLI) {
+	WP_CLI::add_command(
+		'wp-coding-agents homeboy cook-destination',
+		static function (array $args, array $assoc_args): void {
+			$input = json_decode((string) ($assoc_args['workspace-result'] ?? ''), true);
+			if (!is_array($input)) {
+				WP_CLI::error('--workspace-result must be one DMC workspace result JSON object.');
+			}
+			$result = WP_Coding_Agents_Homeboy_Worktrees::cook_destination($input);
+			if (is_wp_error($result)) {
+				WP_CLI::error($result->message);
+			}
+			WP_CLI::log((string) wp_json_encode($result));
+		}
+	);
+}

--- a/tests/homeboy-agents-md.sh
+++ b/tests/homeboy-agents-md.sh
@@ -128,6 +128,12 @@ PHP
 RESULT=$(PATH="$TMP/bin:$PATH" php "$SHIM")
 EXPECTED='{"homeboy_registered":true,"filename":"AGENTS.md","slug":"homeboy-cli","priority":30,"label":"Homeboy","owner":"wp-coding-agents","freshness":"live","has_heading":true,"has_homeboy_ownership":true,"has_dmc_boundary":true,"no_dmc_worktree_commands":true,"no_legacy_dmc_ownership":true,"has_cook":true,"has_fanout":true,"has_review":true,"has_runs":true,"has_stateful":true,"has_health":true,"has_operator_boundary":true,"has_discovery":true,"no_exhaustive_map":true,"dmc_priority":20,"dmc_label":"Data Machine Code + Homeboy","dmc_owner":"wp-coding-agents","dmc_freshness":"live","dmc_live_condition":true,"dmc_has_homeboy_worktree_route":true,"dmc_has_cook_route":true,"dmc_has_dmc_boundary":true,"dmc_has_no_dmc_worktree_commands":true}'
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives concise Homeboy routing guidance"
+if grep -q 'wp-coding-agents homeboy cook-destination' "$MU_FILE" && grep -q 'cook.argv' "$MU_FILE"; then
+  echo "  ok   generated guidance uses the DMC Cook destination resolver"
+else
+  echo "  FAIL generated guidance omits the DMC Cook destination resolver"
+  FAILED=$((FAILED + 1))
+fi
 
 echo "==> re-sync with homeboy present (idempotent)"
 HASH_BEFORE=$(md5sum "$MU_FILE" | cut -d' ' -f1)

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -57,6 +57,9 @@ case "$*" in
   "worktree remove "*)
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"remove","record":{"id":"fixture@fix-474","state":"removed"}}}'
     ;;
+  "component list")
+    cat "$HOMEBOY_COMPONENTS_FILE"
+    ;;
   *)
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":false,"error":{"message":"unexpected fixture command"}}'
     exit 1
@@ -150,6 +153,35 @@ expect(false === $cleanup(array('force' => true))['dry_run'], 'cleanup force rem
 
 $remove = $ability('datamachine-code/workspace-worktree-remove');
 expect(true === $remove(array('repo' => 'fixture', 'branch' => 'fix/474'))['success'], 'remove uses Homeboy safety path');
+
+$root = __DIR__ . '/dmc/blocks-engine@fix-543';
+mkdir($root . '/php-transformer', 0777, true);
+$registered = __DIR__ . '/registered/not-blocks-engine/php-transformer';
+mkdir($registered, 0777, true);
+foreach (array(dirname($root), dirname($registered)) as $repository) {
+	passthru('git init -q ' . escapeshellarg($repository));
+	passthru('git -C ' . escapeshellarg($repository) . ' remote add origin git@github.com:Extra-Chill/blocks-engine.git');
+}
+$workspace = array('repository_prefix' => 'blocks-engine', 'workspace_path' => $root, 'component' => array('registered' => false));
+putenv('HOMEBOY_COMPONENTS_FILE=' . __DIR__ . '/components.json');
+$components = static function (array $components): void { file_put_contents(__DIR__ . '/components.json', json_encode(array('schema' => 'homeboy/command-result/v3', 'success' => true, 'data' => array('entities' => $components)))); };
+passthru('git -C ' . escapeshellarg(dirname($registered)) . ' remote set-url origin https://github.com/Extra-Chill/blocks-engine.git');
+$components(array(array('id' => 'php-transformer', 'local_path' => $registered)));
+$destination = WP_Coding_Agents_Homeboy_Worktrees::cook_destination($workspace);
+expect(!is_wp_error($destination), 'DMC workspace result resolves to a Cook destination');
+expect('github.com/extra-chill/blocks-engine' === $destination['canonical_remote'], 'resolver canonicalizes SSH and HTTPS component remotes');
+expect('blocks-engine' === $destination['repository'] && 'php-transformer' === $destination['component'], 'resolver separates owning repository from registered execution component');
+expect($root . '/php-transformer' === $destination['cwd'], 'resolver maps the registered component path into the DMC workspace');
+expect(array('agent-task', 'cook', '--repo', 'blocks-engine', '--component', 'php-transformer', '--cwd', $root . '/php-transformer') === array_slice($destination['cook']['argv'], 1), 'resolver emits exact replayable Cook argv');
+$components(array());
+$root_only = WP_Coding_Agents_Homeboy_Worktrees::cook_destination($workspace);
+expect(!is_wp_error($root_only) && null === $root_only['component'] && $root === $root_only['cwd'], 'root-only repository remains a root Cook destination');
+$components(array(array('id' => 'one', 'local_path' => $registered), array('id' => 'two', 'local_path' => $registered)));
+expect(is_wp_error(WP_Coding_Agents_Homeboy_Worktrees::cook_destination($workspace)), 'ambiguous registered components fail closed');
+passthru('git init -q ' . escapeshellarg($root . '/php-transformer'));
+passthru('git -C ' . escapeshellarg($root . '/php-transformer') . ' remote add origin git@github.com:Extra-Chill/other.git');
+$components(array(array('id' => 'php-transformer', 'local_path' => $registered)));
+expect(is_wp_error(WP_Coding_Agents_Homeboy_Worktrees::cook_destination($workspace)), 'canonical remote mismatch fails closed');
 
 PHP
 php "$TMP/adapter-harness.php" "$ADAPTER"


### PR DESCRIPTION
## Summary

- add a wp-coding-agents-owned resolver from DMC workspace results to exact Homeboy Cook destination fields and argv
- select nested execution components from Homeboy's generic registry using canonical Git remote and repository-relative path proof
- preserve root-only repositories and fail closed on ambiguity, mismatch, or workspace escape
- update generated guidance and end-to-end adapter fixtures

Closes #543.

## Verification

- `bash tests/homeboy-worktree-adapter.sh`
- `bash tests/homeboy-agents-md.sh`
- `bash tests/homeboy-components.sh`
- `bash tests/homeboy-verification-guidance.sh`
- `php -l templates/wp-coding-agents-homeboy-worktrees.php`
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-terra` via direct OpenCode runs implemented, reviewed, and refined the candidate. OpenAI `gpt-5.6-sol` via OpenCode diagnosed the live DMC/Homeboy handoff friction, orchestrated the isolated repair, reviewed the final diff, and ran verification under Chris Huber's direction. Chris remains responsible for the architecture and change.