### PR TITLE
docs: classify desired-state reconciler

### DIFF
--- a/docs/data-machine-code-migration-inventory.json
+++ b/docs/data-machine-code-migration-inventory.json
@@ -407,6 +407,21 @@
       "verification_gate": "No install/update/discovery call references DMC; explicit components converge through shared reconciler"
     },
     {
+      "id": "wca-desired-state-reconciler",
+      "subsystem": null,
+      "surface": "Credential-free plugins-only operation profile and named plan/apply/verify records",
+      "source": { "repository": "wp-coding-agents", "path": "lib/desired-state-reconciler.sh", "symbol_or_command": "installation_profile_normalize; reconciler_plan_add; reconciler_apply_plan; reconciler_verify_plan" },
+      "evidence_kind": "upgrade",
+      "contracts": ["data-machine-code"],
+      "current_owner": "wp-coding-agents",
+      "current_consumers": ["upgrade.sh --plugins-only"],
+      "persistence": "None; the normalized operation profile and plan exist for one invocation",
+      "target_owner": "wp-coding-agents",
+      "disposition": "replace",
+      "migration_issue": "#455, #525",
+      "verification_gate": "The normalized profile is sole component authority and plugins-only updates only installed setup-managed plugins with bounded replay evidence"
+    },
+    {
       "id": "wca-plugin-upgrade",
       "subsystem": null,
       "surface": "DMC plugin entrypoint/version mapping",
@@ -858,6 +873,21 @@
       "verification_gate": "Generic plugin bounds remain covered after DMC-specific cases are removed"
     },
     {
+      "id": "test-plugins-only-reconciler",
+      "subsystem": null,
+      "surface": "Plugins-only desired-state component authority and phase isolation",
+      "source": { "repository": "wp-coding-agents", "path": "tests/plugins-only-scope.sh", "symbol_or_command": "installation_profile_normalize; reconcile_installed_plugins" },
+      "evidence_kind": "test",
+      "contracts": ["data-machine-code"],
+      "current_owner": "wp-coding-agents tests",
+      "current_consumers": ["CI"],
+      "persistence": "Temporary plugin checkout fixtures",
+      "target_owner": "wp-coding-agents",
+      "disposition": "replace",
+      "migration_issue": "#455, #525",
+      "verification_gate": "Profile-driven plugin plan remains isolated from runtime, bridge, Homeboy, guidance, and service reconciliation"
+    },
+    {
       "id": "test-owned-source-discovery",
       "subsystem": null,
       "surface": "DMC carried-plugin source discovery fixtures",
@@ -1161,10 +1191,10 @@
   ],
   "reference_file_classification": {
     "runtime": [
-      "setup.sh", "upgrade.sh", "lib/data-machine.sh", "lib/homeboy.sh", "lib/plugin-upgrade.sh", "lib/source-policy.sh", "lib/owned-source-discovery.sh", "lib/runtime-signature.sh", "lib/systems-capabilities.sh", "lib/cli-channel.sh", "lib/summary.sh", "runtimes/opencode.sh", "runtimes/claude-code.sh", "bridges/kimaki.sh", "templates/wp-coding-agents-homeboy-worktrees.php", "templates/wp-coding-agents-cli-transport.php", "templates/wp-coding-agents-source-reconcile.php"
+      "setup.sh", "upgrade.sh", "lib/data-machine.sh", "lib/desired-state-reconciler.sh", "lib/homeboy.sh", "lib/plugin-upgrade.sh", "lib/source-policy.sh", "lib/owned-source-discovery.sh", "lib/runtime-signature.sh", "lib/systems-capabilities.sh", "lib/cli-channel.sh", "lib/summary.sh", "runtimes/opencode.sh", "runtimes/claude-code.sh", "bridges/kimaki.sh", "templates/wp-coding-agents-homeboy-worktrees.php", "templates/wp-coding-agents-cli-transport.php", "templates/wp-coding-agents-source-reconcile.php"
     ],
     "tests": [
-      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/worktree-context-projections.sh"
+      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/plugins-only-scope.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/worktree-context-projections.sh"
     ],
     "guidance": [
       "README.md", "guidance/homeboy.sh", "skills/upgrade-wp-coding-agents/SKILL.md", "operator-entrypoints/wp-coding-agents-setup/verify.md"


### PR DESCRIPTION
## Summary

- classify the desired-state reconciler and plugins-only fixture in the DMC migration inventory
- restore the required inventory gate after #550 introduced two new DMC reference files

Follow-up to #550. Refs #455 and #525.

## Validation

- `bash tests/dmc-migration-inventory.sh`
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the post-merge inventory failure, added the required machine-checkable evidence rows and classifications, and validated the isolated repair under Chris Huber's direction.