### PR TITLE
refactor: reconcile plugins-only desired state

### DIFF
--- a/lib/desired-state-reconciler.sh
+++ b/lib/desired-state-reconciler.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Credential-free operation profile and desired-state plan execution.
+
+INSTALLATION_OPERATION_PLUGINS_ONLY="plugins-only"
+
+installation_profile_normalize() {
+  local operation="$1"
+  case "$operation" in
+    "$INSTALLATION_OPERATION_PLUGINS_ONLY") ;;
+    *) error "Unknown installation operation: $operation" ;;
+  esac
+
+  INSTALLATION_PROFILE_OPERATION="$operation"
+  INSTALLATION_PROFILE_SITE_PATH="${SITE_PATH:-${EXISTING_WP:-}}"
+  INSTALLATION_PROFILE_LOCAL_MODE="${LOCAL_MODE:-false}"
+  INSTALLATION_PROFILE_EXTERNAL_WORDPRESS="${EXTERNAL_WORDPRESS:-false}"
+  INSTALLATION_PROFILE_STUDIO="${IS_STUDIO:-false}"
+  INSTALLATION_PROFILE_PLUGIN_CANDIDATES=(data-machine data-machine-code wp-codebox)
+}
+
+installation_profile_record() {
+  printf 'operation=%s site_path=%s local=%s external_wordpress=%s studio=%s components=%s\n' \
+    "$INSTALLATION_PROFILE_OPERATION" "$INSTALLATION_PROFILE_SITE_PATH" \
+    "$INSTALLATION_PROFILE_LOCAL_MODE" "$INSTALLATION_PROFILE_EXTERNAL_WORDPRESS" \
+    "$INSTALLATION_PROFILE_STUDIO" "${INSTALLATION_PROFILE_PLUGIN_CANDIDATES[*]}"
+}
+
+reconciler_plan_reset() {
+  RECONCILER_PLAN_RECORDS=()
+  RECONCILER_PLAN_OPERATIONS=()
+  RECONCILER_PLAN_APPLY=()
+  RECONCILER_PLAN_VERIFY=""
+  RECONCILER_COMPLETED_RECORDS=()
+}
+
+reconciler_plan_add() {
+  local record="$1" operation="$2" apply="$3"
+  RECONCILER_PLAN_RECORDS+=("$record")
+  RECONCILER_PLAN_OPERATIONS+=("$operation")
+  RECONCILER_PLAN_APPLY+=("$apply")
+  log "[desired-state] record=$record operation=$operation planned"
+}
+
+reconciler_plan_set_verify() {
+  RECONCILER_PLAN_VERIFY="$1"
+}
+
+reconciler_apply_plan() {
+  local index record operation apply status=0 step_status
+  for index in "${!RECONCILER_PLAN_RECORDS[@]}"; do
+    record="${RECONCILER_PLAN_RECORDS[$index]}"
+    operation="${RECONCILER_PLAN_OPERATIONS[$index]}"
+    apply="${RECONCILER_PLAN_APPLY[$index]}"
+    log "[desired-state] record=$record operation=$operation apply=start"
+    if "$apply"; then
+      RECONCILER_COMPLETED_RECORDS+=("$record")
+      log "[desired-state] record=$record operation=$operation apply=complete"
+    else
+      step_status=$?
+      status="$PLUGIN_UPDATE_EXIT_PARTIAL"
+      warn "[desired-state] record=$record operation=$operation apply=partial-failure status=$step_status"
+    fi
+  done
+  return "$status"
+}
+
+reconciler_verify_plan() {
+  local status
+  [ -n "$RECONCILER_PLAN_VERIFY" ] || return 0
+  log "[desired-state] operation=plugins.reconcile.verify verification=start"
+  if "$RECONCILER_PLAN_VERIFY"; then
+    log "[desired-state] operation=plugins.reconcile.verify verification=complete"
+    return 0
+  fi
+  status=$?
+  warn "[desired-state] operation=plugins.reconcile.verify verification=partial-failure status=$status"
+  return "$PLUGIN_UPDATE_EXIT_PARTIAL"
+}
+
+reconciler_print_partial_evidence() {
+  local record
+  [ "${#RECONCILER_COMPLETED_RECORDS[@]}" -gt 0 ] || return 0
+  warn "DESIRED_STATE_COMPLETED_RECORDS=${RECONCILER_COMPLETED_RECORDS[*]}"
+  for record in "${RECONCILER_COMPLETED_RECORDS[@]}"; do
+    warn "  completed desired-state record: $record"
+  done
+}

