### PR TITLE
Manage an optional local WordPress service

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -282,6 +282,7 @@ jobs:
           - plugin-upgrade-bounds
           - runtime-signature
           - upgrade-opencode-auth-plugin-sync
+          - wordpress-service
           - worktree-context-projections
           - wp-cli-machine-output
           - wp-config-permissions

--- a/README.md
+++ b/README.md
@@ -164,6 +164,24 @@ or systemd service with `./upgrade.sh --no-datamachine-worker`. The worker runs
 one bounded `wp datamachine worker run --once` pass every two minutes; it does
 not execute generic due WP-Cron events.
 
+### Optional Local WordPress Service
+
+On macOS, an existing site can run without a separate local development app by
+using WP-CLI's built-in HTTP server under launchd:
+
+```bash
+EXISTING_WP=/path/to/wordpress ./setup.sh --local \
+  --with-wordpress-service --wordpress-service-port 8080
+```
+
+The service binds to `127.0.0.1` by default, is identified by the site's absolute
+path, and remains enabled across upgrades. It requires a direct `wp` transport.
+Disable it with:
+
+```bash
+./upgrade.sh --local --wp-path /path/to/wordpress --no-wordpress-service
+```
+
 ### External WordPress Runtime
 
 Run the coding runtime on a host without a mounted WordPress tree. The control

