### PR TITLE
Test disabled Homeboy managed-release cleanup

### DIFF
--- a/tests/dmc-managed-release-integration.sh
+++ b/tests/dmc-managed-release-integration.sh
@@ -42,6 +42,16 @@ source "$ROOT_DIR/lib/integration-adapters.sh"
 log() { :; }
 warn() { :; }
 error() { fail "$1"; }
+setup_homeboy_project() { :; }
+configure_homeboy_worktree_ownership() { :; }
+configure_homeboy_wordpress_extension() { :; }
+homeboy_required() { return 1; }
+wp_cmd() {
+  case "$1 $2" in
+    'option list') printf '0\n' ;;
+    *) return 1 ;;
+  esac
+}
 DRY_RUN=false
 INSTALLATION_PROFILE_SITE_PATH="$SITE_PATH"
 INSTALLATION_PROFILE_EXTERNAL_WORDPRESS=false


### PR DESCRIPTION
## Summary

- provide the isolated managed-release fixture with the disabled-Homeboy owner boundary introduced by #554
- verify the absent Homeboy availability option through the fixture WP transport
- restore the `dmc-managed-release-integration` CI gate after #554 merged

## Verification

- `bash tests/dmc-managed-release-integration.sh`
- `bash tests/integration-adapters.sh`
- `bash tests/convergence-orchestrator.sh`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the post-merge CI failure, added the isolated fixture boundary, and prepared this pull request under Chris Huber direction.