--- a/tests/plugin-upgrade-bounds.sh
+++ b/tests/plugin-upgrade-bounds.sh
@@ -5,6 +5,7 @@ set -eu
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck disable=SC1091
 source "$ROOT_DIR/lib/plugin-upgrade.sh"
+source "$ROOT_DIR/lib/desired-state-reconciler.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -113,5 +114,42 @@ PY
 [ "$before" = "$after" ] || fail "copied DMC mutated during a timed-out plugin update"
 [ ! -e "$PLUGIN/.wp-coding-agents-releases" ] || fail "copied DMC was converted to .wp-coding-agents-releases"
 case "$LOG" in *"installed-after version=1.0.0 active=yes"*"terminal=partial-failure"*) : ;; *) fail "partial terminal verification evidence missing" ;; esac
+
+# Reconciliation reports the records that completed before a bounded later step
+# timed out, making the partial result safe to replay without claiming a change
+# when an idempotent apply was already converged.
+LOG=""
+PLUGIN_UPDATE_PHASE_TIMEOUT_SECONDS=1
+PLUGIN_UPDATE_STARTED_AT="$(date +%s)"
+reconciler_fixture_complete() { return 0; }
+reconciler_fixture_timeout() { plugin_update_run_phase fixture reconciler-timeout "$hung"; }
+reconciler_plan_reset
+reconciler_plan_add plugins.data-machine plugins.reconcile.data-machine reconciler_fixture_complete
+reconciler_plan_add plugins.data-machine-code plugins.reconcile.data-machine-code reconciler_fixture_timeout
+if reconciler_apply_plan; then
+  fail "generic reconciler completed a timed-out plan"
+else
+  status=$?
+fi
+[ "$status" -eq "$PLUGIN_UPDATE_EXIT_PARTIAL" ] || fail "generic reconciler did not return partial status"
+reconciler_print_partial_evidence
+case "$LOG" in
+  *'record=plugins.data-machine operation=plugins.reconcile.data-machine apply=start'*'record=plugins.data-machine-code operation=plugins.reconcile.data-machine-code apply=start'*'phase=reconciler-timeout terminal=timeout'*'DESIRED_STATE_COMPLETED_RECORDS=plugins.data-machine'*) : ;;
+  *) fail "desired-state reconciler omitted timeout or completed-record evidence" ;;
+esac
+
+# Normalized profiles carry installation shape, never credential runtime input.
+SITE_PATH="$TMP/site"
+LOCAL_MODE=true
+EXTERNAL_WORDPRESS=false
+IS_STUDIO=false
+KIMAKI_BOT_TOKEN=credential-must-not-appear
+installation_profile_normalize "$INSTALLATION_OPERATION_PLUGINS_ONLY"
+profile="$(installation_profile_record)"
+case "$profile" in
+  *credential-must-not-appear*|*KIMAKI_BOT_TOKEN*) fail "profile retained a credential" ;;
+  *'operation=plugins-only'*'local=true'*'external_wordpress=false'*) : ;;
+  *) fail "profile omitted plugins-only installation shape" ;;
+esac
 
 echo "plugin-upgrade-bounds tests passed"

--- a/tests/plugins-only-scope.sh
+++ b/tests/plugins-only-scope.sh
@@ -31,6 +31,11 @@ require_source '  _run_filter_active systemd || return 0' "launchd mutation guar
 require_source './upgrade.sh --reconcile-services' "explicit reconciliation command"
 require_source 'if [ "$PLUGINS_ONLY" != true ]; then' "plugins-only source-policy mutation guard"
 require_source 'detect_plugins_only_environment' "narrow plugin-only environment detection"