--- a/services/wordpress-service.sh
+++ b/services/wordpress-service.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Optional local WordPress HTTP service backed by WP-CLI's built-in server.
+
+wordpress_service_site_id() {
+  python3 - "$SITE_PATH" <<'PY'
+import hashlib, sys
+print(hashlib.sha256(sys.argv[1].encode()).hexdigest()[:12])
+PY
+}
+
+wordpress_service_label() { printf 'com.wp.wordpress.%s' "$(wordpress_service_site_id)"; }
+wordpress_service_launchd_dir() { printf '%s' "${WORDPRESS_SERVICE_LAUNCHD_DIR:-$SERVICE_HOME/Library/LaunchAgents}"; }
+wordpress_service_state_file() { printf '%s/.config/wp-coding-agents/wordpress-service/%s.conf' "$SERVICE_HOME" "$(wordpress_service_site_id)"; }
+
+wordpress_service_desired_state() {
+  case "${WORDPRESS_SERVICE_REQUEST:-}" in
+    enabled|true|1) printf 'enabled\n'; return ;;
+    disabled|false|0) printf 'disabled\n'; return ;;
+    "") ;;
+    *) error "Unknown local WordPress service state: $WORDPRESS_SERVICE_REQUEST" ;;
+  esac
+  [ -f "$(wordpress_service_state_file)" ] && printf 'enabled\n' || printf 'disabled\n'
+}
+
+wordpress_service_resolve_settings() {
+  local state_file key value
+  state_file="$(wordpress_service_state_file)"
+  if [ -f "$state_file" ]; then
+    while IFS='=' read -r key value; do
+      case "$key" in
+        host) WORDPRESS_SERVICE_HOST="${WORDPRESS_SERVICE_HOST:-$value}" ;;
+        port) WORDPRESS_SERVICE_PORT="${WORDPRESS_SERVICE_PORT:-$value}" ;;
+      esac
+    done < "$state_file"
+  fi
+
+  WORDPRESS_SERVICE_HOST="${WORDPRESS_SERVICE_HOST:-127.0.0.1}"
+  WORDPRESS_SERVICE_PORT="${WORDPRESS_SERVICE_PORT:-8080}"
+  [[ "$WORDPRESS_SERVICE_PORT" =~ ^[0-9]+$ ]] || error "WordPress service port must be an integer"
+  [ "$WORDPRESS_SERVICE_PORT" -ge 1 ] && [ "$WORDPRESS_SERVICE_PORT" -le 65535 ] || error "WordPress service port must be between 1 and 65535"
+  [[ "$WORDPRESS_SERVICE_HOST" =~ ^[A-Za-z0-9.:_-]+$ ]] || error "WordPress service host contains unsupported characters"
+}
+
+wordpress_service_record_state() {
+  local state="$1" file
+  file="$(wordpress_service_state_file)"
+  if [ "$state" = enabled ]; then
+    run_cmd mkdir -p "${file%/*}"
+    write_file "$file" "host=$WORDPRESS_SERVICE_HOST
+port=$WORDPRESS_SERVICE_PORT"
+  else
+    run_cmd rm -f "$file"
+  fi
+}
+
+wordpress_service_prepare_command() {
+  local executable
+  wp_cli_transport_ensure
+  [ "${#WP_CLI_TRANSPORT[@]}" -eq 1 ] || error "The local WordPress service requires a direct wp transport"
+  executable="$(command -v "${WP_CLI_TRANSPORT[0]}" 2>/dev/null || true)"
+  [ -n "$executable" ] || error "The local WordPress service requires WP-CLI on PATH"
+  WORDPRESS_SERVICE_WP="$executable"
+}
+
+_wordpress_service_xml_text() {
+  local value="$1"
+  value=${value//&/\&amp;}
+  value=${value//</\&lt;}
+  value=${value//>/\&gt;}
+  printf '%s' "$value"
+}
+
+wordpress_service_render_launchd() {
+  local label="$1" log_dir="$SERVICE_HOME/.wp-coding-agents/logs"
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$(_wordpress_service_xml_text "$label")</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$(_wordpress_service_xml_text "$WORDPRESS_SERVICE_WP")</string>
+        <string>server</string>
+        <string>--path=$(_wordpress_service_xml_text "$SITE_PATH")</string>
+        <string>--host=$(_wordpress_service_xml_text "$WORDPRESS_SERVICE_HOST")</string>
+        <string>--port=$WORDPRESS_SERVICE_PORT</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$(_wordpress_service_xml_text "$SITE_PATH")</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$(_wordpress_service_xml_text "$log_dir/wordpress-service.log")</string>
+    <key>StandardErrorPath</key>
+    <string>$(_wordpress_service_xml_text "$log_dir/wordpress-service.error.log")</string>
+</dict>
+</plist>
+EOF
+}
+
+wordpress_service_update() {
+  local label plist_dir plist
+  wordpress_service_resolve_settings
+  wordpress_service_prepare_command
+  label="$(wordpress_service_label)"
+  plist_dir="$(wordpress_service_launchd_dir)"
+  plist="$plist_dir/$label.plist"
+  run_cmd mkdir -p "$plist_dir" "$SERVICE_HOME/.wp-coding-agents/logs"
+  write_file "$plist" "$(wordpress_service_render_launchd "$label")"
+  wordpress_service_record_state enabled
+  if [ "$DRY_RUN" = false ]; then
+    launchctl bootout "gui/$(id -u)" "$plist" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$plist"
+  fi
+  log "Local WordPress service: $label ($WORDPRESS_SERVICE_HOST:$WORDPRESS_SERVICE_PORT)"
+}
+
+wordpress_service_remove() {
+  local plist
+  plist="$(wordpress_service_launchd_dir)/$(wordpress_service_label).plist"
+  if [ "$DRY_RUN" = false ]; then
+    launchctl bootout "gui/$(id -u)" "$plist" 2>/dev/null || true
+  fi
+  run_cmd rm -f "$plist"
+  wordpress_service_record_state disabled
+}
+
+wordpress_service_reconcile() {
+  local state
+  state="$(wordpress_service_desired_state)"
+  if [ "$state" = enabled ]; then
+    [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = mac ] || error "The managed local WordPress service currently requires macOS local mode"
+    wordpress_service_update
+  else
+    [ "$LOCAL_MODE" = true ] && [ "$PLATFORM" = mac ] && wordpress_service_remove
+  fi
+}

--- a/services/wordpress-service.sh
+++ b/services/wordpress-service.sh
@@ -54,12 +54,15 @@ port=$WORDPRESS_SERVICE_PORT"
 }
 
 wordpress_service_prepare_command() {
-  local executable
+  local executable php_executable
   wp_cli_transport_ensure
   [ "${#WP_CLI_TRANSPORT[@]}" -eq 1 ] || error "The local WordPress service requires a direct wp transport"
   executable="$(command -v "${WP_CLI_TRANSPORT[0]}" 2>/dev/null || true)"
   [ -n "$executable" ] || error "The local WordPress service requires WP-CLI on PATH"
+  php_executable="$(command -v php 2>/dev/null || true)"
+  [ -n "$php_executable" ] || error "The local WordPress service requires PHP on PATH"
   WORDPRESS_SERVICE_WP="$executable"
+  WORDPRESS_SERVICE_PHP="$php_executable"
 }
 
 _wordpress_service_xml_text() {
@@ -81,6 +84,7 @@ wordpress_service_render_launchd() {
     <string>$(_wordpress_service_xml_text "$label")</string>
     <key>ProgramArguments</key>
     <array>
+        <string>$(_wordpress_service_xml_text "$WORDPRESS_SERVICE_PHP")</string>
         <string>$(_wordpress_service_xml_text "$WORDPRESS_SERVICE_WP")</string>
         <string>server</string>
         <string>--path=$(_wordpress_service_xml_text "$SITE_PATH")</string>

--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,7 @@ source "$SCRIPT_DIR/bridges/_dispatch.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/guidance/_dispatch.sh"
 source "$SCRIPT_DIR/services/datamachine-worker.sh"
+source "$SCRIPT_DIR/services/wordpress-service.sh"
 
 # Discover available runtimes from runtimes/ directory
 AVAILABLE_RUNTIMES=()
@@ -69,6 +70,9 @@ WITH_HOMEBOY=false
 WITH_AI_GATEWAY=false
 WITH_CLAUDE_CODE_AUTH=true
 ROTATE_AI_GATEWAY_TOKEN=false
+WORDPRESS_SERVICE_REQUEST=""
+WORDPRESS_SERVICE_HOST="${WORDPRESS_SERVICE_HOST:-}"
+WORDPRESS_SERVICE_PORT="${WORDPRESS_SERVICE_PORT:-}"
 RUNTIME=""
 CHAT_BRIDGE_EXPLICIT=false
 HOMEBOY_MODE="auto"
@@ -182,6 +186,22 @@ while [[ $# -gt 0 ]]; do
     --with-datamachine-worker)
       DATAMACHINE_WORKER_REQUEST=enabled
       shift
+      ;;
+    --with-wordpress-service)
+      WORDPRESS_SERVICE_REQUEST=enabled
+      shift
+      ;;
+    --no-wordpress-service)
+      WORDPRESS_SERVICE_REQUEST=disabled
+      shift
+      ;;
+    --wordpress-service-host)
+      WORDPRESS_SERVICE_HOST="$2"
+      shift 2
+      ;;
+    --wordpress-service-port)
+      WORDPRESS_SERVICE_PORT="$2"
+      shift 2
       ;;
     --no-datamachine-worker)
       DATAMACHINE_WORKER_REQUEST=disabled
