### PR TITLE
Add focused WordPress integration package

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -94,6 +94,14 @@ jobs:
       - name: Run tests/smoke-cli-transport.php
         run: php tests/smoke-cli-transport.php
 
+  wordpress-integration-package:
+    name: WordPress integration package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests/wordpress-integration-package.php
+        run: php -d zend.assertions=1 -d assert.exception=1 tests/wordpress-integration-package.php
+
   inbound-event-bridge:
     name: durable inbound event bridge
     runs-on: ubuntu-latest

--- a/carried-plugins/ai-provider-for-claude-code/.wp-coding-agents-carried
+++ b/carried-plugins/ai-provider-for-claude-code/.wp-coding-agents-carried
@@ -1,0 +1,1 @@
+wp-coding-agents/carried-plugin/v1

--- a/carried-plugins/wp-coding-agents-integration/.wp-coding-agents-carried
+++ b/carried-plugins/wp-coding-agents-integration/.wp-coding-agents-carried
@@ -1,0 +1,1 @@
+wp-coding-agents/carried-plugin/v1

--- a/carried-plugins/wp-coding-agents-integration/src/HostCapabilities.php
+++ b/carried-plugins/wp-coding-agents-integration/src/HostCapabilities.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Host capability probes used by WordPress-resident integrations.
+ *
+ * @package WpCodingAgents\Integration
+ */
+
+declare(strict_types=1);
+
+namespace WpCodingAgents\Integration;
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+final class HostCapabilities {
+	/**
+	 * @var array{ok: bool, reason: string, exec_available: bool, shell_exec_available: bool, proc_open_available: bool, output?: string, exit_code?: int|null}|null
+	 */
+	private static ?array $shell_diagnostic = null;
+
+	public static function has_shell(): bool {
+		return true === self::shell_diagnostic()['ok'];
+	}
+
+	/**
+	 * @return array{ok: bool, reason: string, exec_available: bool, shell_exec_available: bool, proc_open_available: bool, output?: string, exit_code?: int|null}
+	 */
+	public static function shell_diagnostic(): array {
+		if (null === self::$shell_diagnostic) {
+			self::$shell_diagnostic = self::evaluate_shell_capability(
+				static fn(string $function_name): bool => function_exists($function_name),
+				(string) ini_get('disable_functions'),
+				static function (string $command): array {
+					$output = array();
+					$exit_code = null;
+					// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Capability probe.
+					exec($command, $output, $exit_code);
+					return array('output' => $output, 'exit_code' => $exit_code);
+				}
+			);
+		}
+
+		return self::$shell_diagnostic;
+	}
+
+	/**
+	 * @param callable $function_exists Receives a function name and returns its availability.
+	 * @param callable $command_runner  Receives a command and returns output plus exit code.
+	 * @return array{ok: bool, reason: string, exec_available: bool, shell_exec_available: bool, proc_open_available: bool, output?: string, exit_code?: int|null}
+	 */
+	public static function evaluate_shell_capability(callable $function_exists, string $disabled_functions, callable $command_runner): array {
+		$disabled = array_filter(array_map('trim', explode(',', $disabled_functions)));
+		$base = array(
+			'exec_available' => self::function_available('exec', $function_exists, $disabled),
+			'shell_exec_available' => self::function_available('shell_exec', $function_exists, $disabled),
+			'proc_open_available' => self::function_available('proc_open', $function_exists, $disabled),
+		);
+
+		foreach (array('exec', 'shell_exec') as $function_name) {
+			$key = $function_name . '_available';
+			if (!$base[$key]) {
+				$reason = $function_exists($function_name) ? $function_name . '_disabled' : $function_name . '_missing';
+				return array_merge($base, array('ok' => false, 'reason' => $reason));
+			}
+		}
+
+		$marker = '__wp_coding_agents_shell_ok__';
+		$result = $command_runner('printf ' . escapeshellarg($marker) . ' 2>&1');
+		$output = trim(implode("\n", array_map('strval', $result['output'])));
+		$exit_code = $result['exit_code'];
+		if (0 !== $exit_code || $marker !== $output) {
+			return array_merge($base, array('ok' => false, 'reason' => 'probe_failed', 'output' => $output, 'exit_code' => $exit_code));
+		}
+
+		return array_merge($base, array('ok' => true, 'reason' => 'ok', 'output' => $output, 'exit_code' => $exit_code));
+	}
+
+	public static function has_writable_content_directory(): bool {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Capability probe.
+		return defined('WP_CONTENT_DIR') && is_writable(WP_CONTENT_DIR);
+	}
+
+	/**
+	 * @param string[] $disabled
+	 */
+	private static function function_available(string $function_name, callable $function_exists, array $disabled): bool {
+		return $function_exists($function_name) && !in_array($function_name, $disabled, true);
+	}
+}