+require_source 'installation_profile_normalize "$INSTALLATION_OPERATION_PLUGINS_ONLY"' "credential-free plugins-only profile normalization"
+require_source 'reconcile_installed_plugins() {' "plugins-only desired-state reconciliation"
+require_source 'plugins.reconcile.data-machine' "explicit data-machine operation name"
+require_source 'plugins.reconcile.data-machine-code' "explicit data-machine-code operation name"
+require_source 'plugins.reconcile.wp-codebox' "explicit wp-codebox operation name"
 require_file_source "$ROOT_DIR/lib/detect.sh" 'Plugin-only scope: installed Data Machine plugins only; runtime, bridge, workspace, and service synchronization disabled' "plugin-only scope evidence"
 require_source '--plugins-only cannot be combined with service, runtime, migration, or other --*-only operations' "plugin-only exclusivity guard"
 require_source 'if _run_filter_active systemd; then' "systems-capability mutation guard"
@@ -59,11 +64,21 @@ load_upgrade_function() {
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 SITE_PATH="$TMP/site"
-mkdir -p "$SITE_PATH/wp-content/plugins/wp-codebox"
+mkdir -p "$SITE_PATH/wp-content/plugins/data-machine" \
+  "$SITE_PATH/wp-content/plugins/data-machine-code" \
+  "$SITE_PATH/wp-content/plugins/wp-codebox"
 PLUGIN_UPDATE_EXIT_PARTIAL=75
+SCRIPT_DIR="$ROOT_DIR"
+source "$ROOT_DIR/lib/plugin-upgrade.sh"
+source "$ROOT_DIR/lib/desired-state-reconciler.sh"
 
 eval "$(load_upgrade_function _run_filter_active)"
 eval "$(load_upgrade_function update_data_machine_plugins)"
+eval "$(load_upgrade_function _reconcile_data_machine_plugin)"
+eval "$(load_upgrade_function _reconcile_data_machine_code_plugin)"
+eval "$(load_upgrade_function _reconcile_wp_codebox_plugin)"
+eval "$(load_upgrade_function _reconcile_installed_plugins_verify)"
+eval "$(load_upgrade_function reconcile_installed_plugins)"
 eval "$(load_upgrade_function reconcile_provider_and_service_state)"
 eval "$(load_upgrade_function update_chat_bridge_systemd)"
 eval "$(load_upgrade_function update_chat_bridge_launchd)"
@@ -80,12 +95,16 @@ AGENTS_MD_ONLY=false
 RECONCILE_SERVICES_ONLY=false
 SKIP_PLUGINS=false
 LOCAL_MODE=true
+EXTERNAL_WORDPRESS=false
+IS_STUDIO=false
 PLATFORM=mac
 CHAT_BRIDGE=kimaki
 upgrade_data_machine_plugins() { printf 'data-machine\n' >> "$TMP/plugins"; }
 update_wp_codebox_plugin_subtree() { printf 'codebox\n' >> "$TMP/plugins"; }
 plugin_update_execute() { local slug="$1"; shift; "$@"; }
 plugin_update_verify_installed_plugins() { :; }
+log() { LOG="${LOG:-}$*"$'\n'; }
+warn() { LOG="${LOG:-}$*"$'\n'; }
 set_compose_agents_md_constant() { printf 'configuration\n' >> "$TMP/reconciliation"; }
 sync_carried_plugins() { printf 'carried\n' >> "$TMP/reconciliation"; }
 configure_homeboy_worktree_ownership() { printf 'homeboy\n' >> "$TMP/reconciliation"; }
@@ -93,14 +112,29 @@ bridge_has_hook() { return 0; }
 bridge_update_launchd() { printf 'changed\n' >> "$LOCAL_SERVICE"; }
 bridge_update_systemd() { printf 'changed\n' >> "$VPS_SERVICE"; }
 
+update_plugin_to_latest_tag() { printf '%s\n' "$1" >> "$TMP/plugins"; }
+installation_profile_normalize "$INSTALLATION_OPERATION_PLUGINS_ONLY"
 update_data_machine_plugins
 reconcile_provider_and_service_state
 update_chat_bridge_launchd
 LOCAL_MODE=false
 update_chat_bridge_systemd
 
-test "$(cat "$TMP/plugins")" = $'data-machine\ncodebox' || {
+test "$(cat "$TMP/plugins")" = $'data-machine\ndata-machine-code\ncodebox' || {
   echo "FAIL: plugins-only did not run exactly the plugin updaters" >&2
+  exit 1
+}
+case "$LOG" in
+  *'profile=operation=plugins-only'*'components=data-machine data-machine-code wp-codebox'*'record=plugins.data-machine operation=plugins.reconcile.data-machine planned'*'record=plugins.data-machine operation=plugins.reconcile.data-machine apply=start'*'record=plugins.data-machine operation=plugins.reconcile.data-machine apply=complete'*) : ;;
+  *) echo "FAIL: plugins-only did not emit planned-step evidence" >&2; exit 1 ;;
+esac
+
+# The normalized profile, not a second updater list, is plan authority.
+rm -f "$TMP/plugins"
+INSTALLATION_PROFILE_PLUGIN_CANDIDATES=(wp-codebox)
+update_data_machine_plugins
+test "$(cat "$TMP/plugins")" = 'codebox' || {
+  echo "FAIL: plugins-only plan ignored the normalized component set" >&2
   exit 1
 }
 test ! -e "$TMP/reconciliation" || {

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -67,7 +67,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
 # Source shared modules (common, detect needed for environment resolution;
 # wordpress is needed for wp_cmd helper used by compose and plugin updates).
-for lib in common detect source-policy owned-source-discovery service-migration plugin-upgrade wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents systems-capabilities; do
+for lib in common detect source-policy owned-source-discovery service-migration plugin-upgrade desired-state-reconciler wordpress data-machine carried-plugins wp-codebox homeboy ai-gateway skills cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance agents-md-backups opencode-subagents systems-capabilities; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -412,6 +412,7 @@ fi
 
 if [ "$PLUGINS_ONLY" = true ]; then
   detect_plugins_only_environment
+  installation_profile_normalize "$INSTALLATION_OPERATION_PLUGINS_ONLY"
 else
   # Auto-detect runtime(s). Same model as setup.sh: DETECTED_RUNTIMES is the
   # full list (drives multi-runtime skills install); RUNTIME is the primary
@@ -618,18 +619,60 @@ _run_filter_active() {
 
 update_data_machine_plugins() {
   _run_filter_active plugins || return 0
+  if [ "$PLUGINS_ONLY" = true ]; then
+    reconcile_installed_plugins
+    return $?
+  fi
   local status=0
   upgrade_data_machine_plugins || status=$PLUGIN_UPDATE_EXIT_PARTIAL
-  if [ "$PLUGINS_ONLY" = true ]; then
-    if [ -d "$SITE_PATH/wp-content/plugins/wp-codebox" ]; then
-      plugin_update_execute wp-codebox update_wp_codebox_plugin_subtree || status=$PLUGIN_UPDATE_EXIT_PARTIAL
-    else
-      log "[wp-codebox] terminal=skipped reason=not-installed"
-    fi
-  else
-    plugin_update_execute wp-codebox update_wp_codebox_plugin_subtree || status=$PLUGIN_UPDATE_EXIT_PARTIAL
-  fi
+  plugin_update_execute wp-codebox update_wp_codebox_plugin_subtree || status=$PLUGIN_UPDATE_EXIT_PARTIAL
   plugin_update_verify_installed_plugins data-machine data-machine-code wp-codebox || status=$PLUGIN_UPDATE_EXIT_PARTIAL
+  return "$status"
+}
+
+_reconcile_data_machine_plugin() {
+  plugin_update_execute data-machine update_plugin_to_latest_tag data-machine https://github.com/Extra-Chill/data-machine.git
+}
+
+_reconcile_data_machine_code_plugin() {
+  plugin_update_execute data-machine-code update_plugin_to_latest_tag data-machine-code https://github.com/Extra-Chill/data-machine-code.git
+}
+
+_reconcile_wp_codebox_plugin() {
+  plugin_update_execute wp-codebox update_wp_codebox_plugin_subtree
+}
+
+_reconcile_installed_plugins_verify() {
+  [ "${#RECONCILER_INSTALLED_PLUGIN_SLUGS[@]}" -gt 0 ] || return 0
+  plugin_update_verify_installed_plugins "${RECONCILER_INSTALLED_PLUGIN_SLUGS[@]}"
+}
+
+# The plugins-only operation has no runtime, bridge, Homeboy, guidance, or
+# service adapters. Its profile plans only setup-installed plugin records.
+reconcile_installed_plugins() {
+  local plugin_dir status=0
+  [ "${INSTALLATION_PROFILE_OPERATION:-}" = "$INSTALLATION_OPERATION_PLUGINS_ONLY" ] || \
+    error "Installed plugin reconciliation requires a plugins-only installation profile"
+  reconciler_plan_reset
+  RECONCILER_INSTALLED_PLUGIN_SLUGS=()
+  log "[desired-state] profile=$(installation_profile_record)"
+
+  for plugin_dir in "${INSTALLATION_PROFILE_PLUGIN_CANDIDATES[@]}"; do
+    [ -d "$INSTALLATION_PROFILE_SITE_PATH/wp-content/plugins/$plugin_dir" ] || {
+      log "[$plugin_dir] terminal=skipped reason=not-installed"
+      continue
+    }
+    RECONCILER_INSTALLED_PLUGIN_SLUGS+=("$plugin_dir")
+    case "$plugin_dir" in
+      data-machine) reconciler_plan_add "plugins.data-machine" plugins.reconcile.data-machine _reconcile_data_machine_plugin ;;
+      data-machine-code) reconciler_plan_add "plugins.data-machine-code" plugins.reconcile.data-machine-code _reconcile_data_machine_code_plugin ;;
+      wp-codebox) reconciler_plan_add "plugins.wp-codebox" plugins.reconcile.wp-codebox _reconcile_wp_codebox_plugin ;;
+    esac
+  done
+
+  reconciler_plan_set_verify _reconcile_installed_plugins_verify
+  reconciler_apply_plan || status=$?
+  reconciler_verify_plan || status=$PLUGIN_UPDATE_EXIT_PARTIAL
   return "$status"
 }
 
