### PR TITLE
Require exact Homeboy worktree owner references

### DIFF
--- a/templates/wp-coding-agents-homeboy-worktrees.php
+++ b/templates/wp-coding-agents-homeboy-worktrees.php
@@ -217,8 +217,9 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 	private static function add(array $input): array|WP_Error {
 		$repo   = self::required_string($input, 'repo');
 		$branch = self::required_string($input, 'branch');
-		if (is_wp_error($repo) || is_wp_error($branch)) {
-			return is_wp_error($repo) ? $repo : $branch;
+		$owner  = self::required_string($input, 'owner_run_ref');
+		if (is_wp_error($repo) || is_wp_error($branch) || is_wp_error($owner)) {
+			return is_wp_error($repo) ? $repo : (is_wp_error($branch) ? $branch : $owner);
 		}
 		foreach (array('inject_context', 'bootstrap', 'allow_stale', 'rebase_base', 'force', 'allow_percentage_byte_floor_exception', 'remediate_capacity', 'remediate_capacity_dry_run', 'verbose') as $unsupported) {
 			if (!empty($input[$unsupported])) {
@@ -247,9 +248,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		if (null !== ($task_url = self::optional_string($input, 'task_url'))) {
 			$command = array_merge($command, array('--task-url', $task_url));
 		}
-		if (null !== ($owner = self::optional_string($input, 'owner_run_ref'))) {
-			$command = array_merge($command, array('--run-id', $owner));
-		}
+		$command = array_merge($command, array('--run-id', $owner));
 		if (null !== ($policy = self::cleanup_policy($input['cleanup_policy'] ?? null))) {
 			$command = array_merge($command, array('--cleanup-policy', $policy));
 		}
@@ -261,6 +260,9 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 		$record = $data['record'] ?? null;
 		if (!is_array($record)) {
 			return self::contract_error('Homeboy create result omitted its native worktree record.', $data);
+		}
+		if ($owner !== self::optional_string($record, 'run_id')) {
+			return self::contract_error('Homeboy create result omitted the exact requested owner-run reference.', $data);
 		}
 		$freshness = self::handoff_freshness($data, $record, !empty($input['allow_unverified_freshness']));
 		if (is_wp_error($freshness)) {
@@ -284,7 +286,7 @@ final class WP_Coding_Agents_Homeboy_Worktrees {
 			'bootstrap'        => array('outcome' => 'not_requested', 'owner' => 'homeboy'),
 			'handoff_freshness' => $freshness,
 			'message'          => 'Homeboy owns this worktree lifecycle.',
-			'metadata'         => array('homeboy' => $record),
+			'metadata'         => array('homeboy' => $record, 'owner_run_ref' => $owner),
 		);
 	}
 

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -37,6 +37,9 @@ case "$*" in
     rm -f "$HOMEBOY_FINALIZER_STATE"
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{}}'
     ;;
+  "worktree create "*"--run-id wrong-run")
+    printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"create","record":{"id":"fixture@wrong-run","component_id":"fixture","worktree_path":"/workspace/fixture@wrong-run","branch":"fix/wrong-run","base_ref":"origin/main","run_id":"other-run","state":"active"},"handoff_freshness":{"status":"verified","proof":{"schema":"homeboy/worktree-handoff-freshness/v1","proof_id":"proof-wrong-run","handle":"fixture@wrong-run","worktree_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","resolved_base_ref":"origin/main","resolved_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_ref":"refs/remotes/origin/main","remote_default_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_advertised_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","verified_at":"2026-08-30T00:00:00Z"}}}}'
+    ;;
   "worktree create "*)
     printf '%s\n' '{"schema":"homeboy/command-result/v3","success":true,"data":{"action":"create","record":{"id":"fixture@fix-474","component_id":"fixture","worktree_path":"/workspace/fixture@fix-474","branch":"fix/474","base_ref":"origin/main","task_url":"https://example.test/474","run_id":"run-474","cleanup_policy":"remove_when_safe","created_at":"2026-08-30T00:00:00Z","state":"active"},"handoff_freshness":{"status":"verified","proof":{"schema":"homeboy/worktree-handoff-freshness/v1","proof_id":"proof-474","handle":"fixture@fix-474","worktree_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","resolved_base_ref":"origin/main","resolved_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_ref":"refs/remotes/origin/main","remote_default_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","remote_default_advertised_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","verified_at":"2026-08-30T00:00:00Z"}}}}'
     ;;
