### PR TITLE
Harden Homeboy worktree adapter defaults

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -261,6 +261,7 @@ jobs:
           - homeboy-codebox-canary
           - homeboy-components
           - homeboy-worktree-adapter
+          - homeboy-worktree-adapter-integration
           - homeboy-project-id
           - homeboy-verification-guidance
           - kimaki-credential-seeding
@@ -287,5 +288,11 @@ jobs:
           - wp-config-permissions
     steps:
       - uses: actions/checkout@v4
+      - name: Cache pinned WP-CLI and DMC integration artifacts
+        if: matrix.test == 'homeboy-worktree-adapter-integration'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/wp-coding-agents/test-fixtures
+          key: homeboy-worktree-adapter-fixtures-wp-cli-2.12.0-dmc-f9509db9168cdc1274237ce2e32f1179647bb756
       - name: Run tests/${{ matrix.test }}.sh
         run: bash tests/${{ matrix.test }}.sh

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -293,6 +293,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/wp-coding-agents/test-fixtures
-          key: homeboy-worktree-adapter-fixtures-wp-cli-2.12.0-dmc-f9509db9168cdc1274237ce2e32f1179647bb756
+          key: homeboy-worktree-adapter-fixtures-wp-cli-2.12.0-dmc-f9509db9168cdc1274237ce2e32f1179647bb756-homeboy-0.367.3
       - name: Run tests/${{ matrix.test }}.sh
         run: bash tests/${{ matrix.test }}.sh

--- a/docs/data-machine-code-migration-inventory.json
+++ b/docs/data-machine-code-migration-inventory.json
@@ -698,7 +698,7 @@
       "surface": "DMC ability-to-Homeboy mapping contract",
       "source": { "repository": "wp-coding-agents", "path": "tests/homeboy-worktree-adapter.sh", "symbol_or_command": "datamachine_code_ability_registration_args and datamachine-code/workspace-worktree-*" },
       "evidence_kind": "test",
-      "contracts": ["datamachine_code_ability_registration_args", "datamachine-code/workspace-*"],
+      "contracts": ["datamachine_code_ability_registration_args", "datamachine_code_finish_bounded_workspace_cli_request", "datamachine-code/workspace-*"],
       "current_owner": "wp-coding-agents tests",
       "current_consumers": ["CI"],
       "persistence": "None",
@@ -706,6 +706,51 @@
       "disposition": "replace",
       "migration_issue": "#529",
       "verification_gate": "Direct Homeboy lifecycle fixture replaces callback mapping assertions"
