### PR TITLE
refactor: persist credential-free installation profile

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -270,6 +270,7 @@ jobs:
           - kimaki-multi-instance
           - kimaki-restart-continuation
           - kimaki-system-message-patch
+          - installation-profile
           - opencode-claude-auth-refresh-hardening
           - opencode-subagents-optional
           - owned-source-discovery

--- a/docs/data-machine-code-migration-inventory.json
+++ b/docs/data-machine-code-migration-inventory.json
@@ -407,6 +407,21 @@
       "verification_gate": "No install/update/discovery call references DMC; explicit components converge through shared reconciler"
     },
     {
+      "id": "wca-desired-state-reconciler",
+      "subsystem": null,
+      "surface": "Credential-free plugins-only operation profile and named plan/apply/verify records",
+      "source": { "repository": "wp-coding-agents", "path": "lib/desired-state-reconciler.sh", "symbol_or_command": "installation_profile_normalize; reconciler_plan_add; reconciler_apply_plan; reconciler_verify_plan" },
+      "evidence_kind": "upgrade",
+      "contracts": ["data-machine-code"],
+      "current_owner": "wp-coding-agents",
+      "current_consumers": ["upgrade.sh --plugins-only"],
+      "persistence": "None; the normalized operation profile and plan exist for one invocation",
+      "target_owner": "wp-coding-agents",
+      "disposition": "replace",
+      "migration_issue": "#455, #525",
+      "verification_gate": "The normalized profile is sole component authority and plugins-only updates only installed setup-managed plugins with bounded replay evidence"
+    },
+    {
       "id": "wca-plugin-upgrade",
       "subsystem": null,
       "surface": "DMC plugin entrypoint/version mapping",
@@ -858,6 +873,21 @@
       "verification_gate": "Generic plugin bounds remain covered after DMC-specific cases are removed"
     },
     {
+      "id": "test-plugins-only-reconciler",
+      "subsystem": null,
+      "surface": "Plugins-only desired-state component authority and phase isolation",
+      "source": { "repository": "wp-coding-agents", "path": "tests/plugins-only-scope.sh", "symbol_or_command": "installation_profile_normalize; reconcile_installed_plugins" },
+      "evidence_kind": "test",
+      "contracts": ["data-machine-code"],
+      "current_owner": "wp-coding-agents tests",
+      "current_consumers": ["CI"],
+      "persistence": "Temporary plugin checkout fixtures",
+      "target_owner": "wp-coding-agents",
+      "disposition": "replace",
+      "migration_issue": "#455, #525",
+      "verification_gate": "Profile-driven plugin plan remains isolated from runtime, bridge, Homeboy, guidance, and service reconciliation"
+    },
+    {
       "id": "test-owned-source-discovery",
       "subsystem": null,
       "surface": "DMC carried-plugin source discovery fixtures",
@@ -1161,10 +1191,10 @@
   ],
   "reference_file_classification": {
     "runtime": [
-      "setup.sh", "upgrade.sh", "lib/data-machine.sh", "lib/homeboy.sh", "lib/plugin-upgrade.sh", "lib/source-policy.sh", "lib/owned-source-discovery.sh", "lib/runtime-signature.sh", "lib/systems-capabilities.sh", "lib/cli-channel.sh", "lib/summary.sh", "runtimes/opencode.sh", "runtimes/claude-code.sh", "bridges/kimaki.sh", "templates/wp-coding-agents-homeboy-worktrees.php", "templates/wp-coding-agents-cli-transport.php", "templates/wp-coding-agents-source-reconcile.php"
+      "setup.sh", "upgrade.sh", "lib/data-machine.sh", "lib/desired-state-reconciler.sh", "lib/homeboy.sh", "lib/plugin-upgrade.sh", "lib/source-policy.sh", "lib/owned-source-discovery.sh", "lib/runtime-signature.sh", "lib/systems-capabilities.sh", "lib/cli-channel.sh", "lib/summary.sh", "runtimes/opencode.sh", "runtimes/claude-code.sh", "bridges/kimaki.sh", "templates/wp-coding-agents-homeboy-worktrees.php", "templates/wp-coding-agents-cli-transport.php", "templates/wp-coding-agents-source-reconcile.php"
     ],
     "tests": [
-      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/worktree-context-projections.sh"
+      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/plugins-only-scope.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/worktree-context-projections.sh"
     ],
     "guidance": [
       "README.md", "guidance/homeboy.sh", "skills/upgrade-wp-coding-agents/SKILL.md", "operator-entrypoints/wp-coding-agents-setup/verify.md"

--- a/lib/desired-state-reconciler.sh
+++ b/lib/desired-state-reconciler.sh
@@ -1,12 +1,37 @@
 #!/bin/bash
-# Credential-free operation profile and desired-state plan execution.
+# Credential-free installation profiles and desired-state plan execution.
 
+INSTALLATION_OPERATION_SETUP="setup"
+INSTALLATION_OPERATION_UPGRADE="upgrade"
 INSTALLATION_OPERATION_PLUGINS_ONLY="plugins-only"
+
+installation_profile_file() {
+  printf '%s/.wp-coding-agents/installation-profile' "${SITE_PATH:-${EXISTING_WP:-}}"
+}
+
+installation_profile_value() {
+  # Profiles are deliberately a small allowlist. Never serialize the process
+  # environment: it contains command transports and optional credentials.
+  case "$1" in
+    operation) printf '%s' "$INSTALLATION_PROFILE_OPERATION" ;;
+    site_path) printf '%s' "$INSTALLATION_PROFILE_SITE_PATH" ;;
+    local_mode) printf '%s' "$INSTALLATION_PROFILE_LOCAL_MODE" ;;
+    external_wordpress) printf '%s' "$INSTALLATION_PROFILE_EXTERNAL_WORDPRESS" ;;
+    studio) printf '%s' "$INSTALLATION_PROFILE_STUDIO" ;;
+    source_mode) printf '%s' "$INSTALLATION_PROFILE_SOURCE_MODE" ;;
+    runtime) printf '%s' "$INSTALLATION_PROFILE_RUNTIME" ;;
+    chat_bridge) printf '%s' "$INSTALLATION_PROFILE_CHAT_BRIDGE" ;;
+    homeboy_mode) printf '%s' "$INSTALLATION_PROFILE_HOMEBOY_MODE" ;;
+    components) printf '%s' "${INSTALLATION_PROFILE_COMPONENTS[*]}" ;;
+    plugin_candidates) printf '%s' "${INSTALLATION_PROFILE_PLUGIN_CANDIDATES[*]}" ;;
+    *) return 1 ;;
+  esac
+}
 
 installation_profile_normalize() {
   local operation="$1"
   case "$operation" in
-    "$INSTALLATION_OPERATION_PLUGINS_ONLY") ;;
+    "$INSTALLATION_OPERATION_SETUP"|"$INSTALLATION_OPERATION_UPGRADE"|"$INSTALLATION_OPERATION_PLUGINS_ONLY") ;;
     *) error "Unknown installation operation: $operation" ;;
   esac
 