@@ -386,6 +406,15 @@ OPTIONS:
                       generic WP-Cron events.
   --no-datamachine-worker
                       Disable the worker and remove its managed service state.
+  --with-wordpress-service
+                      Run this local WordPress site with a managed macOS
+                      launchd service backed by `wp server`.
+  --no-wordpress-service
+                      Disable and remove the managed local WordPress service.
+  --wordpress-service-host <host>
+                      Bind host for the local service (default: 127.0.0.1).
+  --wordpress-service-port <port>
+                      Bind port for the local service (default: 8080).
   --with-ai-gateway  Opt in to WP AI Gateway setup for OpenCode runtimes.
                      Installs/activates the gateway/provider stack, configures
                      the gateway route, mints/reuses a gateway token, and adds
@@ -627,5 +656,6 @@ if [ "$EXTERNAL_WORDPRESS" != true ]; then cli_transport_install; inbound_event_
 # way a live change will.
 if [ "$EXTERNAL_WORDPRESS" != true ]; then source_reconcile_sync; source_reconcile_run; fi
 install_chat_bridge
+if [ "$EXTERNAL_WORDPRESS" != true ]; then wordpress_service_reconcile; fi
 if [ "$EXTERNAL_WORDPRESS" != true ]; then datamachine_worker_reconcile; fi
 print_summary