+    },
+    {
+      "id": "test-homeboy-adapter-integration",
+      "subsystem": null,
+      "surface": "Pinned DMC command compatibility through the real WP-CLI dispatcher",
+      "source": { "repository": "wp-coding-agents", "path": "tests/homeboy-worktree-adapter-integration.sh", "symbol_or_command": "datamachine-code workspace worktree add" },
+      "evidence_kind": "test",
+      "contracts": ["datamachine-code/workspace-*"],
+      "current_owner": "wp-coding-agents tests",
+      "current_consumers": ["CI"],
+      "persistence": "Checksum-keyed test cache only",
+      "target_owner": "Homeboy",
+      "disposition": "replace",
+      "migration_issue": "#534",
+      "verification_gate": "Pinned production DMC command classes remain compatible with guarded Homeboy delegation"
+    },
+    {
+      "id": "test-homeboy-adapter-dispatch-fixture",
+      "subsystem": null,
+      "surface": "Minimal WordPress dispatcher harness for pinned DMC command classes",
+      "source": { "repository": "wp-coding-agents", "path": "tests/fixtures/homeboy-worktree-adapter-dispatch.php", "symbol_or_command": "datamachine_code_finish_bounded_workspace_cli_request" },
+      "evidence_kind": "test",
+      "contracts": ["datamachine_code_finish_bounded_workspace_cli_request"],
+      "current_owner": "wp-coding-agents tests",
+      "current_consumers": ["Adapter integration CI"],
+      "persistence": "None",
+      "target_owner": "Homeboy",
+      "disposition": "replace",
+      "migration_issue": "#534",
+      "verification_gate": "Harness executes the guarded adapter through real WP-CLI dispatch without claiming full plugin bootstrap"
+    },
+    {
+      "id": "test-homeboy-adapter-provenance",
+      "subsystem": null,
+      "surface": "Immutable source and checksum provenance for adapter compatibility fixtures",
+      "source": { "repository": "wp-coding-agents", "path": "tests/fixtures/homeboy-worktree-adapter.PROVENANCE.md", "symbol_or_command": "Pinned Data Machine Code and WP-CLI fixture sources" },
+      "evidence_kind": "test",
+      "contracts": ["data-machine-code"],
+      "current_owner": "wp-coding-agents tests",
+      "current_consumers": ["Maintainers and CI"],
+      "persistence": "None",
+      "target_owner": "Homeboy",
+      "disposition": "replace",
+      "migration_issue": "#534",
+      "verification_gate": "Every downloaded compatibility fixture is immutable or checksum-verified before execution"
     },
     {
       "id": "test-runtime-projections",
@@ -1164,7 +1209,7 @@
       "setup.sh", "upgrade.sh", "lib/data-machine.sh", "lib/homeboy.sh", "lib/plugin-upgrade.sh", "lib/source-policy.sh", "lib/owned-source-discovery.sh", "lib/runtime-signature.sh", "lib/systems-capabilities.sh", "lib/cli-channel.sh", "lib/summary.sh", "runtimes/opencode.sh", "runtimes/claude-code.sh", "bridges/kimaki.sh", "templates/wp-coding-agents-homeboy-worktrees.php", "templates/wp-coding-agents-cli-transport.php", "templates/wp-coding-agents-source-reconcile.php"
     ],
     "tests": [
-      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/worktree-context-projections.sh"
+      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/fixtures/homeboy-worktree-adapter-dispatch.php", "tests/fixtures/homeboy-worktree-adapter.PROVENANCE.md", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter-integration.sh", "tests/homeboy-worktree-adapter.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/worktree-context-projections.sh"
     ],
     "guidance": [
       "README.md", "guidance/homeboy.sh", "skills/upgrade-wp-coding-agents/SKILL.md", "operator-entrypoints/wp-coding-agents-setup/verify.md"

--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -96,20 +96,20 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		if (!self::has_required_add_definition($definition, $synopsis)) {
 			return;
 		}
-		$definition['longdesc'] = "On this Homeboy-owned runtime, context injection and dependency bootstrap are omitted by default, and native handoff freshness is always requested first. The existing --skip-context-injection and --skip-bootstrap flags remain supported aliases. Use --inject-context or --bootstrap to explicitly request DMC-owned behavior; unsupported requests return a typed refusal.\n\n" . (string) ($definition['longdesc'] ?? '');
+		$definition['longdesc'] = "On this Homeboy-owned runtime, context injection and dependency bootstrap are omitted by default, and native handoff freshness is always requested first. The existing --skip-context-injection and --skip-bootstrap flags remain supported aliases. Use --inject-context or --bootstrap to explicitly request DMC-owned behavior.\n\n" . (string) ($definition['longdesc'] ?? '');
 		$definition['synopsis'] = array_merge(
 			$definition['synopsis'],
 			array(
 				array(
 					'type'        => 'flag',
 					'name'        => 'inject-context',
-					'description' => 'Explicitly request DMC context injection (unsupported by the Homeboy adapter).',
+					'description' => 'Route creation through DMC with context injection.',
 					'optional'    => true,
 				),
 				array(
 					'type'        => 'flag',
 					'name'        => 'bootstrap',
-					'description' => 'Explicitly request DMC dependency bootstrap (unsupported by the Homeboy adapter).',
+					'description' => 'Route creation through DMC with dependency bootstrap.',
 					'optional'    => true,
 				),
 			)

--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -345,13 +345,15 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		if (is_wp_error($result)) {
 			return $result;
 		}
-		if (0 !== $result['exit_code'] || 1 !== preg_match('/\Ahomeboy ([0-9]+\.[0-9]+\.[0-9]+)\s*\z/', trim($result['stdout']), $matches)) {
+		$number  = '(?:0|[1-9][0-9]*)';
+		$pattern = '/\Ahomeboy ((' . $number . '\.' . $number . '\.' . $number . ')(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)\z/D';
+		if (0 !== $result['exit_code'] || 1 !== preg_match($pattern, trim($result['stdout']), $matches)) {
 			return self::contract_error(
 				'Homeboy repository-path capability probe returned an invalid version result.',
-				array('capability' => 'worktree_create_repository_path', 'exit_code' => $result['exit_code'], 'stdout' => trim($result['stdout']), 'stderr' => trim($result['stderr']))
+				array('capability' => 'worktree_create_repository_path', 'exit_code' => $result['exit_code'], 'output_redacted' => true, 'stdout_bytes' => strlen($result['stdout']), 'stderr_bytes' => strlen($result['stderr']))
 			);
 		}
-		return array('supported' => version_compare($matches[1], self::REPOSITORY_PATH_MIN_VERSION, '>='), 'version' => $matches[1]);
+		return array('supported' => version_compare($matches[2], self::REPOSITORY_PATH_MIN_VERSION, '>='), 'version' => $matches[1]);
 	}
 
 	private static function is_repository_path_capability_error(array|WP_Error $result): bool {

--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -61,6 +61,146 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		return !isset($input['reuse_policy']) || in_array($input['reuse_policy'], array('', 'isolated'), true);
 	}
 
+	public static function adapt_cli(): void {
+		$workspace_command = 'DataMachineCode\\Cli\\Commands\\WorkspaceCommand';
+		if (
+			!defined('WP_CLI')
+			|| !WP_CLI
+			|| !class_exists('WP_CLI')
+			|| !class_exists($workspace_command)
+			|| !method_exists($workspace_command, 'worktree_command_definitions')
+			|| !method_exists($workspace_command, '__worktree_operation')
+		) {
+			return;
+		}
+		$reflection  = new \ReflectionClass($workspace_command);
+		$definitions = $reflection->getMethod('worktree_command_definitions');
+		$dispatcher  = $reflection->getMethod('__worktree_operation');
+		$constructor = $reflection->getConstructor();
+		if (
+			!$reflection->isInstantiable()
+			|| (null !== $constructor && 0 < $constructor->getNumberOfRequiredParameters())
+			|| !self::has_exact_method_contract($definitions, true, array(), 'array')
+			|| !self::has_exact_method_contract($dispatcher, false, array('string', 'array', 'array'), 'void')
+		) {
+			return;
+		}
+
+		try {
+			$command_definitions = \DataMachineCode\Cli\Commands\WorkspaceCommand::worktree_command_definitions();
+		} catch (\Throwable) {
+			return;
+		}
+		$definition = is_array($command_definitions) ? ($command_definitions['add'] ?? null) : null;
+		$synopsis   = is_array($definition) ? ($definition['synopsis'] ?? null) : null;
+		if (!self::has_required_add_definition($definition, $synopsis)) {
+			return;
+		}
+		$definition['longdesc'] = "On this Homeboy-owned runtime, context injection and dependency bootstrap are omitted by default, and native handoff freshness is always requested first. The existing --skip-context-injection and --skip-bootstrap flags remain supported aliases. Use --inject-context or --bootstrap to explicitly request DMC-owned behavior; unsupported requests return a typed refusal.\n\n" . (string) ($definition['longdesc'] ?? '');
+		$definition['synopsis'] = array_merge(
+			$definition['synopsis'],
+			array(
+				array(
+					'type'        => 'flag',
+					'name'        => 'inject-context',
+					'description' => 'Explicitly request DMC context injection (unsupported by the Homeboy adapter).',
+					'optional'    => true,
+				),
+				array(
+					'type'        => 'flag',
+					'name'        => 'bootstrap',
+					'description' => 'Explicitly request DMC dependency bootstrap (unsupported by the Homeboy adapter).',
+					'optional'    => true,
+				),
+			)
+		);
+		$definition['synopsis'] = array_map(
+			static function (array $argument): array {
+				return match ($argument['name'] ?? null) {
+					'skip-context-injection' => array_merge($argument, array('description' => 'Alias confirming that Homeboy should omit DMC context injection (the adapter default).')),
+					'skip-bootstrap'         => array_merge($argument, array('description' => 'Alias confirming that Homeboy should omit DMC dependency bootstrap (the adapter default).')),
+					default => $argument,
+				};
+			},
+			$definition['synopsis']
+		);
+
+		\WP_CLI::add_command(
+			'datamachine-code workspace worktree add',
+			static function (array $args, array $assoc_args): void {
+				if (!empty($assoc_args['inject-context']) && !empty($assoc_args['skip-context-injection'])) {
+					\WP_CLI::error('Use only one of --inject-context or --skip-context-injection.');
+				}
+				if (!empty($assoc_args['bootstrap']) && !empty($assoc_args['skip-bootstrap'])) {
+					\WP_CLI::error('Use only one of --bootstrap or --skip-bootstrap.');
+				}
+				if (empty($assoc_args['inject-context'])) {
+					$assoc_args['skip-context-injection'] = true;
+				}
+				if (empty($assoc_args['bootstrap'])) {
+					$assoc_args['skip-bootstrap'] = true;
+				}
+				unset($assoc_args['inject-context'], $assoc_args['bootstrap']);
+				(new \DataMachineCode\Cli\Commands\WorkspaceCommand())->__worktree_operation('add', $args, $assoc_args);
+			},
+			$definition
+		);
+	}
+
+	/** @param list<string> $parameter_types */
+	private static function has_exact_method_contract(\ReflectionMethod $method, bool $static, array $parameter_types, string $return_type): bool {
+		if (!$method->isPublic() || $static !== $method->isStatic() || count($parameter_types) !== $method->getNumberOfParameters()) {
+			return false;
+		}
+		$type = $method->getReturnType();
+		if (!$type instanceof \ReflectionNamedType || $type->allowsNull() || !$type->isBuiltin() || $return_type !== $type->getName()) {
+			return false;
+		}
+		foreach ($method->getParameters() as $index => $parameter) {
+			$type = $parameter->getType();
+			if (
+				$parameter->isOptional()
+				|| $parameter->isVariadic()
+				|| $parameter->isPassedByReference()
+				|| !$type instanceof \ReflectionNamedType
+				|| $type->allowsNull()
+				|| !$type->isBuiltin()
+				|| $parameter_types[$index] !== $type->getName()
+			) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static function has_required_add_definition(mixed $definition, mixed $synopsis): bool {
+		if (!is_array($definition) || !is_string($definition['shortdesc'] ?? null) || !is_string($definition['longdesc'] ?? null) || !is_array($synopsis)) {
+			return false;
+		}
+		$arguments = array();
+		foreach ($synopsis as $argument) {
+			$name = is_array($argument) ? ($argument['name'] ?? null) : null;
+			if (!is_string($name) || '' === $name || isset($arguments[$name])) {
+				return false;
+			}
+			$arguments[$name] = $argument;
+		}
+		$required = array(
+			'repo'                   => array('type' => 'positional', 'required' => true),
+			'branch'                 => array('type' => 'positional', 'required' => true),
+			'skip-context-injection' => array('type' => 'flag', 'optional' => true),
+			'skip-bootstrap'         => array('type' => 'flag', 'optional' => true),
+		);
+		foreach ($required as $name => $semantics) {
+			foreach ($semantics as $key => $value) {
+				if (($arguments[$name][$key] ?? null) !== $value) {
+					return false;
+				}
+			}
+		}
+		return !isset($arguments['inject-context']) && !isset($arguments['bootstrap']);
+	}
+
 	/** @param array<string,mixed> $input @return array<string,mixed>|WP_Error */
 	public static function execute(string $slug, array $input): array|WP_Error {
 		return match ($slug) {
@@ -98,10 +238,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			return self::unsupported_input('cleanup_policy', 'Homeboy cannot represent this DMC cleanup policy.');
 		}
 
-		$command = array(self::HOMEBOY, 'worktree', 'create', self::repository_target($repo), '--branch', $branch);
-		if (empty($input['allow_unverified_freshness'])) {
-			$command[] = '--require-handoff-freshness';
-		}
+		$command = array(self::HOMEBOY, 'worktree', 'create', self::repository_target($repo), '--branch', $branch, '--require-handoff-freshness');
 		$from    = self::optional_string($input, 'from') ?? 'origin/HEAD';
 		$command = array_merge($command, array('--from', $from));
 		if (null !== ($task_url = self::optional_string($input, 'task_url'))) {
@@ -114,7 +251,19 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			$command = array_merge($command, array('--cleanup-policy', $policy));
 		}
 
-		$data = self::homeboy($command);
+		$data                     = self::homeboy($command);
+		$used_unverified_fallback = false;
+		if (self::is_unsupported_freshness_result($data)) {
+			if (empty($input['allow_unverified_freshness'])) {
+				return new WP_Error(
+					'worktree_handoff_freshness_unverified',
+					'Installed Homeboy cannot provide native handoff freshness. Upgrade Homeboy or explicitly permit an unverified fallback.',
+					array('status' => 409, 'owner' => 'homeboy', 'retryable' => true, 'remediation' => 'upgrade_homeboy', 'cause' => 'unsupported_option')
+				);
+			}
+			$data                     = self::homeboy(array_values(array_filter($command, static fn(string $argument): bool => '--require-handoff-freshness' !== $argument)));
+			$used_unverified_fallback = true;
+		}
 		if (is_wp_error($data)) {
 			return $data;
 		}
@@ -122,7 +271,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		if (!is_array($record)) {
 			return self::contract_error('Homeboy create result omitted its native worktree record.', $data);
 		}
-		$freshness = self::handoff_freshness($data, $record, !empty($input['allow_unverified_freshness']));
+		$freshness = self::handoff_freshness($data, $record, $used_unverified_fallback);
 		if (is_wp_error($freshness)) {
 			return $freshness;
 		}
@@ -406,6 +555,43 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 
 	/** @param list<string> $command @return array<string,mixed>|WP_Error */
 	private static function homeboy(array $command): array|WP_Error {
+		$result = self::run($command);
+		if (is_wp_error($result)) {
+			return $result;
+		}
+		$stdout = $result['stdout'];
+		$stderr = $result['stderr'];
+		$exit   = $result['exit_code'];
+
+		$payload = json_decode($stdout, true);
+		if (2 === $exit && str_contains($stderr, "unexpected argument '--require-handoff-freshness' found")) {
+			return new WP_Error(
+				'wp_coding_agents_homeboy_worktree_unsupported_option',
+				'Installed Homeboy does not support required handoff freshness.',
+				array('status' => 409, 'owner' => 'homeboy', 'option' => '--require-handoff-freshness', 'retryable' => false)
+			);
+		}
+		if (!is_array($payload) || 'homeboy/command-result/v3' !== ($payload['schema'] ?? null)) {
+			return self::contract_error('Homeboy returned malformed command-result JSON.', array('exit_code' => $exit, 'stderr' => trim($stderr)));
+		}
+		if (0 !== $exit || empty($payload['success'])) {
+			return new WP_Error(
+				'wp_coding_agents_homeboy_worktree_failed',
+				(string) ($payload['diagnostics']['message'] ?? $payload['summary'] ?? 'Homeboy worktree operation failed.'),
+				array('status' => 409, 'owner' => 'homeboy', 'homeboy' => $payload)
+			);
+		}
+		return is_array($payload['data'] ?? null) ? $payload['data'] : array();
+	}
+
+	private static function is_unsupported_freshness_result(array|WP_Error $result): bool {
+		return is_wp_error($result)
+			&& 'wp_coding_agents_homeboy_worktree_unsupported_option' === $result->get_error_code()
+			&& '--require-handoff-freshness' === ($result->get_error_data()['option'] ?? null);
+	}
+
+	/** @param list<string> $command @return array{stdout:string,stderr:string,exit_code:int}|WP_Error */
+	private static function run(array $command): array|WP_Error {
 		$descriptors = array(1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
 		$process = proc_open($command, $descriptors, $pipes, null, null, array('bypass_shell' => true));
 		if (!is_resource($process)) {
@@ -444,19 +630,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			return self::contract_error('Homeboy output exceeded the bounded adapter limit.', array());
 		}
 		self::close_process($process, $pipes);
-
-		$payload = json_decode($stdout, true);
-		if (!is_array($payload) || 'homeboy/command-result/v3' !== ($payload['schema'] ?? null)) {
-			return self::contract_error('Homeboy returned malformed command-result JSON.', array('exit_code' => $exit, 'stderr' => trim($stderr)));
-		}
-		if (0 !== $exit || empty($payload['success'])) {
-			return new WP_Error(
-				'wp_coding_agents_homeboy_worktree_failed',
-				(string) ($payload['diagnostics']['message'] ?? $payload['summary'] ?? 'Homeboy worktree operation failed.'),
-				array('status' => 409, 'owner' => 'homeboy', 'homeboy' => $payload)
-			);
-		}
-		return is_array($payload['data'] ?? null) ? $payload['data'] : array();
+		return array('stdout' => $stdout, 'stderr' => $stderr, 'exit_code' => $exit ?? -1);
 	}
 
 	/** @param resource $process @param array<int,resource> $pipes */
@@ -525,3 +699,4 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 }
 
 add_filter('datamachine_code_ability_registration_args', array(WP_Coding_Agents_Homeboy_Worktrees::class, 'filter_ability'), 10, 2);
+add_action('plugins_loaded', array(WP_Coding_Agents_Homeboy_Worktrees::class, 'adapt_cli'), 22);

--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -11,6 +11,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 	private const HOMEBOY = '@HOMEBOY_BINARY@';
 	private const TIMEOUT_SECONDS = 120;
 	private const OUTPUT_LIMIT_BYTES = 1048576;
+	private const REPOSITORY_PATH_MIN_VERSION = '0.367.3';
 	private const DELEGATED_ABILITIES = array(
 		'datamachine-code/workspace-worktree-add',
 		'datamachine-code/workspace-worktree-list',
@@ -33,7 +34,11 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 				}
 				return call_user_func($native_callback, $input);
 			}
-			return self::execute($slug, $input);
+			$result = self::execute($slug, $input);
+			if ('datamachine-code/workspace-worktree-add' === $slug && self::is_repository_path_capability_error($result) && is_callable($native_callback)) {
+				return call_user_func($native_callback, $input);
+			}
+			return $result;
 		};
 		$args['meta'] = array_merge(
 			is_array($args['meta'] ?? null) ? $args['meta'] : array(),
@@ -56,6 +61,9 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			}
 		}
 		if (null !== self::optional_string($input, 'task_ref')) {
+			return false;
+		}
+		if (self::has_input_value($input, 'purpose')) {
 			return false;
 		}
 		return !isset($input['reuse_policy']) || in_array($input['reuse_policy'], array('', 'isolated'), true);
@@ -225,6 +233,9 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 				return self::unsupported_input($unsupported, 'Homeboy create cannot preserve this DMC-specific behavior.');
 			}
 		}