@@ -15,29 +40,90 @@ installation_profile_normalize() {
   INSTALLATION_PROFILE_LOCAL_MODE="${LOCAL_MODE:-false}"
   INSTALLATION_PROFILE_EXTERNAL_WORDPRESS="${EXTERNAL_WORDPRESS:-false}"
   INSTALLATION_PROFILE_STUDIO="${IS_STUDIO:-false}"
+  INSTALLATION_PROFILE_SOURCE_MODE="${SOURCE_MODE:-workspace}"
+  INSTALLATION_PROFILE_RUNTIME="${RUNTIME:-}"
+  INSTALLATION_PROFILE_CHAT_BRIDGE="${CHAT_BRIDGE:-}"
+  INSTALLATION_PROFILE_HOMEBOY_MODE="${HOMEBOY_MODE:-auto}"
   INSTALLATION_PROFILE_PLUGIN_CANDIDATES=(data-machine data-machine-code wp-codebox)
+  if [ "$operation" = "$INSTALLATION_OPERATION_PLUGINS_ONLY" ]; then
+    INSTALLATION_PROFILE_COMPONENTS=(plugins)
+  else
+    INSTALLATION_PROFILE_COMPONENTS=(plugins runtime guidance bridge homeboy managed-release services)
+  fi
 }
 
 installation_profile_record() {
-  printf 'operation=%s site_path=%s local=%s external_wordpress=%s studio=%s components=%s\n' \
+  local components="${INSTALLATION_PROFILE_COMPONENTS[*]}"
+  if [ "$INSTALLATION_PROFILE_OPERATION" = "$INSTALLATION_OPERATION_PLUGINS_ONLY" ]; then
+    # Preserve the compact plugins-only evidence emitted by the initial #455
+    # slice; callers use it as the narrow-operation replay record.
+    printf 'operation=%s site_path=%s local=%s external_wordpress=%s studio=%s components=%s\n' \
+      "$INSTALLATION_PROFILE_OPERATION" "$INSTALLATION_PROFILE_SITE_PATH" \
+      "$INSTALLATION_PROFILE_LOCAL_MODE" "$INSTALLATION_PROFILE_EXTERNAL_WORDPRESS" \
+      "$INSTALLATION_PROFILE_STUDIO" "${INSTALLATION_PROFILE_PLUGIN_CANDIDATES[*]}"
+    return 0
+  fi
+  printf 'operation=%s site_path=%s local=%s external_wordpress=%s studio=%s source_mode=%s runtime=%s chat_bridge=%s homeboy_mode=%s components=%s\n' \
     "$INSTALLATION_PROFILE_OPERATION" "$INSTALLATION_PROFILE_SITE_PATH" \
     "$INSTALLATION_PROFILE_LOCAL_MODE" "$INSTALLATION_PROFILE_EXTERNAL_WORDPRESS" \
-    "$INSTALLATION_PROFILE_STUDIO" "${INSTALLATION_PROFILE_PLUGIN_CANDIDATES[*]}"
+    "$INSTALLATION_PROFILE_STUDIO" "$INSTALLATION_PROFILE_SOURCE_MODE" \
+    "$INSTALLATION_PROFILE_RUNTIME" "$INSTALLATION_PROFILE_CHAT_BRIDGE" \
+    "$INSTALLATION_PROFILE_HOMEBOY_MODE" "$components"
+}
+
+installation_profile_write() {
+  local file tmp key
+  [ "${DRY_RUN:-false}" = true ] && return 0
+  file="$(installation_profile_file)"
+  if ! mkdir -p "${file%/*}" 2>/dev/null || [ ! -w "${file%/*}" ]; then
+    # An upgrade may deliberately run as a non-root service identity against a
+    # root-owned legacy web tree. Convergence must still proceed; the existing
+    # profile remains valid and the next writable reconciliation can refresh it.
+    warn "[desired-state] installation profile unchanged: ${file%/*} is not writable"
+    return 0
+  fi
+  tmp="${file}.tmp.$$"
+  for key in operation site_path local_mode external_wordpress studio source_mode runtime chat_bridge homeboy_mode components plugin_candidates; do
+    printf '%s=%s\n' "$key" "$(installation_profile_value "$key")" >> "$tmp"
+  done
+  mv "$tmp" "$file"
+  chmod 600 "$file"
+}
+
+installation_profile_load() {
+  local file key value
+  file="$(installation_profile_file)"
+  [ -f "$file" ] || return 0
+  while IFS='=' read -r key value; do
+    case "$key" in
+      source_mode) [ "${SOURCE_MODE_EXPLICIT:-false}" = true ] || SOURCE_MODE="$value" ;;
+      runtime) [ -n "${RUNTIME:-}" ] || RUNTIME="$value" ;;
+      chat_bridge) [ -n "${CHAT_BRIDGE:-}" ] || CHAT_BRIDGE="$value" ;;
+      homeboy_mode) [ "${HOMEBOY_MODE:-auto}" != auto ] || HOMEBOY_MODE="$value" ;;
+    esac
+  done < "$file"
 }
 
 reconciler_plan_reset() {
   RECONCILER_PLAN_RECORDS=()
   RECONCILER_PLAN_OPERATIONS=()
   RECONCILER_PLAN_APPLY=()
+  RECONCILER_PLAN_VERIFY_STEPS=()
+  RECONCILER_PLAN_TIMEOUTS=()
+  RECONCILER_PLAN_REPLAYS=()
   RECONCILER_PLAN_VERIFY=""
   RECONCILER_COMPLETED_RECORDS=()
+  RECONCILER_CHANGED_RECORDS=()
 }
 
 reconciler_plan_add() {
-  local record="$1" operation="$2" apply="$3"
+  local record="$1" operation="$2" apply="$3" verify="${4:-}" timeout="${5:-}" replay="${6:-}"
   RECONCILER_PLAN_RECORDS+=("$record")
   RECONCILER_PLAN_OPERATIONS+=("$operation")
   RECONCILER_PLAN_APPLY+=("$apply")
+  RECONCILER_PLAN_VERIFY_STEPS+=("$verify")
+  RECONCILER_PLAN_TIMEOUTS+=("$timeout")
+  RECONCILER_PLAN_REPLAYS+=("$replay")
   log "[desired-state] record=$record operation=$operation planned"
 }
 