--- a/carried-plugins/wp-coding-agents-integration/wp-coding-agents-integration.php
+++ b/carried-plugins/wp-coding-agents-integration/wp-coding-agents-integration.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Plugin Name: WP Coding Agents Integration
+ * Plugin URI: https://github.com/Extra-Chill/wp-coding-agents
+ * Description: Focused WordPress runtime contracts for wp-coding-agents consumers.
+ * Requires at least: 6.9
+ * Requires PHP: 7.4
+ * Version: 0.1.0
+ * Author: Extra Chill
+ * License: GPL-2.0-or-later
+ * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
+ * Text Domain: wp-coding-agents-integration
+ *
+ * @package WpCodingAgents\Integration
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+require_once __DIR__ . '/src/HostCapabilities.php';

--- a/carried-plugins/wp-coding-agents-integration/wp-coding-agents-integration.php
+++ b/carried-plugins/wp-coding-agents-integration/wp-coding-agents-integration.php
@@ -16,8 +16,27 @@
 
 declare(strict_types=1);
 
+namespace WpCodingAgents\Integration;
+
 if (!defined('ABSPATH')) {
 	exit;
 }
 
 require_once __DIR__ . '/src/HostCapabilities.php';
+
+/**
+ * Supply shell availability through Intelligence's provider-neutral contract.
+ */
+function provide_intelligence_shell_capability(bool $available): bool {
+	return $available || HostCapabilities::has_shell();
+}
+
+/**
+ * Supply writable content-directory availability through Intelligence's contract.
+ */
+function provide_intelligence_writable_content_capability(bool $available): bool {
+	return $available || HostCapabilities::has_writable_content_directory();
+}
+
+add_filter('intelligence_host_has_shell', __NAMESPACE__ . '\\provide_intelligence_shell_capability');
+add_filter('intelligence_host_has_writable_content_directory', __NAMESPACE__ . '\\provide_intelligence_writable_content_capability');

--- a/docs/data-machine-code-migration-inventory.json
+++ b/docs/data-machine-code-migration-inventory.json
@@ -1271,7 +1271,7 @@
       "Their orphaned pipelines 3, 5, and 6 were deleted after the flows",
       "Post-deletion flow and pipeline listings contain no DMC PR-review scaffold; Homeboy is the supported GitHub Actions agent path"
     ],
-    "confirmed_in_process_consumer": "Intelligence uses only shell and writable-content-directory capability checks"
+    "confirmed_in_process_consumer": "Intelligence defines fail-closed shell and writable-content-directory filters; the focused package supplies those capabilities without a package dependency in Intelligence"
   },
   "unresolved_classifications": [
     {

--- a/docs/data-machine-code-migration-inventory.json
+++ b/docs/data-machine-code-migration-inventory.json
@@ -1254,13 +1254,26 @@
     "wp datamachine pipelines list --format=json",
     "Inspect Data Machine flow steps/enabled_tools, bundle manifests, DMC tables, queued jobs, Homeboy config, and workspace metadata for the identifiers in this inventory"
   ],
+  "installed_state_results": {
+    "captured_at": "2026-08-31",
+    "installation": "/Users/chubes/Studio/intelligence-chubes4",
+    "options": "No datamachine_code_% options returned",
+    "active_hooks": [
+      "datamachine_code_ability_registration_args",
+      "datamachine_code_worktree_runtime_signatures",
+      "datamachine_code_worktree_context_projection_targets",
+      "datamachine_code_worktree_context_projection_cleanup",
+      "datamachine_code_cli_channels"
+    ],
+    "ability_query": "Unavailable because the wp ability command is not registered",
+    "pr_review_flows": [
+      "Flows 4, 6, and 7 had no jobs or completed runs and were explicitly retired on 2026-08-31",
+      "Their orphaned pipelines 3, 5, and 6 were deleted after the flows",
+      "Post-deletion flow and pipeline listings contain no DMC PR-review scaffold; Homeboy is the supported GitHub Actions agent path"
+    ],
+    "confirmed_in_process_consumer": "Intelligence uses only shell and writable-content-directory capability checks"
+  },
   "unresolved_classifications": [
-    {
-      "surface": "DMC GitHub abilities, handlers, tools, and PR-review flow",
-      "decision": "retire unless installed-state queries identify a named active shell-less consumer",
-      "required_evidence": "Representative flow, pipeline, enabled_tools, webhook, schedule, and job queries",
-      "fallback": "Open a focused extraction tracker; do not retain DMC wholesale"
-    },
     {
       "surface": "DMC ability aliases and workspace_preload artifact identifier",
       "decision": "replacement owner is known, compatibility duration is not",
@@ -1275,9 +1288,9 @@
     },
     {
       "surface": "Process-path probe WordPress facade",
-      "decision": "host helper remains wp-coding-agents-owned; WordPress facade exists only if a retained in-process consumer requires it",
-      "required_evidence": "Consumer migration design for Intelligence and any DMC RuntimeCapabilities callers",
-      "fallback": "Place the narrow facade in the #530 package, not in setup shell or Homeboy"
+      "decision": "Do not extract it into the #530 package; no retained in-process consumer was found",
+      "required_evidence": "#528 must classify the wp-coding-agents host helper independently from the retired DMC option consumer",
+      "fallback": "Add a neutral facade later only if a named consumer is demonstrated"
     }
   ]
 }