+		if (self::has_input_value($input, 'purpose')) {
+			return self::unsupported_input('purpose', 'Homeboy create cannot preserve DMC worktree purpose metadata.');
+		}
 		if (null !== self::optional_string($input, 'task_ref')) {
 			return self::unsupported_input('task_ref', 'Homeboy create accepts a canonical task URL, not a DMC task reference.');
 		}
@@ -238,7 +249,13 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			return self::unsupported_input('cleanup_policy', 'Homeboy cannot represent this DMC cleanup policy.');
 		}
 
-		$command = array(self::HOMEBOY, 'worktree', 'create', self::repository_target($repo), '--branch', $branch, '--require-handoff-freshness');
+		$target = self::repository_target($repo);
+		if (is_wp_error($target)) {
+			return $target;
+		}
+		$command                  = array(self::HOMEBOY, 'worktree', 'create', $target, '--branch', $branch);
+		$freshness_argument_index = count($command);
+		$command[]                = '--require-handoff-freshness';
 		$from    = self::optional_string($input, 'from') ?? 'origin/HEAD';
 		$command = array_merge($command, array('--from', $from));
 		if (null !== ($task_url = self::optional_string($input, 'task_url'))) {
@@ -261,7 +278,9 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 					array('status' => 409, 'owner' => 'homeboy', 'retryable' => true, 'remediation' => 'upgrade_homeboy', 'cause' => 'unsupported_option')
 				);
 			}
-			$data                     = self::homeboy(array_values(array_filter($command, static fn(string $argument): bool => '--require-handoff-freshness' !== $argument)));
+			$fallback_command = $command;
+			array_splice($fallback_command, $freshness_argument_index, 1);
+			$data                     = self::homeboy($fallback_command);
 			$used_unverified_fallback = true;
 		}
 		if (is_wp_error($data)) {
@@ -297,7 +316,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		);
 	}
 
-	private static function repository_target(string $repo): string {
+	private static function repository_target(string $repo): string|WP_Error {
 		if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
 			return $repo;
 		}
@@ -306,7 +325,41 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		if (false === $root || false === $path || dirname($path) !== $root || !is_dir($path) || !file_exists($path . DIRECTORY_SEPARATOR . '.git')) {
 			return $repo;
 		}
+		$capability = self::repository_path_capability();
+		if (is_wp_error($capability)) {
+			return $capability;
+		}
+		if (!$capability['supported']) {
+			return new WP_Error(
+				'wp_coding_agents_homeboy_worktree_repository_path_unsupported',
+				'Installed Homeboy cannot create a worktree from the DMC repository path. Upgrade Homeboy before delegating this request.',
+				array('status' => 409, 'owner' => 'homeboy', 'capability' => 'worktree_create_repository_path', 'installed_version' => $capability['version'], 'minimum_version' => self::REPOSITORY_PATH_MIN_VERSION, 'remediation' => 'upgrade_homeboy', 'retryable' => true)
+			);
+		}
 		return $path;
+	}
+
+	/** @return array{supported:bool,version:string}|WP_Error */
+	private static function repository_path_capability(): array|WP_Error {
+		$result = self::run(array(self::HOMEBOY, '--version'));
+		if (is_wp_error($result)) {
+			return $result;
+		}
+		if (0 !== $result['exit_code'] || 1 !== preg_match('/\Ahomeboy ([0-9]+\.[0-9]+\.[0-9]+)\s*\z/', trim($result['stdout']), $matches)) {
+			return self::contract_error(
+				'Homeboy repository-path capability probe returned an invalid version result.',
+				array('capability' => 'worktree_create_repository_path', 'exit_code' => $result['exit_code'], 'stdout' => trim($result['stdout']), 'stderr' => trim($result['stderr']))
+			);
+		}
+		return array('supported' => version_compare($matches[1], self::REPOSITORY_PATH_MIN_VERSION, '>='), 'version' => $matches[1]);
+	}
+
+	private static function is_repository_path_capability_error(array|WP_Error $result): bool {
+		if (!is_wp_error($result)) {
+			return false;
+		}
+		$data = $result->get_error_data();
+		return 'worktree_create_repository_path' === ($data['capability'] ?? $data['evidence']['capability'] ?? null);
 	}
 
 	/** @param array<string,mixed> $data @param array<string,mixed> $record @return array<string,mixed>|WP_Error */