@@ -46,22 +132,41 @@ reconciler_plan_set_verify() {
 }
 
 reconciler_apply_plan() {
-  local index record operation apply status=0 step_status
+  local index record operation apply verify timeout replay status=0 step_status
   for index in "${!RECONCILER_PLAN_RECORDS[@]}"; do
     record="${RECONCILER_PLAN_RECORDS[$index]}"
     operation="${RECONCILER_PLAN_OPERATIONS[$index]}"
     apply="${RECONCILER_PLAN_APPLY[$index]}"
-    log "[desired-state] record=$record operation=$operation apply=start"
+    verify="${RECONCILER_PLAN_VERIFY_STEPS[$index]}"
+    timeout="${RECONCILER_PLAN_TIMEOUTS[$index]}"
+    replay="${RECONCILER_PLAN_REPLAYS[$index]}"
+    log "[desired-state] record=$record operation=$operation apply=start${timeout:+ timeout=${timeout}s}"
     if "$apply"; then
       RECONCILER_COMPLETED_RECORDS+=("$record")
-      log "[desired-state] record=$record operation=$operation apply=complete"
+      if [ -n "$verify" ] && ! "$verify"; then
+        step_status=$?
+        status="${PLUGIN_UPDATE_EXIT_PARTIAL:-75}"
+        warn "[desired-state] record=$record operation=$operation verify=partial-failure status=$step_status${replay:+ replay=$replay}"
+      else
+        log "[desired-state] record=$record operation=$operation apply=complete${replay:+ replay=$replay}"
+      fi
     else
       step_status=$?
-      status="$PLUGIN_UPDATE_EXIT_PARTIAL"
-      warn "[desired-state] record=$record operation=$operation apply=partial-failure status=$step_status"
+      status="${PLUGIN_UPDATE_EXIT_PARTIAL:-75}"
+      if [ "$step_status" -eq 124 ]; then
+        warn "[desired-state] record=$record operation=$operation apply=timeout${timeout:+ timeout=${timeout}s}${replay:+ replay=$replay}"
+      else
+        warn "[desired-state] record=$record operation=$operation apply=partial-failure status=$step_status${replay:+ replay=$replay}"
+      fi
     fi
   done
   return "$status"
+}
+
+reconciler_mark_changed() {
+  local record="$1"
+  RECONCILER_CHANGED_RECORDS+=("$record")
+  log "[desired-state] record=$record result=changed"
 }
 
 reconciler_verify_plan() {

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source shared modules
-for lib in common detect source-policy owned-source-discovery wordpress external-wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance opencode-subagents systems-capabilities; do
+for lib in common detect source-policy owned-source-discovery desired-state-reconciler wordpress external-wordpress infrastructure data-machine carried-plugins homeboy ai-gateway skills summary cli-transport inbound-event-bridge cli-channel runtime-signature runtime-guard source-reconcile agents-md-guidance opencode-subagents systems-capabilities; do
   source "$SCRIPT_DIR/lib/${lib}.sh"
 done
 
@@ -596,6 +596,10 @@ if [ "$INSTALL_CHAT" = true ] && [ "$CHAT_BRIDGE" = "kimaki" ] && [ "$LOCAL_MODE
   _kimaki_resolve_instance
 fi
 
+# Persist only declarative installation intent after environment and optional
+# component selection have settled. Credentials remain runtime-only inputs.
+installation_profile_normalize "$INSTALLATION_OPERATION_SETUP"
+
 # --skills-only early exit
 if [ "$SKILLS_ONLY" = true ]; then
   install_skills
@@ -658,4 +662,5 @@ if [ "$EXTERNAL_WORDPRESS" != true ]; then source_reconcile_sync; source_reconci
 install_chat_bridge
 if [ "$EXTERNAL_WORDPRESS" != true ]; then wordpress_service_reconcile; fi
 if [ "$EXTERNAL_WORDPRESS" != true ]; then datamachine_worker_reconcile; fi
+installation_profile_write
 print_summary

--- a/tests/installation-profile.sh
+++ b/tests/installation-profile.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Credential-free profile persistence is shared by setup and upgrade.
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+source "$ROOT_DIR/lib/desired-state-reconciler.sh"
+
+SITE_PATH="$TMP/site"
+mkdir -p "$SITE_PATH"
+LOCAL_MODE=true
+EXTERNAL_WORDPRESS=false
+IS_STUDIO=true
+SOURCE_MODE=workspace
+RUNTIME=opencode
+CHAT_BRIDGE=kimaki
+HOMEBOY_MODE=enabled
+DRY_RUN=false
+KIMAKI_BOT_TOKEN='must-not-be-persisted'
+WP_CONTROL_TRANSPORT_JSON='["ssh","host","secret"]'
+
+installation_profile_normalize "$INSTALLATION_OPERATION_SETUP"
+installation_profile_write
+
+PROFILE="$(installation_profile_file)"
+test -f "$PROFILE"
+if stat -f '%Lp' "$PROFILE" >/dev/null 2>&1; then
+  test "$(stat -f '%Lp' "$PROFILE")" = 600
+else
+  test "$(stat -c '%a' "$PROFILE")" = 600
+fi
+if grep -Eq 'TOKEN|TRANSPORT|secret|must-not-be-persisted' "$PROFILE"; then
+  echo "FAIL: profile persisted credential or command transport material" >&2
+  exit 1
+fi
+
+SOURCE_MODE=""
+RUNTIME=""
+CHAT_BRIDGE=""
+HOMEBOY_MODE=auto
+SOURCE_MODE_EXPLICIT=false
+installation_profile_load
+test "$SOURCE_MODE" = workspace
+test "$RUNTIME" = opencode
+test "$CHAT_BRIDGE" = kimaki
+test "$HOMEBOY_MODE" = enabled
+
+# Explicit command-line intent remains authoritative over persisted defaults.
+RUNTIME=codex
+installation_profile_load
+test "$RUNTIME" = codex
+
+echo "PASS: credential-free installation profile persists declarative intent"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -414,6 +414,9 @@ if [ "$PLUGINS_ONLY" = true ]; then
   detect_plugins_only_environment
   installation_profile_normalize "$INSTALLATION_OPERATION_PLUGINS_ONLY"
 else
+  # Load declarative setup intent before runtime selection and source-policy
+  # resolution. The profile never contains transport argv, tokens, or secrets.
+  installation_profile_load
   # Auto-detect runtime(s). Same model as setup.sh: DETECTED_RUNTIMES is the
   # full list (drives multi-runtime skills install); RUNTIME is the primary
   # (first-match cascade: claude-code > opencode > codex). Explicit --runtime
@@ -464,6 +467,7 @@ if [ "$PLUGINS_ONLY" != true ]; then
   source_policy_record_log_paths
 fi
 systems_capabilities_resolve_profile
+installation_profile_normalize "$INSTALLATION_OPERATION_UPGRADE"
 
 # Detect chat bridge from installed services / installed binaries via the
 # bridges/_dispatch.sh registry walk. See bridge_detect_local /
@@ -1592,6 +1596,9 @@ update_chat_bridge_launchd
 reconcile_wordpress_service
 reconcile_datamachine_worker_service
 refresh_opencode_runtime_signature_phase
+if [ "$PLUGINS_ONLY" != true ]; then
+  installation_profile_write
+fi
 print_summary
 if [ "$PLUGINS_ONLY" = true ]; then
   exit "$PLUGIN_ONLY_EXIT_STATUS"


### PR DESCRIPTION
## Summary

- classify the desired-state reconciler as the owning #455 architecture boundary
- persist an allowlisted, credential-free declarative installation profile from setup
- load installed intent before upgrade runtime and source-policy resolution
- preserve the merged `--plugins-only` desired-state slice unchanged

This is the next bounded #455 prerequisite; component adapter migration remains separately reviewable.

## Validation

- `bash tests/installation-profile.sh`
- `bash tests/plugins-only-scope.sh`
- `bash tests/plugin-upgrade-bounds.sh`
- `bash tests/ci-coverage.sh`
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` implemented and verified profile persistence. OpenCode with OpenAI GPT-5.6 Sol recovered the commits after #550 merged concurrently, rebased them into this focused branch, reran verification, and prepared this pull request under Chris Huber’s direction.