--- a/docs/data-machine-code-migration-inventory.json
+++ b/docs/data-machine-code-migration-inventory.json
@@ -1256,7 +1256,7 @@
   ],
   "installed_state_results": {
     "captured_at": "2026-08-31",
-    "installation": "/Users/chubes/Studio/intelligence-chubes4",
+    "installation": "representative local WordPress installation",
     "options": "No datamachine_code_% options returned",
     "active_hooks": [
       "datamachine_code_ability_registration_args",

--- a/docs/data-machine-code-migration-inventory.md
+++ b/docs/data-machine-code-migration-inventory.md
@@ -22,7 +22,7 @@ Each row identifies a source path and symbol or command, current owner and consu
 
 Source evidence cannot prove the contents of long-lived WordPress databases, bundle directories, queued jobs, or Homeboy configuration. Before #528 removes aliases or #525 removes DMC, run the `installed_state_queries` against representative local, VPS, Studio/external WordPress, and Homeboy-enabled installations. Record a replacement or explicit retirement for every returned DMC ability, handler, tool, flow, bundle artifact, option, table row, queue item, and external command reference.
 
-The four entries under `unresolved_classifications` are bounded decisions, not indefinite compatibility promises. If a query identifies a real shell-less GitHub/pipeline consumer, create a focused extraction tracker. Do not transplant the DMC control plane.
+The representative local census is recorded under `installed_state_results`. The three DMC PR-review flows had no jobs or completed runs and were explicitly retired with their orphaned pipelines; Homeboy is the supported GitHub Actions agent path. Intelligence's confirmed requirement is limited to shell and writable-content-directory checks, so #530 does not include the DMC process-path facade or GitHub control plane.
 
 ## Validation
 

--- a/docs/wordpress-integration-package.md
+++ b/docs/wordpress-integration-package.md
@@ -4,4 +4,4 @@
 
 Generated MU-plugins remain limited to installation governance that must always load, such as runtime registration, channel transport, inbound events, and source reconciliation. Host installation, repository policy, and Homeboy lifecycle stay outside the WordPress package.
 
-The initial package surface is `WpCodingAgents\Integration\HostCapabilities`, extracted for Intelligence's confirmed shell and writable-content-directory checks. No DMC workspace, GitHub, ability, flow, task, or lifecycle implementation is included.
+The initial package keeps `WpCodingAgents\Integration\HostCapabilities` private to the provider package and adapts its probes onto Intelligence-owned `intelligence_host_has_shell` and `intelligence_host_has_writable_content_directory` filters. Intelligence and Data Machine do not reference this package or namespace. No DMC workspace, GitHub, ability, flow, task, or lifecycle implementation is included.

--- a/docs/wordpress-integration-package.md
+++ b/docs/wordpress-integration-package.md
@@ -1,0 +1,7 @@
+# WordPress integration package
+
+`wp-coding-agents-integration` is the canonical regular WordPress plugin for retained in-process contracts owned by wp-coding-agents. It is selected through the normalized installation profile's explicit carried-plugin intent and receives normal activation and fatal-error recovery semantics.
+
+Generated MU-plugins remain limited to installation governance that must always load, such as runtime registration, channel transport, inbound events, and source reconciliation. Host installation, repository policy, and Homeboy lifecycle stay outside the WordPress package.
+
+The initial package surface is `WpCodingAgents\Integration\HostCapabilities`, extracted for Intelligence's confirmed shell and writable-content-directory checks. No DMC workspace, GitHub, ability, flow, task, or lifecycle implementation is included.

--- a/lib/carried-plugins.sh
+++ b/lib/carried-plugins.sh
@@ -3,20 +3,15 @@
 
 carried_plugin_should_install() {
   local slug="$1"
-
-  case "$slug" in
-    ai-provider-for-claude-code)
-      for runtime in "${DETECTED_RUNTIMES[@]}"; do
-        if [ "$runtime" = "claude-code" ]; then
-          return 0
-        fi
-      done
-      [ "${RUNTIME:-}" = "claude-code" ] && return 0
-      return 1
-      ;;
-  esac
-
+  local desired
+  for desired in "${INSTALLATION_PROFILE_CARRIED_PLUGINS[@]:-}"; do
+    [ "$desired" = "$slug" ] && return 0
+  done
   return 1
+}
+
+carried_plugin_is_managed() {
+  [ -f "$1/.wp-coding-agents-carried" ]
 }
 
 sync_carried_plugins() {
@@ -28,11 +23,37 @@ sync_carried_plugins() {
     [ -d "$source_dir" ] || continue
     slug=$(basename "$source_dir")
 
+    target_dir="$SITE_PATH/wp-content/plugins/$slug"
     if ! carried_plugin_should_install "$slug"; then
+      carried_plugin_is_managed "$target_dir" || continue
+      log "Removing undesired carried plugin: $slug"
+      if [ "$DRY_RUN" = true ]; then
+        if [ "${MULTISITE:-false}" = true ]; then
+          echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) plugin deactivate $slug --network --path=$SITE_PATH $WP_ROOT_FLAG"
+          echo -e "${BLUE}[dry-run]${NC} Would deactivate $slug on every multisite site before removal"
+        fi
+        echo -e "${BLUE}[dry-run]${NC} $(wp_cli_transport_display) plugin deactivate $slug --path=$SITE_PATH $WP_ROOT_FLAG"
+        echo -e "${BLUE}[dry-run]${NC} rm -rf $target_dir"
+        continue
+      fi
+      if [ "${MULTISITE:-false}" = true ]; then
+        wp_cmd plugin deactivate "$slug" --network >/dev/null || return $?
+        local site_urls site_url
+        site_urls="$(wp_cmd site list --field=url)" || return $?
+        while IFS= read -r site_url; do
+          [ -n "$site_url" ] || continue
+          wp_cmd plugin deactivate "$slug" --url="$site_url" >/dev/null || return $?
+        done <<< "$site_urls"
+      else
+        wp_cmd plugin deactivate "$slug" >/dev/null || return $?
+      fi
+      rm -rf "$target_dir"
+      if declare -p UPDATED_ITEMS >/dev/null 2>&1; then
+        UPDATED_ITEMS+=("removed carried plugin $slug")
+      fi
       continue
     fi
 
-    target_dir="$SITE_PATH/wp-content/plugins/$slug"
     log "Syncing carried plugin: $slug"
 
     if [ "$DRY_RUN" = true ]; then

--- a/lib/desired-state-reconciler.sh
+++ b/lib/desired-state-reconciler.sh
@@ -62,6 +62,14 @@ installation_profile_normalize() {
   fi
   INSTALLATION_PROFILE_HOMEBOY_MODE="${HOMEBOY_MODE:-auto}"
   INSTALLATION_PROFILE_PLUGIN_CANDIDATES=(data-machine data-machine-code wp-codebox)
+  INSTALLATION_PROFILE_CARRIED_PLUGINS=()
+  if [ "$INSTALLATION_PROFILE_EXTERNAL_WORDPRESS" != true ]; then
+    INSTALLATION_PROFILE_CARRIED_PLUGINS+=(wp-coding-agents-integration)
+    local runtime
+    for runtime in "${DETECTED_RUNTIMES[@]:-${INSTALLATION_PROFILE_RUNTIME}}"; do
+      [ "$runtime" = claude-code ] && INSTALLATION_PROFILE_CARRIED_PLUGINS+=(ai-provider-for-claude-code)
+    done
+  fi
   if [ "$operation" = "$INSTALLATION_OPERATION_PLUGINS_ONLY" ]; then
     INSTALLATION_PROFILE_COMPONENTS=(plugins)
   else

--- a/lib/integration-adapters.sh
+++ b/lib/integration-adapters.sh
@@ -24,11 +24,12 @@ integration_adapters_detect() {
 
   if [ -d "${SCRIPT_DIR:-.}/carried-plugins" ] && \
      declare -F carried_plugin_should_install >/dev/null 2>&1; then
-    local source_dir slug
+    local source_dir slug target_dir
     for source_dir in "${SCRIPT_DIR:-.}/carried-plugins"/*; do
       [ -d "$source_dir" ] || continue
       slug="${source_dir##*/}"
-      if carried_plugin_should_install "$slug"; then
+      target_dir="$site_path/wp-content/plugins/$slug"
+      if carried_plugin_should_install "$slug" || carried_plugin_is_managed "$target_dir"; then
         INTEGRATION_ADAPTER_RECORDS+=("integrations.carried-plugin.$slug")
       fi
     done
@@ -107,14 +108,21 @@ _integration_adapter_sync_carried_plugins() {
 }
 
 _integration_adapter_verify_carried_plugins() {
-  local record slug
-  for record in "${INTEGRATION_ADAPTER_RECORDS[@]}"; do
-    case "$record" in
-      integrations.carried-plugin.*)
-        slug="${record##*.}"
-        [ -d "$SITE_PATH/wp-content/plugins/$slug" ] || return 1
-        ;;
-    esac
+  [ "${DRY_RUN:-false}" = true ] && return 0
+  local source_dir slug target_dir
+  for source_dir in "${SCRIPT_DIR:-.}/carried-plugins"/*; do
+    [ -d "$source_dir" ] || continue
+    slug="${source_dir##*/}"
+    target_dir="$SITE_PATH/wp-content/plugins/$slug"
+    if carried_plugin_should_install "$slug"; then
+      [ -d "$target_dir" ] || return 1
+      wp_cmd plugin is-active "$slug" >/dev/null 2>&1 || return 1
+      if [ "$slug" = wp-coding-agents-integration ]; then
+        wp_cmd eval 'exit(class_exists("\\WpCodingAgents\\Integration\\HostCapabilities") ? 0 : 1);' >/dev/null 2>&1 || return 1
+      fi
+    elif carried_plugin_is_managed "$target_dir"; then
+      return 1
+    fi
   done
 }
 

--- a/lib/integration-adapters.sh
+++ b/lib/integration-adapters.sh
@@ -118,7 +118,7 @@ _integration_adapter_verify_carried_plugins() {
       [ -d "$target_dir" ] || return 1
       wp_cmd plugin is-active "$slug" >/dev/null 2>&1 || return 1
       if [ "$slug" = wp-coding-agents-integration ]; then
-        wp_cmd eval 'exit(class_exists("\\WpCodingAgents\\Integration\\HostCapabilities") ? 0 : 1);' >/dev/null 2>&1 || return 1
+        wp_cmd eval 'exit(false !== has_filter("intelligence_host_has_shell", "WpCodingAgents\\Integration\\provide_intelligence_shell_capability") && false !== has_filter("intelligence_host_has_writable_content_directory", "WpCodingAgents\\Integration\\provide_intelligence_writable_content_capability") ? 0 : 1);' >/dev/null 2>&1 || return 1
       fi
     elif carried_plugin_is_managed "$target_dir"; then
       return 1

--- a/lib/owned-source-discovery.sh
+++ b/lib/owned-source-discovery.sh
@@ -82,6 +82,8 @@ owned_discovery_carried_plugins() {
 data-machine
 data-machine-code
 wp-codebox
+wp-coding-agents-integration
+ai-provider-for-claude-code
 EOF
 }
 

--- a/templates/wp-coding-agents-source-reconcile.php
+++ b/templates/wp-coding-agents-source-reconcile.php
@@ -74,9 +74,15 @@ if ( ! defined( 'WP_CODING_AGENTS_INVENTORY_OPTION' ) ) {
  * @return string[]
  */
 function wp_coding_agents_carried_slugs() {
+	$slugs = array( 'data-machine', 'data-machine-code', 'wp-codebox' );
+	$plugin_dir = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : ABSPATH . 'wp-content/plugins';
+	foreach ( glob( $plugin_dir . '/*/.wp-coding-agents-carried' ) ?: array() as $marker ) {
+		$slugs[] = basename( dirname( $marker ) );
+	}
+
 	return apply_filters(
 		'wp_coding_agents_carried_slugs',
-		array( 'data-machine', 'data-machine-code', 'wp-codebox' )
+		array_values( array_unique( $slugs ) )
 	);
 }
 

--- a/tests/carried-claude-code-plugin.sh
+++ b/tests/carried-claude-code-plugin.sh
@@ -43,11 +43,12 @@ source "$SCRIPT_DIR/lib/carried-plugins.sh"
 
 DETECTED_RUNTIMES=(claude-code)
 RUNTIME=claude-code
+INSTALLATION_PROFILE_CARRIED_PLUGINS=(wp-coding-agents-integration ai-provider-for-claude-code)
 
 output="$(sync_carried_plugins)"
 
 case "$output" in
-  *"Syncing carried plugin: ai-provider-for-claude-code"*"rsync -a --no-perms --no-owner --no-group --omit-dir-times --delete"*"wp plugin activate ai-provider-for-claude-code"*) ;;
+  *"Syncing carried plugin: ai-provider-for-claude-code"*"wp plugin activate ai-provider-for-claude-code"*"Syncing carried plugin: wp-coding-agents-integration"*"wp plugin activate wp-coding-agents-integration"*) ;;
   *)
     printf 'Expected Claude Code carried plugin sync, got:\n%s\n' "$output" >&2
     exit 1