--- a/tests/wordpress-service.sh
+++ b/tests/wordpress-service.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+root="$(mktemp -d)"
+trap 'rm -r "$root"' EXIT
+
+export SITE_PATH="$root/site & one" SERVICE_HOME="$root/home" LOCAL_MODE=true PLATFORM=mac DRY_RUN=false
+export WORDPRESS_SERVICE_LAUNCHD_DIR="$root/LaunchAgents"
+mkdir -p "$SITE_PATH" "$SERVICE_HOME" "$WORDPRESS_SERVICE_LAUNCHD_DIR" "$root/bin"
+printf '#!/bin/sh\n' > "$root/bin/wp"
+chmod +x "$root/bin/wp"
+PATH="$root/bin:$PATH"
+
+source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/services/wordpress-service.sh"
+
+launchctl() { printf 'launchctl %s\n' "$*" >> "$root/calls"; }
+wp_cli_transport_set wp
+
+WORDPRESS_SERVICE_REQUEST=enabled
+WORDPRESS_SERVICE_HOST=127.0.0.1
+WORDPRESS_SERVICE_PORT=8881
+wordpress_service_reconcile >/dev/null
+
+label="$(wordpress_service_label)"
+plist="$WORDPRESS_SERVICE_LAUNCHD_DIR/$label.plist"
+[ -f "$plist" ]
+[ -f "$(wordpress_service_state_file)" ]
+grep -q 'host=127.0.0.1' "$(wordpress_service_state_file)"
+grep -q 'port=8881' "$(wordpress_service_state_file)"
+grep -q 'launchctl bootstrap' "$root/calls"
+
+if command -v plutil >/dev/null 2>&1; then
+  plutil -lint "$plist" >/dev/null
+  [ "$(plutil -extract ProgramArguments.0 raw -o - "$plist")" = "$root/bin/wp" ]
+  [ "$(plutil -extract ProgramArguments.2 raw -o - "$plist")" = "--path=$SITE_PATH" ]
+  [ "$(plutil -extract ProgramArguments.3 raw -o - "$plist")" = "--host=127.0.0.1" ]
+  [ "$(plutil -extract ProgramArguments.4 raw -o - "$plist")" = "--port=8881" ]
+fi
+
+first_label="$label"
+SITE_PATH="$root/site-two"
+mkdir -p "$SITE_PATH"
+[ "$(wordpress_service_label)" != "$first_label" ]
+
+SITE_PATH="$root/site & one"
+WORDPRESS_SERVICE_REQUEST=disabled
+wordpress_service_reconcile >/dev/null
+[ ! -e "$plist" ]
+[ ! -e "$(wordpress_service_state_file)" ]
+
+echo "PASS: tests/wordpress-service.sh"

--- a/tests/wordpress-service.sh
+++ b/tests/wordpress-service.sh
@@ -9,7 +9,9 @@ export SITE_PATH="$root/site & one" SERVICE_HOME="$root/home" LOCAL_MODE=true PL
 export WORDPRESS_SERVICE_LAUNCHD_DIR="$root/LaunchAgents"
 mkdir -p "$SITE_PATH" "$SERVICE_HOME" "$WORDPRESS_SERVICE_LAUNCHD_DIR" "$root/bin"
 printf '#!/bin/sh\n' > "$root/bin/wp"
+printf '#!/bin/sh\n' > "$root/bin/php"
 chmod +x "$root/bin/wp"
+chmod +x "$root/bin/php"
 PATH="$root/bin:$PATH"
 
 source "$SCRIPT_DIR/lib/common.sh"
@@ -33,10 +35,11 @@ grep -q 'launchctl bootstrap' "$root/calls"
 
 if command -v plutil >/dev/null 2>&1; then
   plutil -lint "$plist" >/dev/null
-  [ "$(plutil -extract ProgramArguments.0 raw -o - "$plist")" = "$root/bin/wp" ]
-  [ "$(plutil -extract ProgramArguments.2 raw -o - "$plist")" = "--path=$SITE_PATH" ]
-  [ "$(plutil -extract ProgramArguments.3 raw -o - "$plist")" = "--host=127.0.0.1" ]
-  [ "$(plutil -extract ProgramArguments.4 raw -o - "$plist")" = "--port=8881" ]
+  [ "$(plutil -extract ProgramArguments.0 raw -o - "$plist")" = "$root/bin/php" ]
+  [ "$(plutil -extract ProgramArguments.1 raw -o - "$plist")" = "$root/bin/wp" ]
+  [ "$(plutil -extract ProgramArguments.3 raw -o - "$plist")" = "--path=$SITE_PATH" ]
+  [ "$(plutil -extract ProgramArguments.4 raw -o - "$plist")" = "--host=127.0.0.1" ]
+  [ "$(plutil -extract ProgramArguments.5 raw -o - "$plist")" = "--port=8881" ]
 fi
 
 first_label="$label"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -81,6 +81,7 @@ source "$SCRIPT_DIR/bridges/_dispatch.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/guidance/_dispatch.sh"
 source "$SCRIPT_DIR/services/datamachine-worker.sh"
+source "$SCRIPT_DIR/services/wordpress-service.sh"
 
 # Discover available runtimes
 AVAILABLE_RUNTIMES=()