@@ -650,6 +703,11 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 	/** @param array<string,mixed> $input */
 	private static function optional_string(array $input, string $field): ?string {
 		return isset($input[$field]) && is_scalar($input[$field]) && '' !== trim((string) $input[$field]) ? trim((string) $input[$field]) : null;
+	}
+
+	/** @param array<string,mixed> $input */
+	private static function has_input_value(array $input, string $field): bool {
+		return array_key_exists($field, $input) && (!is_scalar($input[$field]) || '' !== trim((string) $input[$field]));
 	}
 
 	private static function cleanup_policy(mixed $value): ?string {

--- a/tests/fixtures/homeboy-worktree-adapter-dispatch.php
+++ b/tests/fixtures/homeboy-worktree-adapter-dispatch.php
@@ -1,0 +1,153 @@
+<?php
+
+// Narrow MIT-owned harness for WP-CLI dispatch and DMC command-class loading.
+// This deliberately does not bootstrap WordPress or either plugin.
+
+define('WP_CLI', true);
+define('ABSPATH', __DIR__ . '/');
+$wp_cli_phar = getenv('WP_CLI_PHAR');
+define('WP_CLI_ROOT', 'phar://' . $wp_cli_phar . '/vendor/wp-cli/wp-cli');
+define('WP_CLI_VENDOR_DIR', 'phar://' . $wp_cli_phar . '/vendor');
+require WP_CLI_ROOT . '/php/fallback-functions.php';
+require WP_CLI_ROOT . '/php/utils.php';
+require WP_CLI_ROOT . '/php/dispatcher.php';
+require WP_CLI_ROOT . '/php/class-wp-cli.php';
+require WP_CLI_ROOT . '/php/class-wp-cli-command.php';
+require 'phar://' . $wp_cli_phar . '/vendor/autoload.php';
+WP_CLI::set_logger(new WP_CLI\Loggers\Regular(false));
+$runner = WP_CLI::get_runner();
+$runner_config = new ReflectionProperty($runner, 'config');
+$runner_config->setValue($runner, array('debug' => false, 'quiet' => false, 'prompt' => false));
+
+final class WP_Error {
+	public function __construct(public string $code, public string $message, public array $data = array()) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): array { return $this->data; }
+}
+
+function is_wp_error(mixed $value): bool { return $value instanceof WP_Error; }
+function wp_json_encode(mixed $value, int $flags = 0): string|false { return json_encode($value, $flags); }
+
+$GLOBALS['test_actions'] = array();
+$GLOBALS['test_filters'] = array();
+function add_action(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void {
+	$GLOBALS['test_actions'][$hook][$priority][] = $callback;
+}
+function add_filter(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void {
+	$GLOBALS['test_filters'][$hook][$priority][] = $callback;
+}
+
+function datamachine_code_finish_bounded_workspace_cli_request(): void {
+	if (false !== getenv('DMC_FINALIZER_LOG')) {
+		file_put_contents(getenv('DMC_FINALIZER_LOG'), "finalized\n", FILE_APPEND);
+	}
+}
+
+final class DMC_Test_Ability {
+	public function execute(array $input): array|WP_Error {
+		return ($GLOBALS['dmc_test_ability_callback'])($input);
+	}
+}
+function wp_get_ability(string $name): ?DMC_Test_Ability {
+	return 'datamachine-code/workspace-worktree-add' === $name ? new DMC_Test_Ability() : null;
+}
+
+eval('namespace DataMachine\\Cli; class BaseCommand extends \\WP_CLI_Command {}');
+$version_skew = getenv('DMC_VERSION_SKEW');
+if (false !== $version_skew && '' !== $version_skew) {
+	$valid_definition = "array('add' => array('shortdesc' => 'Add.', 'longdesc' => 'Add.', 'synopsis' => array(array('type' => 'positional', 'name' => 'repo', 'required' => true), array('type' => 'positional', 'name' => 'branch', 'required' => true), array('type' => 'flag', 'name' => 'skip-context-injection', 'optional' => true), array('type' => 'flag', 'name' => 'skip-bootstrap', 'optional' => true))))";
+	$definition = 'definition' === $version_skew
+		? "array('add' => array('shortdesc' => 'Add.', 'longdesc' => 'Add.', 'synopsis' => array(array('type' => 'positional', 'name' => 'repo', 'required' => true), array('type' => 'positional', 'name' => 'branch', 'optional' => true), array('type' => 'flag', 'name' => 'skip-context-injection', 'optional' => true), array('type' => 'flag', 'name' => 'skip-bootstrap', 'optional' => true))))"
+		: $valid_definition;
+	$dispatcher = match ($version_skew) {
+		'arity'  => 'public function __worktree_operation(string $operation, array $args): void {}',
+		'types'  => 'public function __worktree_operation(array $operation, array $args, array $assoc_args): void {}',
+		'return' => 'public function __worktree_operation(string $operation, array $args, array $assoc_args): array { return array(); }',
+		default  => 'public function __worktree_operation(string $operation, array $args, array $assoc_args): void {}',
+	};
+	eval("namespace DataMachineCode\\Cli\\Commands; class WorkspaceCommand extends \\DataMachine\\Cli\\BaseCommand { public static function worktree_command_definitions(): array { return {$definition}; } {$dispatcher} }");
+} else {
+	$fixture_root = getenv('DMC_FIXTURE_ROOT');
+	if (!is_string($fixture_root) || !is_dir($fixture_root)) {
+		throw new RuntimeException('DMC_FIXTURE_ROOT must identify the verified, extracted DMC source.');
+	}
+	require $fixture_root . '/inc/Workspace/WorktreeContextInjector.php';
+	require $fixture_root . '/inc/Cli/CliResponseRenderer.php';
+	require $fixture_root . '/inc/Cli/Commands/WorkspaceCommand.php';
+}
+
+require getenv('HOMEBOY_ADAPTER_PATH');
+$ability_args = array('execute_callback' => static fn(array $input): array => $input, 'meta' => array());
+foreach ($GLOBALS['test_filters']['datamachine_code_ability_registration_args'] ?? array() as $callbacks) {
+	foreach ($callbacks as $callback) {
+		$ability_args = $callback($ability_args, 'datamachine-code/workspace-worktree-add');
+	}
+}
+$GLOBALS['dmc_test_ability_callback'] = $ability_args['execute_callback'];
+
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		$namespace = '';
+		foreach (array('datamachine-code', 'workspace', 'worktree') as $part) {
+			$namespace = ltrim($namespace . ' ' . $part);
+			WP_CLI::add_command($namespace, WP_CLI\Dispatcher\CommandNamespace::class);
+		}
+		if (false !== getenv('DMC_VERSION_SKEW') && '' !== getenv('DMC_VERSION_SKEW')) {
+			WP_CLI::add_command(
+				'datamachine-code workspace worktree add',
+				static function (): void { WP_CLI::line('native-version-skew-command'); },
+				array('synopsis' => '<repo> <branch>')
+			);
+			return;
+		}
+
+		WP_CLI::add_command(
+			'datamachine-code workspace worktree add',
+			static function (): void { throw new RuntimeException('The adapter did not replace the test leaf.'); },
+			array('after_invoke' => 'datamachine_code_finish_bounded_workspace_cli_request')
+		);
+	},
+	21
+);
+
+ksort($GLOBALS['test_actions']['plugins_loaded']);
+foreach ($GLOBALS['test_actions']['plugins_loaded'] as $callbacks) {
+	foreach ($callbacks as $callback) {
+		$callback();
+	}
+}
+
+$path = array('datamachine-code', 'workspace', 'worktree', 'add');
+$command = WP_CLI::get_root_command();
+foreach ($path as $part) {
+	$lookup = array($part);
+	$command = $command->find_subcommand($lookup);
+	if (!$command) {
+		break;
+	}
+}
+if (!$command instanceof WP_CLI\Dispatcher\Subcommand) {
+	throw new RuntimeException('The worktree add command was not registered as a WP-CLI leaf: ' . get_debug_type($command));
+}
+if ('--dispatcher-help' === ($argv[1] ?? '')) {
+	echo wp_json_encode(array('synopsis' => $command->get_synopsis(), 'longdesc' => $command->get_longdesc())), "\n";
+	exit;
+}
+
+$tokens = array_slice($argv, 1);
+if (array_slice($tokens, 0, 4) !== $path) {
+	throw new RuntimeException('Unexpected command route.');
+}
+$args = array();
+$assoc_args = array();
+foreach (array_slice($tokens, 4) as $token) {
+	if (!str_starts_with($token, '--')) {
+		$args[] = $token;
+		continue;
+	}
+	[$key, $value] = array_pad(explode('=', substr($token, 2), 2), 2, true);
+	$assoc_args[$key] = $value;
+}
+$command->invoke($args, $assoc_args, array());

--- a/tests/fixtures/homeboy-worktree-adapter-dispatch.php
+++ b/tests/fixtures/homeboy-worktree-adapter-dispatch.php
@@ -5,6 +5,10 @@
 
 define('WP_CLI', true);
 define('ABSPATH', __DIR__ . '/');
+$workspace_path = getenv('DMC_WORKSPACE_PATH');
+if (is_string($workspace_path) && '' !== $workspace_path) {
+	define('DATAMACHINE_WORKSPACE_PATH', $workspace_path);
+}
 $wp_cli_phar = getenv('WP_CLI_PHAR');
 define('WP_CLI_ROOT', 'phar://' . $wp_cli_phar . '/vendor/wp-cli/wp-cli');
 define('WP_CLI_VENDOR_DIR', 'phar://' . $wp_cli_phar . '/vendor');

--- a/tests/fixtures/homeboy-worktree-adapter.PROVENANCE.md
+++ b/tests/fixtures/homeboy-worktree-adapter.PROVENANCE.md
@@ -1,0 +1,25 @@
+# Homeboy Worktree Adapter Integration Provenance
+
+The integration test downloads these upstream artifacts into a user cache and
+verifies their pinned SHA-256 digests before loading or extracting them:
+
+- WP-CLI `2.12.0` PHAR:
+  `https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar`
+  (`ce34ddd838f7351d6759068d09793f26755463b4a4610a5a5c0a97b68220d85c`)
+- Data Machine Code `0.74.1` commit
+  `f9509db9168cdc1274237ce2e32f1179647bb756` archive:
+  `https://codeload.github.com/Extra-Chill/data-machine-code/tar.gz/f9509db9168cdc1274237ce2e32f1179647bb756`
+  (`45107900643a74e6a76b51b28cd7332aea68756ddb2eaac5f9360e0f9823b62b`)
+
+The local `homeboy-worktree-adapter-dispatch.php` is a small MIT-owned test
+harness. It loads the real WP-CLI dispatcher from the verified PHAR and the
+production DMC `WorkspaceCommand` class and its synopsis dependencies from the
+verified commit. The test claims compatibility with those dispatch and
+command-class surfaces. It does not claim a full WordPress, Data Machine, or
+Data Machine Code plugin bootstrap.
+
+The WP-CLI project does not publish a known immutable official byte URL for the
+PHAR. Its release-asset availability is therefore mutable residual risk. The
+test does not vendor the binary and fails closed unless downloaded and cached
+bytes match the digest above; a changed or unavailable release asset cannot be
+loaded by the harness.

--- a/tests/fixtures/homeboy-worktree-adapter.PROVENANCE.md
+++ b/tests/fixtures/homeboy-worktree-adapter.PROVENANCE.md
@@ -10,6 +10,10 @@ verifies their pinned SHA-256 digests before loading or extracting them:
   `f9509db9168cdc1274237ce2e32f1179647bb756` archive:
   `https://codeload.github.com/Extra-Chill/data-machine-code/tar.gz/f9509db9168cdc1274237ce2e32f1179647bb756`
   (`45107900643a74e6a76b51b28cd7332aea68756ddb2eaac5f9360e0f9823b62b`)
+- Homeboy `0.367.3` official release archive selected for the host platform:
+  - `aarch64-apple-darwin`: `634731246fb92bc6846e2576552dc2c903f990b2252e161cf77645020e1e59e8`
+  - `x86_64-unknown-linux-gnu`: `cd373e81613de9140e5ada23189cca408ddd06a8160fb7cc4031cf536b9ea6e4`
+  - `aarch64-unknown-linux-gnu`: `c0726076f8ab6620e50e761a534240ee49e49b0046732474ed20ba974e1cf764`
 
 The local `homeboy-worktree-adapter-dispatch.php` is a small MIT-owned test
 harness. It loads the real WP-CLI dispatcher from the verified PHAR and the
@@ -17,6 +21,12 @@ production DMC `WorkspaceCommand` class and its synopsis dependencies from the
 verified commit. The test claims compatibility with those dispatch and
 command-class surfaces. It does not claim a full WordPress, Data Machine, or
 Data Machine Code plugin bootstrap.
+
+On supported CI and development platforms, the harness also executes the
+checksum-verified official Homeboy binary and requires its exact
+`homeboy 0.367.3+3fa0c185d41b` version result before using that result in the
+repository-path capability fixture. Other platforms retain deterministic
+metadata-format coverage without claiming official-binary execution.
 
 The WP-CLI project does not publish a known immutable official byte URL for the
 PHAR. Its release-asset availability is therefore mutable residual risk. The

--- a/tests/homeboy-worktree-adapter-integration.sh
+++ b/tests/homeboy-worktree-adapter-integration.sh
@@ -113,17 +113,11 @@ if "${WP[@]}" datamachine-code workspace worktree add homeboy invalid --unknown-
   exit 1
 fi
 
-if EXPLICIT="$("${WP[@]}" datamachine-code workspace worktree add homeboy explicit-context --inject-context --format=json)"; then
-  echo "FAIL: explicit context injection unexpectedly succeeded" >&2
-  exit 1
-fi
-php -r '$e=json_decode($argv[1],true)["error"]??array(); if (($e["code"]??null)!=="wp_coding_agents_homeboy_worktree_unsupported_input" || ($e["data"]["field"]??null)!=="inject_context") exit(1);' "$EXPLICIT"
-
-if EXPLICIT="$("${WP[@]}" datamachine-code workspace worktree add homeboy explicit-bootstrap --bootstrap --format=json)"; then
-  echo "FAIL: explicit dependency bootstrap unexpectedly succeeded" >&2
-  exit 1
-fi
-php -r '$e=json_decode($argv[1],true)["error"]??array(); if (($e["code"]??null)!=="wp_coding_agents_homeboy_worktree_unsupported_input" || ($e["data"]["field"]??null)!=="bootstrap") exit(1);' "$EXPLICIT"
+: > "$LOG"
+"${WP[@]}" datamachine-code workspace worktree add homeboy explicit-context --inject-context --format=json >/dev/null
+[ ! -s "$LOG" ] || { echo "FAIL: explicit context injection reached Homeboy instead of native DMC" >&2; exit 1; }
+"${WP[@]}" datamachine-code workspace worktree add homeboy explicit-bootstrap --bootstrap --format=json >/dev/null
+[ ! -s "$LOG" ] || { echo "FAIL: explicit dependency bootstrap reached Homeboy instead of native DMC" >&2; exit 1; }
 
 : > "$LOG"
 if LEGACY="$(HOMEBOY_LEGACY=true "${COMMAND[@]}")"; then