@@ -56,11 +57,53 @@ esac
 
 DETECTED_RUNTIMES=(opencode)
 RUNTIME=opencode
+INSTALLATION_PROFILE_CARRIED_PLUGINS=(wp-coding-agents-integration)
+mkdir -p "$SITE_PATH/wp-content/plugins/ai-provider-for-claude-code"
+printf 'wp-coding-agents/carried-plugin/v1\n' > "$SITE_PATH/wp-content/plugins/ai-provider-for-claude-code/.wp-coding-agents-carried"
 
 output="$(sync_carried_plugins)"
-if [ -n "$output" ]; then
-  printf 'Expected no carried plugin sync for opencode, got:\n%s\n' "$output" >&2
+case "$output" in
+  *"Removing undesired carried plugin: ai-provider-for-claude-code"*"plugin deactivate ai-provider-for-claude-code"*"Syncing carried plugin: wp-coding-agents-integration"*) ;;
+  *) printf 'Expected the WordPress integration package for opencode, got:\n%s\n' "$output" >&2; exit 1 ;;
+esac
+
+# Removal fails closed when WordPress cannot deactivate the managed plugin.
+DRY_RUN=false
+MULTISITE=false
+wp_cmd() { return 1; }
+activate_plugin() { :; }
+fix_ownership() { :; }
+if sync_carried_plugins >/dev/null 2>&1; then
+  printf 'Expected failed plugin deactivation to fail reconciliation.\n' >&2
   exit 1
 fi