@@ -104,6 +105,9 @@ SKIP_PLUGINS=false
 WITH_AI_GATEWAY=false
 WITH_CLAUDE_CODE_AUTH=true
 ROTATE_AI_GATEWAY_TOKEN=false
+WORDPRESS_SERVICE_REQUEST=""
+WORDPRESS_SERVICE_HOST="${WORDPRESS_SERVICE_HOST:-}"
+WORDPRESS_SERVICE_PORT="${WORDPRESS_SERVICE_PORT:-}"
 SHOW_HELP=false
 SOURCE_MODE=""
 SOURCE_MODE_EXPLICIT=false
@@ -154,6 +158,10 @@ while [[ $# -gt 0 ]]; do
     --with-ai-gateway) WITH_AI_GATEWAY=true; shift ;;
     --with-datamachine-worker) DATAMACHINE_WORKER_REQUEST=enabled; shift ;;
     --no-datamachine-worker) DATAMACHINE_WORKER_REQUEST=disabled; shift ;;
+    --with-wordpress-service) WORDPRESS_SERVICE_REQUEST=enabled; shift ;;
+    --no-wordpress-service) WORDPRESS_SERVICE_REQUEST=disabled; shift ;;
+    --wordpress-service-host) WORDPRESS_SERVICE_HOST="$2"; shift 2 ;;
+    --wordpress-service-port) WORDPRESS_SERVICE_PORT="$2"; shift 2 ;;
     --with-claude-code-auth) WITH_CLAUDE_CODE_AUTH=true; shift ;;
     --no-claude-code-auth) WITH_CLAUDE_CODE_AUTH=false; shift ;;
     --ai-gateway-provider) AI_GATEWAY_ROUTE_PROVIDER="$2"; shift 2 ;;
@@ -265,6 +273,13 @@ USAGE:
   ./upgrade.sh --no-datamachine-worker
                                  Disable the worker and remove its managed
                                  launchd or systemd service.
+  ./upgrade.sh --with-wordpress-service
+                                 Run this local WordPress site with a managed
+                                 macOS launchd service backed by `wp server`.
+  ./upgrade.sh --no-wordpress-service
+                                 Disable and remove the managed local service.
+  ./upgrade.sh --wordpress-service-host 127.0.0.1 --wordpress-service-port 8080
+                                 Set the local WordPress bind address.
   ./upgrade.sh --with-ai-gateway --rotate-ai-gateway-token
                                 Explicitly mint a replacement gateway token.
   ./upgrade.sh --with-ai-gateway --ai-gateway-provider openai --ai-gateway-model gpt-4o-mini
@@ -1310,6 +1325,11 @@ reconcile_datamachine_worker_service() {
   datamachine_worker_reconcile
 }
 
+reconcile_wordpress_service() {
+  _run_filter_active systemd || return 0
+  wordpress_service_reconcile
+}
+
 # ============================================================================
 # Phase 7: Refresh the opencode runtime signature
 #
@@ -1525,6 +1545,7 @@ sync_runtime_instructions
 opencode_project_subagents_optional
 update_chat_bridge_systemd
 update_chat_bridge_launchd
+reconcile_wordpress_service
 reconcile_datamachine_worker_service
 refresh_opencode_runtime_signature_phase
 print_summary


### PR DESCRIPTION
## Summary

- add an opt-in macOS launchd service backed by `wp server`
- persist site-scoped host, port, and enabled state across upgrades
- execute resolved PHP and WP-CLI paths directly so launchd does not depend on shell PATH
- keep existing WordPress Studio support unchanged

Closes #544.

## Verification

- `bash -n setup.sh upgrade.sh services/wordpress-service.sh tests/wordpress-service.sh`
- `bash tests/wordpress-service.sh`
- `bash tests/ci-coverage.sh`
- migrated an existing MDI-primary local site from Studio to this service
- verified homepage and REST API return HTTP 200
- verified an MDI option write survived a launchd service restart and was readable before cleanup
- verified Kimaki, OpenCode, and WordPress MCP use the direct `wp` transport after restart

The repository-wide shell loop also reaches the existing unrelated `tests/claude-code-hook-scope.sh` failure; this branch does not modify that test or its implementation.

## AI assistance

GPT-5.6 Sol via OpenCode inspected the existing service and transport contracts, implemented the launchd integration under my direction, diagnosed the launchd PATH failure from runtime evidence, and helped execute the migration and verification. I reviewed the resulting diff, commands, and evidence.