--- a/tests/homeboy-worktree-adapter-integration.sh
+++ b/tests/homeboy-worktree-adapter-integration.sh
@@ -18,6 +18,15 @@ DMC_VERSION="0.74.1"
 DMC_COMMIT="f9509db9168cdc1274237ce2e32f1179647bb756"
 DMC_SHA256="45107900643a74e6a76b51b28cd7332aea68756ddb2eaac5f9360e0f9823b62b"
 DMC_URL="https://codeload.github.com/Extra-Chill/data-machine-code/tar.gz/${DMC_COMMIT}"
+HOMEBOY_RELEASE_VERSION="0.367.3"
+HOMEBOY_RELEASE_BUILD="3fa0c185d41b"
+HOMEBOY_RELEASE_TARGET=""
+HOMEBOY_RELEASE_SHA256=""
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64) HOMEBOY_RELEASE_TARGET="aarch64-apple-darwin"; HOMEBOY_RELEASE_SHA256="634731246fb92bc6846e2576552dc2c903f990b2252e161cf77645020e1e59e8" ;;
+  Linux-x86_64) HOMEBOY_RELEASE_TARGET="x86_64-unknown-linux-gnu"; HOMEBOY_RELEASE_SHA256="cd373e81613de9140e5ada23189cca408ddd06a8160fb7cc4031cf536b9ea6e4" ;;
+  Linux-aarch64) HOMEBOY_RELEASE_TARGET="aarch64-unknown-linux-gnu"; HOMEBOY_RELEASE_SHA256="c0726076f8ab6620e50e761a534240ee49e49b0046732474ed20ba974e1cf764" ;;
+esac
 FIXTURE_CACHE_DIR="${WP_CODING_AGENTS_FIXTURE_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME:-$TMP}/.cache}/wp-coding-agents/test-fixtures}"
 mkdir -p "$FIXTURE_CACHE_DIR"
 
@@ -49,6 +58,20 @@ download_verified "$DMC_URL" "$DMC_SHA256" "$DMC_ARCHIVE"
 verify_sha256 "$WP_CLI_SHA256" "$WP_CLI_PHAR" || { echo "FAIL: cached WP-CLI checksum changed" >&2; exit 1; }
 verify_sha256 "$DMC_SHA256" "$DMC_ARCHIVE" || { echo "FAIL: cached DMC checksum changed" >&2; exit 1; }
 
+HOMEBOY_VERSION_OUTPUT="homeboy ${HOMEBOY_RELEASE_VERSION}+${HOMEBOY_RELEASE_BUILD}"
+if [ -n "$HOMEBOY_RELEASE_TARGET" ]; then
+  HOMEBOY_RELEASE_URL="https://github.com/Extra-Chill/homeboy/releases/download/v${HOMEBOY_RELEASE_VERSION}/homeboy-${HOMEBOY_RELEASE_TARGET}.tar.xz"
+  HOMEBOY_RELEASE_ARCHIVE="$FIXTURE_CACHE_DIR/homeboy-${HOMEBOY_RELEASE_VERSION}-${HOMEBOY_RELEASE_TARGET}-${HOMEBOY_RELEASE_SHA256}.tar.xz"
+  download_verified "$HOMEBOY_RELEASE_URL" "$HOMEBOY_RELEASE_SHA256" "$HOMEBOY_RELEASE_ARCHIVE"
+  verify_sha256 "$HOMEBOY_RELEASE_SHA256" "$HOMEBOY_RELEASE_ARCHIVE" || { echo "FAIL: cached Homeboy checksum changed" >&2; exit 1; }
+  mkdir -p "$TMP/homeboy-release"
+  tar -xJf "$HOMEBOY_RELEASE_ARCHIVE" -C "$TMP/homeboy-release"
+  OFFICIAL_HOMEBOY="$TMP/homeboy-release/homeboy-${HOMEBOY_RELEASE_TARGET}/homeboy"
+  [ -x "$OFFICIAL_HOMEBOY" ] || { echo "FAIL: pinned Homeboy archive omitted its executable" >&2; exit 1; }
+  HOMEBOY_VERSION_OUTPUT="$("$OFFICIAL_HOMEBOY" --version)"
+  [ "$HOMEBOY_VERSION_OUTPUT" = "homeboy ${HOMEBOY_RELEASE_VERSION}+${HOMEBOY_RELEASE_BUILD}" ] || { echo "FAIL: pinned Homeboy release returned unexpected version output" >&2; exit 1; }
+fi
+
 DMC_FIXTURE_ROOT="$TMP/data-machine-code-${DMC_COMMIT}"
 mkdir -p "$DMC_FIXTURE_ROOT"
 tar -xzf "$DMC_ARCHIVE" --strip-components=1 -C "$DMC_FIXTURE_ROOT"
@@ -60,7 +83,11 @@ cat > "$BIN/homeboy" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >> "$HOMEBOY_ADAPTER_TEST_LOG"
 if [ "$*" = "--version" ]; then
-  printf 'homeboy %s\n' "${HOMEBOY_VERSION:-0.367.3}"
+  if [ "${HOMEBOY_VERSION+x}" = x ]; then
+    printf 'homeboy %s\n' "$HOMEBOY_VERSION"
+  else
+    printf '%s\n' "$HOMEBOY_VERSION_OUTPUT"
+  fi
   exit 0
 fi
 if [ "${HOMEBOY_LEGACY:-false}" = true ]; then
@@ -86,7 +113,7 @@ esac
 SH
 chmod +x "$BIN/homeboy"
 
-export PATH="$BIN:$PATH" HOMEBOY_ADAPTER_TEST_LOG="$LOG" HOMEBOY_TEST_REPOSITORY_PATH="$WORKSPACE_REAL/homeboy"
+export PATH="$BIN:$PATH" HOMEBOY_ADAPTER_TEST_LOG="$LOG" HOMEBOY_TEST_REPOSITORY_PATH="$WORKSPACE_REAL/homeboy" HOMEBOY_VERSION_OUTPUT
 SCRIPT_DIR="$ROOT_DIR"
 # shellcheck disable=SC1091
 source "$ROOT_DIR/lib/common.sh"