+if [ ! -f "$SITE_PATH/wp-content/plugins/ai-provider-for-claude-code/.wp-coding-agents-carried" ]; then
+  printf 'Failed deactivation removed the managed plugin files.\n' >&2
+  exit 1
+fi
+
+# Multisite removal deactivates the plugin network-wide and on every site.
+MULTISITE=true
+WP_TRACE="$TMP/wp-trace"
+wp_cmd() {
+  printf '%s\n' "$*" >> "$WP_TRACE"
+  if [ "$1 $2 $3" = "site list --field=url" ]; then
+    printf '%s\n' 'https://one.example/' 'https://two.example/'
+  fi
+}
+sync_carried_plugins >/dev/null
+if [ -e "$SITE_PATH/wp-content/plugins/ai-provider-for-claude-code" ]; then
+  printf 'Multisite reconciliation retained an undesired managed plugin.\n' >&2
+  exit 1
+fi
+for expected in \
+  'plugin deactivate ai-provider-for-claude-code --network' \
+  'plugin deactivate ai-provider-for-claude-code --url=https://one.example/' \
+  'plugin deactivate ai-provider-for-claude-code --url=https://two.example/'; do
+  if ! grep -qF "$expected" "$WP_TRACE"; then
+    printf 'Missing multisite deactivation: %s\n' "$expected" >&2
+    exit 1
+  fi
+done
 
 echo "PASS: tests/carried-claude-code-plugin.sh"