@@ -125,13 +128,16 @@ $native = $add(array('repo' => 'fixture', 'branch' => 'fix/native'));
 expect('dmc' === ($native['backend'] ?? null), 'default context and bootstrap behavior retains DMC native creation');
 $native_option = $add(array('repo' => 'fixture', 'branch' => 'fix/native-option', 'inject_context' => false, 'bootstrap' => false, 'allow_stale' => true));
 expect('dmc' === ($native_option['backend'] ?? null), 'DMC-only create options retain DMC native creation');
-$verified = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'inject_context' => false, 'bootstrap' => false));
+$verified = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'owner_run_ref' => 'run-474', 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($verified) && 'verified' === ($verified['handoff_freshness']['status'] ?? null), 'create maps Homeboy remote freshness into the DMC handoff contract');
 $created = $add(array('repo' => 'fixture', 'branch' => 'fix/474', 'from' => 'origin/main', 'task_url' => 'https://example.test/474', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'remove_on_success', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($created) && 'fixture@fix-474' === $created['handle'], 'create projects native Homeboy record');
+expect('run-474' === ($created['metadata']['owner_run_ref'] ?? null), 'create preserves its explicit owner-run reference for audit');
 expect('verified' === ($created['handoff_freshness']['status'] ?? null), 'create retains available Homeboy freshness when unverified fallback is allowed');
-$manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'cleanup_policy' => 'manual', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
+$manual = $add(array('repo' => 'fixture', 'branch' => 'fix/474-manual', 'owner_run_ref' => 'run-474', 'cleanup_policy' => 'manual', 'allow_unverified_freshness' => true, 'inject_context' => false, 'bootstrap' => false));
 expect(!is_wp_error($manual), 'manual lifecycle intent maps to non-cleanup-eligible Homeboy policy');
+expect(is_wp_error($add(array('repo' => 'fixture', 'branch' => 'missing-owner', 'inject_context' => false, 'bootstrap' => false))), 'Homeboy create refuses a worktree without an explicit owner-run reference');
+expect(is_wp_error($add(array('repo' => 'fixture', 'branch' => 'wrong-run', 'owner_run_ref' => 'wrong-run', 'inject_context' => false, 'bootstrap' => false))), 'Homeboy create refuses a result with a different owner-run reference');
 
 $list = $ability('datamachine-code/workspace-worktree-list');
 $listed = $list(array('handle' => 'fixture@fix-474', 'include_status' => true, 'limit' => 1));
@@ -192,8 +198,8 @@ if grep -q 'datamachine-code' "$LOG"; then
   exit 1
 fi
 grep -q "^worktree create $WORKSPACE_REAL/fixture " "$LOG"
-grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474 --require-handoff-freshness --from origin/HEAD$" "$LOG"
-grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474-manual --from origin/HEAD --cleanup-policy preserve-on-failure$" "$LOG"
+grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474 --require-handoff-freshness --from origin/HEAD --run-id run-474$" "$LOG"
+grep -q "^worktree create $WORKSPACE_REAL/fixture --branch fix/474-manual --from origin/HEAD --run-id run-474 --cleanup-policy preserve-on-failure$" "$LOG"
 grep -q '^worktree finalize fixture@fix-474 --owner-run-ref run-474 --disposition succeeded$' "$LOG"
 grep -q '^worktree cleanup --apply$' "$LOG"
 


### PR DESCRIPTION
## Summary
- require callers to provide the owning Homeboy run reference
- forward that exact reference as `--run-id` during worktree creation
- verify returned ownership and persist auditable owner metadata

## Verification
- `bash tests/homeboy-worktree-adapter.sh`
- `php -l templates/wp-coding-agents-homeboy-worktrees.php`
- `shellcheck -e SC2034 tests/homeboy-worktree-adapter.sh`
- `git diff --check`

Closes #538

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used to investigate, implement, and run verification. Chris Huber reviewed and orchestrated the work.