--- a/tests/homeboy-worktree-adapter-integration.sh
+++ b/tests/homeboy-worktree-adapter-integration.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SITE_PATH="$TMP/site"
+BIN="$TMP/bin"
+LOG="$TMP/homeboy.log"
+mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$BIN"
+
+WP_CLI_VERSION="2.12.0"
+WP_CLI_SHA256="ce34ddd838f7351d6759068d09793f26755463b4a4610a5a5c0a97b68220d85c"
+WP_CLI_URL="https://github.com/wp-cli/wp-cli/releases/download/v${WP_CLI_VERSION}/wp-cli-${WP_CLI_VERSION}.phar"
+DMC_VERSION="0.74.1"
+DMC_COMMIT="f9509db9168cdc1274237ce2e32f1179647bb756"
+DMC_SHA256="45107900643a74e6a76b51b28cd7332aea68756ddb2eaac5f9360e0f9823b62b"
+DMC_URL="https://codeload.github.com/Extra-Chill/data-machine-code/tar.gz/${DMC_COMMIT}"
+FIXTURE_CACHE_DIR="${WP_CODING_AGENTS_FIXTURE_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME:-$TMP}/.cache}/wp-coding-agents/test-fixtures}"
+mkdir -p "$FIXTURE_CACHE_DIR"
+
+verify_sha256() {
+  printf '%s  %s\n' "$1" "$2" | shasum -a 256 -c - >/dev/null 2>&1
+}
+
+download_verified() {
+  local url="$1" sha256="$2" destination="$3" download
+  download="$TMP/$(basename "$destination").download"
+  if [ -f "$destination" ] && verify_sha256 "$sha256" "$destination"; then
+    return
+  fi
+  rm -f "$destination" "$download"
+  curl --fail --location --silent --show-error --retry 3 --connect-timeout 10 --max-time 120 --output "$download" "$url"
+  if ! verify_sha256 "$sha256" "$download"; then
+    echo "FAIL: downloaded fixture failed pinned SHA-256 verification: $url" >&2
+    rm -f "$download"
+    return 1
+  fi
+  mv "$download" "$destination"
+}
+
+WP_CLI_PHAR="$FIXTURE_CACHE_DIR/wp-cli-${WP_CLI_VERSION}-${WP_CLI_SHA256}.phar"
+DMC_ARCHIVE="$FIXTURE_CACHE_DIR/data-machine-code-${DMC_VERSION}-${DMC_COMMIT}-${DMC_SHA256}.tar.gz"
+download_verified "$WP_CLI_URL" "$WP_CLI_SHA256" "$WP_CLI_PHAR"
+download_verified "$DMC_URL" "$DMC_SHA256" "$DMC_ARCHIVE"
+# Recheck cache hits immediately before either upstream artifact is loaded.
+verify_sha256 "$WP_CLI_SHA256" "$WP_CLI_PHAR" || { echo "FAIL: cached WP-CLI checksum changed" >&2; exit 1; }
+verify_sha256 "$DMC_SHA256" "$DMC_ARCHIVE" || { echo "FAIL: cached DMC checksum changed" >&2; exit 1; }
+
+DMC_FIXTURE_ROOT="$TMP/data-machine-code-${DMC_COMMIT}"
+mkdir -p "$DMC_FIXTURE_ROOT"
+tar -xzf "$DMC_ARCHIVE" --strip-components=1 -C "$DMC_FIXTURE_ROOT"
+for source in inc/Cli/Commands/WorkspaceCommand.php inc/Cli/CliResponseRenderer.php inc/Workspace/WorktreeContextInjector.php; do
+  [ -f "$DMC_FIXTURE_ROOT/$source" ] || { echo "FAIL: pinned DMC archive omitted $source" >&2; exit 1; }
+done
+
+cat > "$BIN/homeboy" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >> "$HOMEBOY_ADAPTER_TEST_LOG"
+if [ "${HOMEBOY_LEGACY:-false}" = true ] && [[ "$*" = *"--require-handoff-freshness"* ]]; then
+  printf '%s\n' "error: unexpected argument '--require-handoff-freshness' found" >&2
+  exit 2
+fi
+case "$*" in
+  "worktree create homeboy --branch fix/534-adapter-defaults --require-handoff-freshness --from origin/main --task-url https://github.com/Extra-Chill/wp-coding-agents/issues/534 --run-id studio-run-534 --cleanup-policy remove-when-safe")
+    printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"record":{"id":"homeboy@fix-534-adapter-defaults","component_id":"homeboy","worktree_path":"/workspace/homeboy@fix-534-adapter-defaults","branch":"fix/534-adapter-defaults","base_ref":"origin/main","run_id":"studio-run-534","state":"active"},"handoff_freshness":{"status":"verified","proof":{"proof_id":"proof-534","worktree_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","resolved_base_ref":"origin/main","resolved_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_ref":"refs/remotes/origin/main","remote_default_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_advertised_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","verified_at":"2026-08-31T00:00:00Z"}}}}'
+    ;;
+  "worktree create homeboy --branch fix/534-adapter-defaults --from origin/main --task-url https://github.com/Extra-Chill/wp-coding-agents/issues/534 --run-id studio-run-534 --cleanup-policy remove-when-safe")
+    printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"record":{"id":"homeboy@fix-534-adapter-defaults","component_id":"homeboy","worktree_path":"/workspace/homeboy@fix-534-adapter-defaults","branch":"fix/534-adapter-defaults","base_ref":"origin/main","run_id":"studio-run-534","state":"active"}}}'
+    ;;
+  *)
+    printf '%s\n' '{"schema":"homeboy/command-result/v3","success":false,"summary":"unexpected integration command"}'
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$BIN/homeboy"
+
+export PATH="$BIN:$PATH" HOMEBOY_ADAPTER_TEST_LOG="$LOG"
+SCRIPT_DIR="$ROOT_DIR"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/lib/homeboy.sh"
+UPDATED_ITEMS=()
+DRY_RUN=false
+service_file_normalize_perms() { chmod 0664 "$1"; }
+homeboy_worktree_adapter_sync
+ADAPTER="$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-homeboy-worktrees.php"
+
+BOOTSTRAP="$ROOT_DIR/tests/fixtures/homeboy-worktree-adapter-dispatch.php"
+export HOMEBOY_ADAPTER_PATH="$ADAPTER"
+export WP_CLI_PHAR
+export DMC_FIXTURE_ROOT
+export DMC_FINALIZER_LOG="$TMP/finalizer.log"
+WP=(php -d error_reporting=22527 "$BOOTSTRAP")
+
+COMMAND=("${WP[@]}" datamachine-code workspace worktree add homeboy fix/534-adapter-defaults --from=origin/main --task-url=https://github.com/Extra-Chill/wp-coding-agents/issues/534 --reuse-policy=isolated --purpose=issue-534 --owner-run-ref=studio-run-534 --cleanup-policy=remove_on_success --format=json)
+RESULT="$("${COMMAND[@]}")"
+php -r '$r=json_decode($argv[1],true); if (($r["success"]??false)!==true || ($r["context_injected"]??true)!==false || ($r["handoff_freshness"]["status"]??null)!=="verified") exit(1);' "$RESULT"
+[ "$(grep -c '^worktree create homeboy ' "$LOG")" -eq 1 ]
+grep -q -- '--require-handoff-freshness' "$LOG"
+[ "$(grep -c '^finalized$' "$DMC_FINALIZER_LOG")" -eq 1 ]
+
+HELP="$("${WP[@]}" --dispatcher-help)"
+for FLAG in inject-context bootstrap skip-context-injection skip-bootstrap; do
+	grep -q -- "--$FLAG" <<< "$HELP"
+done
+grep -q 'context injection and dependency bootstrap are omitted by default' <<< "$HELP"
+
+if "${WP[@]}" datamachine-code workspace worktree add homeboy invalid --unknown-adapter-flag >/dev/null 2>&1; then
+  echo "FAIL: registered WP-CLI synopsis accepted an unknown flag" >&2
+  exit 1
+fi
+
+if EXPLICIT="$("${WP[@]}" datamachine-code workspace worktree add homeboy explicit-context --inject-context --format=json)"; then
+  echo "FAIL: explicit context injection unexpectedly succeeded" >&2
+  exit 1
+fi
+php -r '$e=json_decode($argv[1],true)["error"]??array(); if (($e["code"]??null)!=="wp_coding_agents_homeboy_worktree_unsupported_input" || ($e["data"]["field"]??null)!=="inject_context") exit(1);' "$EXPLICIT"
+
+if EXPLICIT="$("${WP[@]}" datamachine-code workspace worktree add homeboy explicit-bootstrap --bootstrap --format=json)"; then
+  echo "FAIL: explicit dependency bootstrap unexpectedly succeeded" >&2
+  exit 1
+fi
+php -r '$e=json_decode($argv[1],true)["error"]??array(); if (($e["code"]??null)!=="wp_coding_agents_homeboy_worktree_unsupported_input" || ($e["data"]["field"]??null)!=="bootstrap") exit(1);' "$EXPLICIT"
+
+: > "$LOG"
+if LEGACY="$(HOMEBOY_LEGACY=true "${COMMAND[@]}")"; then
+  echo "FAIL: legacy Homeboy unexpectedly created a strict-freshness worktree" >&2
+  exit 1
+fi
+php -r '$e=json_decode($argv[1],true)["error"]??array(); if (($e["code"]??null)!=="worktree_handoff_freshness_unverified" || ($e["data"]["remediation"]??null)!=="upgrade_homeboy") exit(1);' "$LEGACY"
+[ "$(grep -c '^worktree create homeboy ' "$LOG")" -eq 1 ]
+grep -q -- '--require-handoff-freshness' "$LOG"
+
+: > "$LOG"
+FALLBACK="$(HOMEBOY_LEGACY=true "${COMMAND[@]}" --allow-unverified-freshness)"
+php -r '$r=json_decode($argv[1],true); if (($r["handoff_freshness"]["status"]??null)!=="unverified") exit(1);' "$FALLBACK"
+[ "$(grep -c '^worktree create homeboy ' "$LOG")" -eq 2 ]
+grep -q -- '--require-handoff-freshness' "$LOG"
+
+: > "$LOG"
+SKIP_ALIAS="$("${COMMAND[@]}" --skip-context-injection --skip-bootstrap)"
+php -r '$r=json_decode($argv[1],true); if (($r["success"]??false)!==true) exit(1);' "$SKIP_ALIAS"
+
+if "${WP[@]}" datamachine-code workspace worktree add homeboy conflicting-context --inject-context --skip-context-injection >/dev/null 2>&1; then
+  echo "FAIL: conflicting context flags unexpectedly succeeded" >&2
+  exit 1
+fi
+
+for SKEW_MODE in arity types return definition; do
+  SKEW="$(DMC_VERSION_SKEW="$SKEW_MODE" "${WP[@]}" datamachine-code workspace worktree add homeboy version-skew)"
+  [ "$SKEW" = 'native-version-skew-command' ] || { echo "FAIL: $SKEW_MODE skew replaced native registration" >&2; exit 1; }
+done
+
+echo "OK: real WP-CLI 2.12.0 dispatch and pinned production DMC 0.74.1 command-class compatibility retain version-skew safety"

--- a/tests/homeboy-worktree-adapter-integration.sh
+++ b/tests/homeboy-worktree-adapter-integration.sh
@@ -5,9 +5,11 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 SITE_PATH="$TMP/site"
+WORKSPACE="$TMP/workspace"
 BIN="$TMP/bin"
 LOG="$TMP/homeboy.log"
-mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$BIN"
+mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$WORKSPACE/homeboy/.git" "$BIN"
+WORKSPACE_REAL="$(cd "$WORKSPACE" && pwd -P)"
 
 WP_CLI_VERSION="2.12.0"
 WP_CLI_SHA256="ce34ddd838f7351d6759068d09793f26755463b4a4610a5a5c0a97b68220d85c"
@@ -57,15 +59,23 @@ done
 cat > "$BIN/homeboy" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >> "$HOMEBOY_ADAPTER_TEST_LOG"
-if [ "${HOMEBOY_LEGACY:-false}" = true ] && [[ "$*" = *"--require-handoff-freshness"* ]]; then
-  printf '%s\n' "error: unexpected argument '--require-handoff-freshness' found" >&2
-  exit 2
+if [ "$*" = "--version" ]; then
+  printf 'homeboy %s\n' "${HOMEBOY_VERSION:-0.367.3}"
+  exit 0
+fi
+if [ "${HOMEBOY_LEGACY:-false}" = true ]; then
+  case "$*" in
+    worktree\ create\ *\ --branch\ *\ --require-handoff-freshness\ --from\ *)
+      printf '%s\n' "error: unexpected argument '--require-handoff-freshness' found" >&2
+      exit 2
+      ;;
+  esac
 fi
 case "$*" in
-  "worktree create homeboy --branch fix/534-adapter-defaults --require-handoff-freshness --from origin/main --task-url https://github.com/Extra-Chill/wp-coding-agents/issues/534 --run-id studio-run-534 --cleanup-policy remove-when-safe")
+  "worktree create $HOMEBOY_TEST_REPOSITORY_PATH --branch fix/534-adapter-defaults --require-handoff-freshness --from origin/main --task-url https://github.com/Extra-Chill/wp-coding-agents/issues/534 --run-id studio-run-534 --cleanup-policy remove-when-safe")
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"record":{"id":"homeboy@fix-534-adapter-defaults","component_id":"homeboy","worktree_path":"/workspace/homeboy@fix-534-adapter-defaults","branch":"fix/534-adapter-defaults","base_ref":"origin/main","run_id":"studio-run-534","state":"active"},"handoff_freshness":{"status":"verified","proof":{"proof_id":"proof-534","worktree_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","resolved_base_ref":"origin/main","resolved_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_ref":"refs/remotes/origin/main","remote_default_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_advertised_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","verified_at":"2026-08-31T00:00:00Z"}}}}'
     ;;