--- a/tests/ci-coverage.sh
+++ b/tests/ci-coverage.sh
@@ -85,7 +85,7 @@ fi
 
 # Non-shell suites are invoked directly by their own jobs; assert the ones that
 # exist stay wired, since they are the easiest to lose in a restructure.
-for other in tests/dm-agent-sync.mjs tests/setup-profile-compiler.mjs tests/smoke-cli-transport.php tests/smoke-inbound-event-bridge.php; do
+for other in tests/dm-agent-sync.mjs tests/setup-profile-compiler.mjs tests/smoke-cli-transport.php tests/smoke-inbound-event-bridge.php tests/wordpress-integration-package.php; do
   [ -e "$other" ] || continue
   case "$workflow_text" in
     *"$(basename "$other")"*) echo "  ok   $(basename "$other") is referenced" ;;

--- a/tests/integration-adapters.sh
+++ b/tests/integration-adapters.sh
@@ -21,12 +21,15 @@ homeboy_required() { return 1; }
 wp_cmd() {
   case "$1 $2" in
     'option list') printf '0\n' ;;
+    'plugin is-active') return 0 ;;
+    'eval exit(class_exists("\\WpCodingAgents\\Integration\\HostCapabilities") ? 0 : 1);') [ "${HOST_CAPABILITIES_AVAILABLE:-true}" = true ] ;;
     *) return 1 ;;
   esac
 }
 sync_carried_plugins() {
   printf 'sync\n' >> "$CARRIED_TRACE"
   mkdir -p "$SITE_PATH/wp-content/plugins/ai-provider-for-claude-code"
+  mkdir -p "$SITE_PATH/wp-content/plugins/wp-coding-agents-integration"
 }
 
 SCRIPT_DIR="$ROOT_DIR"
@@ -36,6 +39,7 @@ INSTALLATION_PROFILE_EXTERNAL_WORDPRESS=false
 INSTALLATION_PROFILE_HOMEBOY_MODE=disabled
 RUNTIME=claude-code
 DETECTED_RUNTIMES=(claude-code)
+INSTALLATION_PROFILE_CARRIED_PLUGINS=(wp-coding-agents-integration ai-provider-for-claude-code)
 DRY_RUN=false
 CARRIED_TRACE="$TMP/carried-sync"
 HOMEBOY_TRACE="$TMP/homeboy-sync"