@@ -1432,6 +1475,7 @@ print_summary() {
   echo ""
   if [ "$PLUGINS_ONLY" = true ]; then
     plugin_update_print_terminal_summary
+    [ "${PLUGIN_ONLY_EXIT_STATUS:-0}" -eq 0 ] || reconciler_print_partial_evidence
     echo ""
     _print_plugins_only_verify_block
   else


### PR DESCRIPTION
## Summary

- normalize `--plugins-only` into a credential-free operation profile with an explicit component set
- derive the plugin update plan from that profile and execute named plan/apply/verify records
- persist a credential-free declarative installation profile from setup and load it before upgrade runtime/source-policy resolution
- keep profile serialization allowlisted: no tokens, credential values, or command-transport argv are stored
- preserve existing bounded plugin updater deadlines while reporting completed records on partial replay

## Validation

- `bash tests/installation-profile.sh`
- `bash tests/plugins-only-scope.sh`
- `bash tests/plugin-upgrade-bounds.sh`
- `bash tests/dmc-managed-release.sh`
- `bash tests/dmc-managed-release-integration.sh`
- `bash tests/external-wordpress-runtime.sh`
- `bash tests/ci-coverage.sh`
- `bash -n setup.sh upgrade.sh lib/desired-state-reconciler.sh tests/installation-profile.sh`
- `git diff --check`

`tests/source-mode.sh` has a macOS-only failure in its GNU `stat` fixture assertion. The test is unchanged from `origin/main`, so this is a baseline portability failure, not a change from this branch.

## Remaining Limitations

This remains an incremental #455 implementation, not completion of the architecture issue. Setup and full upgrade still use legacy orchestration for runtime, guidance, bridge/Kimaki, Homeboy, carried/managed release, copied-DMC cleanup, and service phases. Those components do not yet all implement and execute through a shared `detect`/`plan`/`apply`/`verify` adapter contract, and setup/upgrade are not yet thin shared-convergence entrypoints. The only fully migrated vertical slice remains `--plugins-only`.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` implemented and verified this incremental profile persistence work under Chris Huber's direction.