-  "worktree create homeboy --branch fix/534-adapter-defaults --from origin/main --task-url https://github.com/Extra-Chill/wp-coding-agents/issues/534 --run-id studio-run-534 --cleanup-policy remove-when-safe")
+  "worktree create $HOMEBOY_TEST_REPOSITORY_PATH --branch fix/534-adapter-defaults --from origin/main --task-url https://github.com/Extra-Chill/wp-coding-agents/issues/534 --run-id studio-run-534 --cleanup-policy remove-when-safe")
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"record":{"id":"homeboy@fix-534-adapter-defaults","component_id":"homeboy","worktree_path":"/workspace/homeboy@fix-534-adapter-defaults","branch":"fix/534-adapter-defaults","base_ref":"origin/main","run_id":"studio-run-534","state":"active"}}}'
     ;;
   *)
@@ -76,7 +86,7 @@ esac
 SH
 chmod +x "$BIN/homeboy"
 
-export PATH="$BIN:$PATH" HOMEBOY_ADAPTER_TEST_LOG="$LOG"
+export PATH="$BIN:$PATH" HOMEBOY_ADAPTER_TEST_LOG="$LOG" HOMEBOY_TEST_REPOSITORY_PATH="$WORKSPACE_REAL/homeboy"
 SCRIPT_DIR="$ROOT_DIR"
 # shellcheck disable=SC1091
 source "$ROOT_DIR/lib/common.sh"
@@ -92,13 +102,14 @@ BOOTSTRAP="$ROOT_DIR/tests/fixtures/homeboy-worktree-adapter-dispatch.php"
 export HOMEBOY_ADAPTER_PATH="$ADAPTER"
 export WP_CLI_PHAR
 export DMC_FIXTURE_ROOT
+export DMC_WORKSPACE_PATH="$WORKSPACE_REAL"
 export DMC_FINALIZER_LOG="$TMP/finalizer.log"
 WP=(php -d error_reporting=22527 "$BOOTSTRAP")
 
-COMMAND=("${WP[@]}" datamachine-code workspace worktree add homeboy fix/534-adapter-defaults --from=origin/main --task-url=https://github.com/Extra-Chill/wp-coding-agents/issues/534 --reuse-policy=isolated --purpose=issue-534 --owner-run-ref=studio-run-534 --cleanup-policy=remove_on_success --format=json)
+COMMAND=("${WP[@]}" datamachine-code workspace worktree add homeboy fix/534-adapter-defaults --from=origin/main --task-url=https://github.com/Extra-Chill/wp-coding-agents/issues/534 --reuse-policy=isolated --owner-run-ref=studio-run-534 --cleanup-policy=remove_on_success --format=json)
 RESULT="$("${COMMAND[@]}")"
 php -r '$r=json_decode($argv[1],true); if (($r["success"]??false)!==true || ($r["context_injected"]??true)!==false || ($r["handoff_freshness"]["status"]??null)!=="verified") exit(1);' "$RESULT"
-[ "$(grep -c '^worktree create homeboy ' "$LOG")" -eq 1 ]
+[ "$(grep -c "^worktree create $WORKSPACE_REAL/homeboy " "$LOG")" -eq 1 ]
 grep -q -- '--require-handoff-freshness' "$LOG"
 [ "$(grep -c '^finalized$' "$DMC_FINALIZER_LOG")" -eq 1 ]
 
@@ -114,6 +125,18 @@ if "${WP[@]}" datamachine-code workspace worktree add homeboy invalid --unknown-
 fi
 
 : > "$LOG"
+"${WP[@]}" datamachine-code workspace worktree add homeboy native-purpose --purpose=issue-534 --format=json >/dev/null
+[ ! -s "$LOG" ] || { echo "FAIL: non-empty purpose reached Homeboy instead of native DMC" >&2; exit 1; }
+
+: > "$LOG"
+HOMEBOY_VERSION=0.367.2 "${COMMAND[@]}" >/dev/null
+grep -q '^--version$' "$LOG"
+if grep -q '^worktree create ' "$LOG"; then
+  echo "FAIL: pre-0.367.3 Homeboy received an unsupported repository path" >&2
+  exit 1
+fi
+
+: > "$LOG"
 "${WP[@]}" datamachine-code workspace worktree add homeboy explicit-context --inject-context --format=json >/dev/null
 [ ! -s "$LOG" ] || { echo "FAIL: explicit context injection reached Homeboy instead of native DMC" >&2; exit 1; }
 "${WP[@]}" datamachine-code workspace worktree add homeboy explicit-bootstrap --bootstrap --format=json >/dev/null
@@ -125,13 +148,13 @@ if LEGACY="$(HOMEBOY_LEGACY=true "${COMMAND[@]}")"; then
   exit 1
 fi
 php -r '$e=json_decode($argv[1],true)["error"]??array(); if (($e["code"]??null)!=="worktree_handoff_freshness_unverified" || ($e["data"]["remediation"]??null)!=="upgrade_homeboy") exit(1);' "$LEGACY"
-[ "$(grep -c '^worktree create homeboy ' "$LOG")" -eq 1 ]
+[ "$(grep -c "^worktree create $WORKSPACE_REAL/homeboy " "$LOG")" -eq 1 ]
 grep -q -- '--require-handoff-freshness' "$LOG"
 
 : > "$LOG"
 FALLBACK="$(HOMEBOY_LEGACY=true "${COMMAND[@]}" --allow-unverified-freshness)"
 php -r '$r=json_decode($argv[1],true); if (($r["handoff_freshness"]["status"]??null)!=="unverified") exit(1);' "$FALLBACK"
-[ "$(grep -c '^worktree create homeboy ' "$LOG")" -eq 2 ]
+[ "$(grep -c "^worktree create $WORKSPACE_REAL/homeboy " "$LOG")" -eq 2 ]
 grep -q -- '--require-handoff-freshness' "$LOG"
 
 : > "$LOG"

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -20,6 +20,10 @@ WORKSPACE_REAL="$(cd "$WORKSPACE" && pwd -P)"
 cat > "$FAKE_BIN/homeboy" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >> "$HOMEBOY_ADAPTER_TEST_LOG"
+if [ "$*" = "--version" ]; then
+	printf 'homeboy %s\n' "${HOMEBOY_VERSION:-0.367.3}"
+	exit 0
+fi
 case "$*" in
   "config show /worktree_providers/dmc")
     [ -f "$HOMEBOY_PROVIDER_STATE" ] || exit 1
@@ -38,9 +42,13 @@ case "$*" in
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{}}'
     ;;
   "worktree create "*)
-	if [ "${HOMEBOY_LEGACY:-false}" = true ] && [[ "$*" = *"--require-handoff-freshness"* ]]; then
-		printf '%s\n' "error: unexpected argument '--require-handoff-freshness' found" >&2
-		exit 2
+	if [ "${HOMEBOY_LEGACY:-false}" = true ]; then
+		case "$*" in
+		  worktree\ create\ *\ --branch\ *\ --require-handoff-freshness\ --from\ *)
+			printf '%s\n' "error: unexpected argument '--require-handoff-freshness' found" >&2
+			exit 2
+			;;
+		esac
 	fi
 	if [ "${HOMEBOY_MISSING_PROOF:-false}" = true ]; then
 		printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"record":{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","state":"active"}}}'
@@ -133,6 +141,17 @@ $native = $add(array('repo' => 'fixture', 'branch' => 'fix/native'));
 expect('dmc' === ($native['backend'] ?? null), 'default context and bootstrap behavior retains DMC native creation');
 $native_option = $add(array('repo' => 'fixture', 'branch' => 'fix/native-option', 'inject_context' => false, 'bootstrap' => false, 'allow_stale' => true));
 expect('dmc' === ($native_option['backend'] ?? null), 'DMC-only create options retain DMC native creation');
+$native_purpose = $add(array('repo' => 'fixture', 'branch' => 'fix/native-purpose', 'inject_context' => false, 'bootstrap' => false, 'purpose' => 'review-fix'));
+expect('dmc' === ($native_purpose['backend'] ?? null), 'non-empty purpose retains DMC native creation');
+$native_zero_purpose = $add(array('repo' => 'fixture', 'branch' => 'fix/native-zero-purpose', 'inject_context' => false, 'bootstrap' => false, 'purpose' => '0'));
+expect('dmc' === ($native_zero_purpose['backend'] ?? null), 'string-zero purpose retains DMC native validation');
+putenv('HOMEBOY_VERSION=0.367.2');
+$native_legacy_path = $add(array('repo' => 'fixture', 'branch' => 'fix/native-legacy-path', 'inject_context' => false, 'bootstrap' => false));
+expect('dmc' === ($native_legacy_path['backend'] ?? null), 'pre-repository-path Homeboy preserves native DMC creation');
+$legacy_path_error = WP_Coding_Agents_Homeboy_Worktrees::execute('datamachine-code/workspace-worktree-add', array('repo' => 'fixture', 'branch' => 'fix/legacy-path-remediation'));
+expect(is_wp_error($legacy_path_error) && 'wp_coding_agents_homeboy_worktree_repository_path_unsupported' === $legacy_path_error->code, 'direct repository-path delegation returns a typed capability refusal');
+expect('upgrade_homeboy' === ($legacy_path_error->data['remediation'] ?? null) && '0.367.3' === ($legacy_path_error->data['minimum_version'] ?? null), 'repository-path refusal includes exact upgrade remediation');
+putenv('HOMEBOY_VERSION=0.367.3');
 $verified = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($verified) && 'verified' === ($verified['handoff_freshness']['status'] ?? null), 'create maps Homeboy remote freshness into the DMC handoff contract');
 $created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