@@ -52,7 +56,7 @@ INSTALLATION_PROFILE_OPERATION=upgrade
 integration_adapters_detect
 [ "$setup_records" = "${INTEGRATION_ADAPTER_RECORDS[*]}" ] || fail "setup and upgrade derived different records"
 case "$setup_records" in
-  *"integrations.dmc-managed-release-cleanup"*"integrations.dmc-copied-release"*"integrations.carried-plugin.ai-provider-for-claude-code"*) ;;
+  *"integrations.dmc-managed-release-cleanup"*"integrations.dmc-copied-release"*"integrations.carried-plugin.ai-provider-for-claude-code"*"integrations.carried-plugin.wp-coding-agents-integration"*) ;;
   *) fail "expected managed-release, copied-DMC, and carried-plugin records" ;;
 esac
 
@@ -62,7 +66,11 @@ integration_adapters_apply
 [ ! -e "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-dmc-managed-release.php" ] || fail "managed-release cleanup was not applied"
 [ -f "$SITE_PATH/wp-content/plugins/data-machine-code/HOMEBOY_DEPLOYED" ] || fail "copied DMC was changed"
 [ -d "$SITE_PATH/wp-content/plugins/ai-provider-for-claude-code" ] || fail "carried provider was not applied"
+[ -d "$SITE_PATH/wp-content/plugins/wp-coding-agents-integration" ] || fail "WordPress integration package was not applied"
 [ "$(grep -c '^homeboy$' "$HOMEBOY_TRACE")" -eq 1 ] || fail "disabled Homeboy cleanup was not applied"
+HOST_CAPABILITIES_AVAILABLE=false
+if _integration_adapter_verify_carried_plugins; then fail "missing integration package runtime contract passed verification"; fi
+HOST_CAPABILITIES_AVAILABLE=true
 
 # Multiple eligible carried sources are one aggregate desired-state effect.
 mkdir -p "$TMP/carried-plugins/one" "$TMP/carried-plugins/two"
@@ -83,8 +91,10 @@ INSTALLATION_PROFILE_HOMEBOY_MODE=auto
 # Keep core utilities available while removing the test-local fake Homeboy path.
 PATH="/usr/bin:/bin"
 integration_adapters_detect
-[ "${#INTEGRATION_ADAPTER_RECORDS[@]}" -eq 2 ] || fail "absent Homeboy cleanup was not planned"
-[ "${INTEGRATION_ADAPTER_RECORDS[1]}" = "integrations.homeboy" ] || fail "Homeboy cleanup record missing"
+case "${INTEGRATION_ADAPTER_RECORDS[*]}" in
+  *"integrations.homeboy") ;;
+  *) fail "Homeboy cleanup record missing" ;;
+esac
 
 # Verification reads Homeboy's command-result envelope and rejects a nested
 # legacy DMC provider rather than treating the envelope root as config.

--- a/tests/integration-adapters.sh
+++ b/tests/integration-adapters.sh
@@ -22,7 +22,7 @@ wp_cmd() {
   case "$1 $2" in
     'option list') printf '0\n' ;;
     'plugin is-active') return 0 ;;
-    'eval exit(class_exists("\\WpCodingAgents\\Integration\\HostCapabilities") ? 0 : 1);') [ "${HOST_CAPABILITIES_AVAILABLE:-true}" = true ] ;;
+    'eval exit(false !== has_filter("intelligence_host_has_shell", "WpCodingAgents\\Integration\\provide_intelligence_shell_capability") && false !== has_filter("intelligence_host_has_writable_content_directory", "WpCodingAgents\\Integration\\provide_intelligence_writable_content_capability") ? 0 : 1);') [ "${HOST_CAPABILITIES_AVAILABLE:-true}" = true ] ;;
     *) return 1 ;;
   esac
 }
@@ -69,7 +69,7 @@ integration_adapters_apply
 [ -d "$SITE_PATH/wp-content/plugins/wp-coding-agents-integration" ] || fail "WordPress integration package was not applied"
 [ "$(grep -c '^homeboy$' "$HOMEBOY_TRACE")" -eq 1 ] || fail "disabled Homeboy cleanup was not applied"
 HOST_CAPABILITIES_AVAILABLE=false
-if _integration_adapter_verify_carried_plugins; then fail "missing integration package runtime contract passed verification"; fi
+if _integration_adapter_verify_carried_plugins; then fail "missing integration hook adapters passed verification"; fi
 HOST_CAPABILITIES_AVAILABLE=true
 
 # Multiple eligible carried sources are one aggregate desired-state effect.

--- a/tests/owned-source-discovery.sh
+++ b/tests/owned-source-discovery.sh
@@ -121,7 +121,7 @@ refute_line "$DERIVED" "wp-content/themes/twentytwentyfive" "excludes a wp.org b
 
 # The agent's own runtime is replaced wholesale by the next upgrade, and
 # capturing it would commit this project's source into the site's repository.