@@ -147,9 +166,18 @@ expect(is_wp_error($strict_legacy) && 'worktree_handoff_freshness_unverified' ==
 $fallback_legacy = $add(array('repo' => 'fixture', 'branch' => 'legacy-fallback', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($fallback_legacy), 'explicit unverified policy retries after typed unsupported capability');
 putenv('HOMEBOY_LEGACY=false');
-$legacy_commands = array_slice(file(getenv('HOMEBOY_ADAPTER_TEST_LOG'), FILE_IGNORE_NEW_LINES), $before_legacy);
+$legacy_commands = array_values(array_filter(array_slice(file(getenv('HOMEBOY_ADAPTER_TEST_LOG'), FILE_IGNORE_NEW_LINES), $before_legacy), static fn(string $command): bool => str_starts_with($command, 'worktree create ')));
 expect(3 === count($legacy_commands), 'strict refusal performs once and permitted fallback performs exactly twice');
 expect(str_contains($legacy_commands[1], '--require-handoff-freshness') && !str_contains($legacy_commands[2], '--require-handoff-freshness'), 'fallback occurs only after the freshness option is rejected');
+$before_equal_fallback = count(file(getenv('HOMEBOY_ADAPTER_TEST_LOG')));
+putenv('HOMEBOY_LEGACY=true');
+$equal_fallback = $add(array('repo' => 'fixture', 'branch' => 'legacy-equal-value', 'from' => '--require-handoff-freshness', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
+expect(!is_wp_error($equal_fallback), 'legacy fallback preserves a user value equal to the adapter freshness argument');
+putenv('HOMEBOY_LEGACY=false');
+$equal_commands = array_values(array_filter(array_slice(file(getenv('HOMEBOY_ADAPTER_TEST_LOG'), FILE_IGNORE_NEW_LINES), $before_equal_fallback), static fn(string $command): bool => str_starts_with($command, 'worktree create ')));
+expect(2 === count($equal_commands), 'equal-value fallback attempts strict creation once and fallback once');
+expect(2 === substr_count($equal_commands[0], '--require-handoff-freshness') && 1 === substr_count($equal_commands[1], '--require-handoff-freshness'), 'fallback removes only the adapter-inserted freshness argument');
+expect(str_contains($equal_commands[1], '--from --require-handoff-freshness'), 'fallback retains the equal user-supplied base value');
 putenv('HOMEBOY_MISSING_PROOF=true');
 $missing_proof = $add(array('repo' => 'fixture', 'branch' => 'missing-proof', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(is_wp_error($missing_proof) && 'wp_coding_agents_homeboy_worktree_contract_error' === $missing_proof->code, 'permitted fallback does not excuse a supported response that omits freshness proof');

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -38,7 +38,15 @@ case "$*" in
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{}}'
     ;;
   "worktree create "*)
-    printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"create","record":{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","task_url":"https://example.test/474","run_id":"run-474","cleanup_policy":"remove_when_safe","created_at":"2026-08-30T00:00:00Z","state":"active"},"handoff_freshness":{"status":"verified","proof":{"schema":"homeboy/worktree-handoff-freshness/v1","proof_id":"proof-474","handle":"fixture@fix-474","worktree_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","resolved_base_ref":"origin/main","resolved_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_ref":"refs/remotes/origin/main","remote_default_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_advertised_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","verified_at":"2026-08-30T00:00:00Z"}}}}'
+	if [ "${HOMEBOY_LEGACY:-false}" = true ] && [[ "$*" = *"--require-handoff-freshness"* ]]; then
+		printf '%s\n' "error: unexpected argument '--require-handoff-freshness' found" >&2
+		exit 2
+	fi
+	if [ "${HOMEBOY_MISSING_PROOF:-false}" = true ]; then
+		printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"record":{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","state":"active"}}}'
+		exit 0
+	fi
+	printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"create","record":{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","task_url":"https://example.test/474","run_id":"run-474","cleanup_policy":"remove_when_safe","created_at":"2026-08-30T00:00:00Z","state":"active"},"handoff_freshness":{"status":"verified","proof":{"schema":"homeboy/worktree-handoff-freshness/v1","proof_id":"proof-474","handle":"fixture@fix-474","worktree_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","resolved_base_ref":"origin/main","resolved_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_ref":"refs/remotes/origin/main","remote_default_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_advertised_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","verified_at":"2026-08-30T00:00:00Z"}}}}'
     ;;
   "worktree list")
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"list","worktrees":[{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","task_url":"https://example.test/474","run_id":"run-474","created_at":"2026-08-30T00:00:00Z","state":"active"},{"id":"fixture@removed","component_id":"fixture","worktree_path":"/workspace/fixture@removed","branch":"removed","state":"removed"}]}}'
@@ -84,6 +92,8 @@ define('DATAMACHINE_WORKSPACE_PATH', __DIR__ . '/workspace');
 
 final class WP_Error {
 	public function __construct(public string $code, public string $message, public array $data = array()) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_data(): array { return $this->data; }
 }
 function is_wp_error(mixed $value): bool { return $value instanceof WP_Error; }
 function wp_json_encode(mixed $value): string|false { return json_encode($value); }
@@ -92,6 +102,7 @@ function add_filter(string $hook, callable $callback, int $priority = 10, int $a
 	global $filters;
 	$filters[$hook] = $callback;
 }
+function add_action(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void {}
 function expect(bool $condition, string $message): void {
 	if (!$condition) {
 		fwrite(STDERR, "FAIL: {$message}\n");
@@ -129,6 +140,20 @@ expect(!is_wp_error($created) && 'fixture@fix-474' === $created['handle'], 'crea
 expect('verified' === ($created['handoff_freshness']['status'] ?? null), 'create retains available Homeboy freshness when unverified fallback is allowed');
 $manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'cleanup_policy' => 'manual', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($manual), 'manual lifecycle intent maps to non-cleanup-eligible Homeboy policy');
+$before_legacy = count(file(getenv('HOMEBOY_ADAPTER_TEST_LOG')));
+putenv('HOMEBOY_LEGACY=true');
+$strict_legacy = $add(array('repo' => 'fixture', 'branch' => 'legacy-strict', 'inject_context' => false, 'bootstrap' => false));
+expect(is_wp_error($strict_legacy) && 'worktree_handoff_freshness_unverified' === $strict_legacy->code, 'strict freshness maps typed unsupported capability to remediation');
+$fallback_legacy = $add(array('repo' => 'fixture', 'branch' => 'legacy-fallback', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
+expect(!is_wp_error($fallback_legacy), 'explicit unverified policy retries after typed unsupported capability');
+putenv('HOMEBOY_LEGACY=false');
+$legacy_commands = array_slice(file(getenv('HOMEBOY_ADAPTER_TEST_LOG'), FILE_IGNORE_NEW_LINES), $before_legacy);
+expect(3 === count($legacy_commands), 'strict refusal performs once and permitted fallback performs exactly twice');
+expect(str_contains($legacy_commands[1], '--require-handoff-freshness') && !str_contains($legacy_commands[2], '--require-handoff-freshness'), 'fallback occurs only after the freshness option is rejected');
+putenv('HOMEBOY_MISSING_PROOF=true');
+$missing_proof = $add(array('repo' => 'fixture', 'branch' => 'missing-proof', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
+expect(is_wp_error($missing_proof) && 'wp_coding_agents_homeboy_worktree_contract_error' === $missing_proof->code, 'permitted fallback does not excuse a supported response that omits freshness proof');
+putenv('HOMEBOY_MISSING_PROOF=false');
 
 $list = $ability('datamachine-code/workspace-worktree-list');
 $listed = $list(array('handle' => 'fixture@fix-474', 'include_status' => true, 'limit' => 1));
@@ -161,7 +186,7 @@ if grep -q 'datamachine-code' "$LOG"; then
 fi
 grep -q "^worktree create $WORKSPACE_REAL/fixture " "$LOG"
 grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474 --require-handoff-freshness --from origin/HEAD$" "$LOG"
-grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474-manual --from origin/HEAD --cleanup-policy preserve-on-failure$" "$LOG"
+grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474-manual --require-handoff-freshness --from origin/HEAD --cleanup-policy preserve-on-failure$" "$LOG"
 grep -q '^worktree finalize fixture@fix-474 --owner-run-ref run-474 --disposition succeeded$' "$LOG"
 grep -q '^worktree cleanup --apply$' "$LOG"
 

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -21,7 +21,11 @@ cat > "$FAKE_BIN/homeboy" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >> "$HOMEBOY_ADAPTER_TEST_LOG"
 if [ "$*" = "--version" ]; then
-	printf 'homeboy %s\n' "${HOMEBOY_VERSION:-0.367.3}"
+	if [ -n "${HOMEBOY_VERSION_OUTPUT:-}" ]; then
+		printf '%s\n' "$HOMEBOY_VERSION_OUTPUT"
+	else
+		printf 'homeboy %s\n' "${HOMEBOY_VERSION:-0.367.3+3fa0c185d41b}"
+	fi
 	exit 0
 fi
 case "$*" in
@@ -154,6 +158,15 @@ expect('upgrade_homeboy' === ($legacy_path_error->data['remediation'] ?? null) &
 putenv('HOMEBOY_VERSION=0.367.3');
 $verified = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($verified) && 'verified' === ($verified['handoff_freshness']['status'] ?? null), 'create maps Homeboy remote freshness into the DMC handoff contract');
+putenv('HOMEBOY_VERSION_OUTPUT=homeboy 0.367.3+3fa0c185d41b');
+$metadata_version = $add(array('repo' => 'fixture', 'branch' => 'fix/metadata-version', 'inject_context' => false, 'bootstrap' => false));
+expect(!is_wp_error($metadata_version), 'official Homeboy SemVer build metadata retains repository-path delegation');
+putenv('HOMEBOY_VERSION_OUTPUT=homeboy malformed secret-version-output');
+$malformed_version = WP_Coding_Agents_Homeboy_Worktrees::execute('datamachine-code/workspace-worktree-add', array('repo' => 'fixture', 'branch' => 'fix/malformed-version'));
+expect(is_wp_error($malformed_version) && 'wp_coding_agents_homeboy_worktree_contract_error' === $malformed_version->code, 'malformed Homeboy version output fails closed');
+$malformed_evidence = $malformed_version->data['evidence'] ?? array();
+expect(true === ($malformed_evidence['output_redacted'] ?? false) && !str_contains((string) json_encode($malformed_evidence), 'secret-version-output'), 'malformed Homeboy version evidence is redacted');
+putenv('HOMEBOY_VERSION_OUTPUT');
 $created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($created) && 'fixture@fix-474' === $created['handle'], 'create projects native Homeboy record');
 expect('verified' === ($created['handoff_freshness']['status'] ?? null), 'create retains available Homeboy freshness when unverified fallback is allowed');


### PR DESCRIPTION
## Summary
- preserve native DMC creation for DMC-owned intent while defaulting the replacement WP-CLI leaf to Homeboy-safe skip behavior
- negotiate handoff freshness strictly with typed legacy fallback and repository-path capability handling
- guard DMC/WP-CLI version skew with exact callable and synopsis validation
- add checksum-pinned production compatibility coverage and CI wiring

Closes #534

## Verification
- `bash tests/homeboy-worktree-adapter.sh`
- `bash tests/homeboy-worktree-adapter-integration.sh`
- `bash tests/ci-coverage.sh`
- PHP and Bash syntax checks
- `git diff --check origin/main..HEAD`

## AI assistance
OpenAI gpt-5.6-sol was used through OpenCode to implement, test, recover, rebase, and independently review this change. I directed the work, evaluated review findings, and retained the final implementation after deterministic checks passed.