-for p in data-machine data-machine-code wp-codebox; do
+for p in data-machine data-machine-code wp-codebox wp-coding-agents-integration ai-provider-for-claude-code; do
   refute_line "$DERIVED" "wp-content/plugins/$p" "excludes carried plugin $p"
 done
 

--- a/tests/wordpress-integration-package.php
+++ b/tests/wordpress-integration-package.php
@@ -5,11 +5,31 @@ declare(strict_types=1);
 define('ABSPATH', __DIR__);
 define('WP_CONTENT_DIR', __DIR__);
 
+$GLOBALS['wp_coding_agents_test_filters'] = array();
+function add_filter(string $hook, callable $callback): void {
+	$GLOBALS['wp_coding_agents_test_filters'][$hook][] = $callback;
+}
+
+function apply_filters(string $hook, $value) {
+	foreach ($GLOBALS['wp_coding_agents_test_filters'][$hook] ?? array() as $callback) {
+		$value = $callback($value);
+	}
+	return $value;
+}
+
 require_once dirname(__DIR__) . '/carried-plugins/wp-coding-agents-integration/wp-coding-agents-integration.php';
 
 use WpCodingAgents\Integration\HostCapabilities;
 
 assert(class_exists(HostCapabilities::class));
+assert(isset($GLOBALS['wp_coding_agents_test_filters']['intelligence_host_has_shell']));
+assert(isset($GLOBALS['wp_coding_agents_test_filters']['intelligence_host_has_writable_content_directory']));
+assert(
+	'WpCodingAgents\\Integration\\provide_intelligence_shell_capability'
+	=== $GLOBALS['wp_coding_agents_test_filters']['intelligence_host_has_shell'][0]
+);
+assert(true === apply_filters('intelligence_host_has_shell', true));
+assert(true === apply_filters('intelligence_host_has_writable_content_directory', false));
 
 $available = static fn(string $function_name): bool => in_array($function_name, array('exec', 'shell_exec', 'proc_open'), true);
 $success = static fn(string $command): array => array(

--- a/tests/wordpress-integration-package.php
+++ b/tests/wordpress-integration-package.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+define('ABSPATH', __DIR__);
+define('WP_CONTENT_DIR', __DIR__);
+
+require_once dirname(__DIR__) . '/carried-plugins/wp-coding-agents-integration/wp-coding-agents-integration.php';
+
+use WpCodingAgents\Integration\HostCapabilities;
+
+assert(class_exists(HostCapabilities::class));
+
+$available = static fn(string $function_name): bool => in_array($function_name, array('exec', 'shell_exec', 'proc_open'), true);
+$success = static fn(string $command): array => array(
+	'output' => array('__wp_coding_agents_shell_ok__'),
+	'exit_code' => 0,
+);
+
+$diagnostic = HostCapabilities::evaluate_shell_capability($available, '', $success);
+assert(true === $diagnostic['ok']);
+assert(true === $diagnostic['proc_open_available']);
+assert(true === HostCapabilities::has_writable_content_directory());
+
+$disabled = HostCapabilities::evaluate_shell_capability($available, 'shell_exec', $success);
+assert(false === $disabled['ok']);
+assert('shell_exec_disabled' === $disabled['reason']);
+
+$failed = HostCapabilities::evaluate_shell_capability(
+	$available,
+	'',
+	static fn(string $command): array => array('output' => array('wrong'), 'exit_code' => 0)
+);
+assert(false === $failed['ok']);
+assert('probe_failed' === $failed['reason']);
+
+echo "PASS: focused WordPress integration host capabilities\n";


### PR DESCRIPTION
## Summary
- add `wp-coding-agents-integration` as the canonical regular plugin for retained WordPress runtime adapters
- keep host probes private to the provider and expose them through Intelligence-owned, fail-closed filters
- derive carried-plugin installation and removal from explicit profile intent, with fail-closed single-site and multisite cleanup
- record the representative DMC census and retirement of the unused PR-review flows

Intelligence and Data Machine do not reference this package or its PHP namespace.

## Verification
- `bash tests/carried-claude-code-plugin.sh`
- `bash tests/integration-adapters.sh`
- `bash tests/installation-profile.sh`
- `bash tests/source-reconcile.sh`
- `bash tests/dmc-migration-inventory.sh`
- `php -d zend.assertions=1 -d assert.exception=1 tests/wordpress-integration-package.php`
- `shellcheck lib/carried-plugins.sh lib/desired-state-reconciler.sh lib/integration-adapters.sh`
- independent final code review found no remaining production defects

Closes #530.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode performed the installed-state census, implemented the focused provider and hook adapters, added verification coverage, and reviewed the final diff under Chris Huber's direction.