### PR TITLE
Add the required DMC-free workspace gate

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -297,6 +297,7 @@ jobs:
           - upgrade-opencode-auth-plugin-sync
           - wordpress-service
           - worktree-context-projections
+          - workspace-installation
           - wp-cli-machine-output
           - wp-config-permissions
     steps:

--- a/docs/data-machine-code-migration-inventory.json
+++ b/docs/data-machine-code-migration-inventory.json
@@ -798,6 +798,21 @@
       "verification_gate": "Workspace-mode assertions exercise native repositories and Git with DMC absent"
     },
     {
+      "id": "test-dmc-free-workspace-installation",
+      "subsystem": null,
+      "surface": "DMC-free workspace installation fixture asserts the retired plugin and callback surface stay absent",
+      "source": { "repository": "wp-coding-agents", "path": "tests/workspace-installation.sh", "symbol_or_command": "DMC-free repository, WordPress integration, native Git, verify, and Homeboy fixture" },
+      "evidence_kind": "test",
+      "contracts": ["data-machine-code"],
+      "current_owner": "wp-coding-agents tests",
+      "current_consumers": ["CI", "#529 migration gate"],
+      "persistence": "Temporary WordPress site and Git checkout only",
+      "target_owner": "wp-coding-agents",
+      "disposition": "replace",
+      "migration_issue": "#529",
+      "verification_gate": "Required fixture proves the DMC-free workspace target and detects a broken repository-permission seam"
+    },
+    {
       "id": "test-homeboy-components",
       "subsystem": null,
       "surface": "DMC workspace primary checkout to Homeboy component mapping",
@@ -1239,7 +1254,7 @@
       "setup.sh", "upgrade.sh", "lib/data-machine.sh", "lib/desired-state-reconciler.sh", "lib/homeboy.sh", "lib/integration-adapters.sh", "lib/plugin-upgrade.sh", "lib/source-policy.sh", "lib/owned-source-discovery.sh", "lib/runtime-signature.sh", "lib/systems-capabilities.sh", "lib/cli-channel.sh", "lib/summary.sh", "runtimes/opencode.sh", "runtimes/claude-code.sh", "bridges/kimaki.sh", "templates/wp-coding-agents-homeboy-worktrees.php", "templates/wp-coding-agents-cli-transport.php", "templates/wp-coding-agents-source-reconcile.php"
     ],
     "tests": [
-      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter.sh", "tests/installation-profile.sh", "tests/integration-adapters.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/plugins-only-scope.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/worktree-context-projections.sh"
+      "tests/agents-md-composition-integration.sh", "tests/agents-md-guidance.sh", "tests/cli-channel-binary-path.sh", "tests/dm-workspace-discovery.sh", "tests/dmc-managed-release-integration.sh", "tests/dmc-managed-release.sh", "tests/homeboy-agents-md.sh", "tests/homeboy-codebox-canary.sh", "tests/homeboy-verification-guidance.sh", "tests/homeboy-worktree-adapter.sh", "tests/installation-profile.sh", "tests/integration-adapters.sh", "tests/owned-source-discovery.sh", "tests/plugin-upgrade-bounds.sh", "tests/plugins-only-scope.sh", "tests/runtime-signature.sh", "tests/service-migration.sh", "tests/smoke-cli-transport.php", "tests/source-mode.sh", "tests/systems-capabilities.sh", "tests/workspace-installation.sh", "tests/worktree-context-projections.sh"
     ],
     "guidance": [
       "README.md", "guidance/homeboy.sh", "skills/upgrade-wp-coding-agents/SKILL.md", "operator-entrypoints/wp-coding-agents-setup/verify.md"

--- a/guidance/wordpress-source.workspace.sh
+++ b/guidance/wordpress-source.workspace.sh
@@ -7,7 +7,7 @@
 # point — see the header of wordpress-source.managed.sh and #322.
 #
 # What differs from managed is only where changes land: engineering routes them
-# through a Data Machine Code workspace so they are tracked in git and reviewed.
+# through configured repositories so they are tracked in git and reviewed.
 
 guidance_id() { printf 'wordpress-source'; }
 guidance_priority() { printf '1'; }
@@ -28,6 +28,12 @@ The WordPress running this site is on disk underneath you. Read it to verify cor
 
 Grep and read these freely. They are the ground truth for how this site actually behaves.
 
-These paths are **read-only reference**. Make code changes in the configured managed workspace, not in the installed source tree.
+These paths are **read-only reference**. Make code changes in the configured repository checkout, not in the installed source tree.
 MD
+
+  local repository
+  while IFS= read -r repository; do
+    [ -n "$repository" ] || continue
+    printf '%s\n' "- \`$repository\`"
+  done < <(source_policy_workspace_repositories)
 }

--- a/lib/desired-state-reconciler.sh
+++ b/lib/desired-state-reconciler.sh
@@ -34,6 +34,7 @@ installation_profile_value() {
     install_chat) printf '%s' "$INSTALLATION_PROFILE_INSTALL_CHAT" ;;
     chat_bridge) printf '%s' "$INSTALLATION_PROFILE_CHAT_BRIDGE" ;;
     homeboy_mode) printf '%s' "$INSTALLATION_PROFILE_HOMEBOY_MODE" ;;
+    workspace_repositories) printf '%s' "$INSTALLATION_PROFILE_WORKSPACE_REPOSITORIES" ;;
     components) printf '%s' "${INSTALLATION_PROFILE_COMPONENTS[*]}" ;;
     plugin_candidates) printf '%s' "${INSTALLATION_PROFILE_PLUGIN_CANDIDATES[*]}" ;;
     *) return 1 ;;
@@ -61,6 +62,7 @@ installation_profile_normalize() {
     INSTALLATION_PROFILE_CHAT_BRIDGE=""
   fi
   INSTALLATION_PROFILE_HOMEBOY_MODE="${HOMEBOY_MODE:-auto}"
+  INSTALLATION_PROFILE_WORKSPACE_REPOSITORIES="${WORKSPACE_REPOSITORIES:-}"
   INSTALLATION_PROFILE_PLUGIN_CANDIDATES=(data-machine data-machine-code wp-codebox)
   INSTALLATION_PROFILE_CARRIED_PLUGINS=()
   if [ "$INSTALLATION_PROFILE_EXTERNAL_WORDPRESS" != true ]; then
@@ -118,7 +120,7 @@ installation_profile_write() {
     local key
     umask 077
     : > "$tmp"
-    for key in operation site_path local_mode external_wordpress studio source_mode runtime install_chat chat_bridge homeboy_mode components plugin_candidates; do
+    for key in operation site_path local_mode external_wordpress studio source_mode runtime install_chat chat_bridge homeboy_mode workspace_repositories components plugin_candidates; do
       printf '%s=%s\n' "$key" "$(installation_profile_value "$key")" >> "$tmp"
     done
     mv "$tmp" "$file"
@@ -147,6 +149,7 @@ installation_profile_load() {
         ;;
       chat_bridge) [ -n "${CHAT_BRIDGE:-}" ] || CHAT_BRIDGE="$value" ;;
       homeboy_mode) [ "${HOMEBOY_MODE:-auto}" != auto ] || HOMEBOY_MODE="$value" ;;
+      workspace_repositories) [ -n "${WORKSPACE_REPOSITORIES:-}" ] || WORKSPACE_REPOSITORIES="$value" ;;
     esac
   done < "$file"
 }

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -474,7 +474,11 @@ configure_homeboy_worktree_ownership() {
     return 0
   fi
 
-  homeboy_worktree_adapter_sync
+  # The adapter is solely an integration for an installed DMC ability surface.
+  # Homeboy's generic lifecycle ownership does not require a WordPress callback.
+  if [ -d "$SITE_PATH/wp-content/plugins/data-machine-code" ]; then
+    homeboy_worktree_adapter_sync
+  fi
 
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE}[dry-run]${NC} homeboy config remove /worktree_providers/dmc"

--- a/lib/homeboy.sh
+++ b/lib/homeboy.sh
@@ -463,6 +463,23 @@ PY
   service_file_normalize_perms "$file"
 }
 
+homeboy_worktree_adapter_remove() {
+  local file
+  file="$(homeboy_worktree_adapter_file)"
+  [ -e "$file" ] || return 0
+
+  if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would remove stale Homeboy worktree ability adapter at $file"
+    return 0
+  fi
+
+  if rm -f "$file"; then
+    [ -z "${UPDATED_ITEMS+x}" ] || UPDATED_ITEMS+=("removed stale Homeboy worktree ability adapter")
+  else
+    homeboy_handle_failure "Could not remove stale Homeboy worktree ability adapter."
+  fi
+}
+
 configure_homeboy_worktree_ownership() {
   if [ "${HOMEBOY_MODE:-auto}" = "disabled" ]; then
     log "Skipping Homeboy worktree ownership setup (--no-homeboy)"
@@ -478,6 +495,8 @@ configure_homeboy_worktree_ownership() {
   # Homeboy's generic lifecycle ownership does not require a WordPress callback.
   if [ -d "$SITE_PATH/wp-content/plugins/data-machine-code" ]; then
     homeboy_worktree_adapter_sync
+  else
+    homeboy_worktree_adapter_remove
   fi
 
   if [ "${DRY_RUN:-false}" = true ]; then

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -726,6 +726,15 @@ source_policy_workspace_enabled() {
   esac
 }
 
+# Explicit primary checkout roots for workspace mode. These are the repository
+# authority; when unset, older installs retain their existing runtime workspace.
+source_policy_workspace_repositories() {
+  source_policy_workspace_enabled || return 0
+  printf '%s\n' "${WORKSPACE_REPOSITORIES:-}" | tr ' ' '\n' | while IFS= read -r path; do
+    [ -n "$path" ] && printf '%s\n' "${path%/}"
+  done
+}
+
 # The ordered edit ruleset for the active source mode, as tab-separated
 # `<path>\t<deny|allow>` lines.
 #

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -726,11 +726,12 @@ source_policy_workspace_enabled() {
   esac
 }
 
-# Explicit primary checkout roots for workspace mode. These are the repository
-# authority; when unset, older installs retain their existing runtime workspace.
+# Explicit primary checkout roots for workspace mode, colon-separated so paths
+# remain literal when they contain spaces. These are the repository authority;
+# when unset, older installs retain their existing runtime workspace.
 source_policy_workspace_repositories() {
   source_policy_workspace_enabled || return 0
-  printf '%s\n' "${WORKSPACE_REPOSITORIES:-}" | tr ' ' '\n' | while IFS= read -r path; do
+  printf '%s\n' "${WORKSPACE_REPOSITORIES:-}" | tr ':' '\n' | while IFS= read -r path; do
     [ -n "$path" ] && printf '%s\n' "${path%/}"
   done
 }

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -237,10 +237,17 @@ runtime_generate_config() {
   # recover the site it just broke.
   local _ext_rules=""
   if source_policy_workspace_enabled; then
-    local workspace_repository
+    local workspace_repository workspace_pattern
     while IFS= read -r workspace_repository; do
       [ -n "$workspace_repository" ] || continue
-      _ext_rules="${_ext_rules}${_ext_rules:+,}\n      \"${workspace_repository}/**\": \"allow\""
+      workspace_pattern="$(python3 - "$workspace_repository/**" <<'PY'
+import json
+import sys
+
+print(json.dumps(sys.argv[1]))
+PY
+)"
+      _ext_rules="${_ext_rules}${_ext_rules:+,}\n      ${workspace_pattern}: \"allow\""
     done < <(source_policy_workspace_repositories)
     [ -n "$_ext_rules" ] || _ext_rules="\n      \"${DM_WORKSPACE_DIR}/**\": \"allow\""
   fi

--- a/runtimes/opencode.sh
+++ b/runtimes/opencode.sh
@@ -237,7 +237,12 @@ runtime_generate_config() {
   # recover the site it just broke.
   local _ext_rules=""
   if source_policy_workspace_enabled; then
-    _ext_rules="\n      \"${DM_WORKSPACE_DIR}/**\": \"allow\""
+    local workspace_repository
+    while IFS= read -r workspace_repository; do
+      [ -n "$workspace_repository" ] || continue
+      _ext_rules="${_ext_rules}${_ext_rules:+,}\n      \"${workspace_repository}/**\": \"allow\""
+    done < <(source_policy_workspace_repositories)
+    [ -n "$_ext_rules" ] || _ext_rules="\n      \"${DM_WORKSPACE_DIR}/**\": \"allow\""
   fi
   local _log_path
   while IFS= read -r _log_path; do

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -372,7 +372,7 @@ function add_filter( \$tag, \$callback, \$priority = 10 ) {
         'source_has_core' => str_contains( \$source_content, '\`wp-includes/\`' ),
         'source_has_code' => str_contains( \$source_content, '\`wp-content/plugins/\`' ) && str_contains( \$source_content, '\`wp-content/themes/\`' ),
         'source_promotes_direct_reference' => str_contains( \$source_content, 'verify core APIs, hooks, conventions, and runtime behavior instead of relying on assumptions' ),
-        'source_keeps_installed_tree_read_only' => str_contains( \$source_content, 'Make code changes in the configured managed workspace' ),
+        'source_keeps_installed_tree_read_only' => str_contains( \$source_content, 'Make code changes in the configured repository checkout' ),
         'abilities_has_tools' => str_contains( \$abilities_content, 'active runtime tool listings' ),
     ]);
 }

--- a/tests/homeboy-worktree-adapter.sh
+++ b/tests/homeboy-worktree-adapter.sh
@@ -14,7 +14,7 @@ SITE_PATH="$TMP/site"
 WORKSPACE="$TMP/workspace"
 FAKE_BIN="$TMP/bin"
 LOG="$TMP/homeboy.log"
-mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$WORKSPACE/fixture/.git" "$FAKE_BIN"
+mkdir -p "$SITE_PATH/wp-content/mu-plugins" "$SITE_PATH/wp-content/plugins/data-machine-code" "$WORKSPACE/fixture/.git" "$FAKE_BIN"
 WORKSPACE_REAL="$(cd "$WORKSPACE" && pwd -P)"
 
 cat > "$FAKE_BIN/homeboy" <<'SH'

--- a/tests/installation-profile.sh
+++ b/tests/installation-profile.sh
@@ -17,6 +17,7 @@ SOURCE_MODE=workspace
 RUNTIME=opencode
 CHAT_BRIDGE=kimaki
 HOMEBOY_MODE=enabled
+WORKSPACE_REPOSITORIES="/tmp/workspace-repository"
 INSTALL_CHAT=true
 DRY_RUN=false
 KIMAKI_BOT_TOKEN='must-not-be-persisted'
@@ -44,6 +45,7 @@ SOURCE_MODE=""
 RUNTIME=""
 CHAT_BRIDGE=""
 HOMEBOY_MODE=auto
+WORKSPACE_REPOSITORIES=""
 INSTALL_CHAT=false
 SOURCE_MODE_EXPLICIT=false
 installation_profile_load
@@ -51,6 +53,7 @@ test "$SOURCE_MODE" = workspace
 test "$RUNTIME" = opencode
 test "$CHAT_BRIDGE" = kimaki
 test "$HOMEBOY_MODE" = enabled
+test "$WORKSPACE_REPOSITORIES" = /tmp/workspace-repository
 test "$INSTALL_CHAT" = true
 
 # Explicit command-line intent remains authoritative over persisted defaults.

--- a/tests/source-mode.sh
+++ b/tests/source-mode.sh
@@ -342,7 +342,7 @@ ENG_PROSE="$(guidance_call wordpress-source render)"
 assert_eq "$(guidance_call wordpress-source id)" "wordpress-source" \
   "section id is stable across postures"
 assert_contains "$ENG_PROSE" "read-only" "workspace mode prose says read-only"
-assert_contains "$ENG_PROSE" "managed workspace" "workspace mode prose routes changes to the workspace"
+assert_contains "$ENG_PROSE" "configured repository checkout" "workspace mode prose routes changes to the configured repository"
 
 SOURCE_MODE=owned
 OWNED_SOURCES="wp-content/themes/acme
@@ -631,7 +631,7 @@ wp-content/plugins/acme-core" \
 
 # The reader is an unprivileged identity that is not us. A mode that keeps it
 # out defeats the only reason the file exists.
-assert_eq "$(stat -c '%a' "$MANI" 2>/dev/null)" "644" "manifest is world-readable"
+assert_eq "$(stat -c '%a' "$MANI" 2>/dev/null || stat -f '%Lp' "$MANI" 2>/dev/null)" "644" "manifest is world-readable"
 
 # SITE_PATH is the nginx docroot on a real install (verified on
 # h44lacrosse.com: `root /var/www/h44lacrosse.com;`). A manifest written there

--- a/tests/workspace-installation.sh
+++ b/tests/workspace-installation.sh
@@ -7,7 +7,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 SITE="$TMP/site"
-REPOSITORY="$TMP/repository"
+REPOSITORY="$TMP/repository with spaces and \"quotes\""
 BIN="$TMP/bin"
 mkdir -p "$SITE/wp-content/plugins" "$REPOSITORY" "$BIN"
 : > "$SITE/wp-config.php"
@@ -113,11 +113,13 @@ source "$ROOT/lib/homeboy.sh"
 HOMEBOY_LOG="$TMP/homeboy.log"
 HOMEBOY_PROVIDER="$TMP/provider"
 touch "$HOMEBOY_PROVIDER"
+mkdir -p "$SITE/wp-content/mu-plugins"
+printf 'stale adapter\n' > "$SITE/wp-content/mu-plugins/wp-coding-agents-homeboy-worktrees.php"
 export HOMEBOY_LOG HOMEBOY_PROVIDER PATH
 UPDATED_ITEMS=()
 configure_homeboy_worktree_ownership
 test ! -e "$HOMEBOY_PROVIDER" || fail "Homeboy retained a DMC provider"
-test ! -e "$SITE/wp-content/mu-plugins/wp-coding-agents-homeboy-worktrees.php" || fail "DMC-free Homeboy ownership installed an ability callback"
+test ! -e "$SITE/wp-content/mu-plugins/wp-coding-agents-homeboy-worktrees.php" || fail "DMC-free Homeboy ownership retained an ability callback"
 
 test ! -d "$SITE/wp-content/plugins/data-machine-code" || fail "fixture installed data-machine-code"
 echo "PASS: DMC-free workspace installation fixture"

--- a/tests/workspace-installation.sh
+++ b/tests/workspace-installation.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# A DMC-free workspace fixture: generated runtime state must be sufficient for
+# native repository work and optional Homeboy ownership.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+SITE="$TMP/site"
+REPOSITORY="$TMP/repository"
+BIN="$TMP/bin"
+mkdir -p "$SITE/wp-content/plugins" "$REPOSITORY" "$BIN"
+: > "$SITE/wp-config.php"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+git -C "$REPOSITORY" init -q
+git -C "$REPOSITORY" config user.email fixture@example.test
+git -C "$REPOSITORY" config user.name Fixture
+printf 'initial\n' > "$REPOSITORY/plugin.php"
+git -C "$REPOSITORY" add plugin.php
+git -C "$REPOSITORY" commit -qm initial
+
+# The real focused plugin remains loadable without DMC and only registers its
+# consumer-bound WordPress capability hooks.
+php -r '
+define("ABSPATH", __DIR__);
+$hooks = array();
+function add_filter($hook, $callback) { global $hooks; $hooks[$hook] = $callback; }
+require $argv[1];
+if (!isset($hooks["intelligence_host_has_shell"], $hooks["intelligence_host_has_writable_content_directory"])) exit(1);
+foreach (array_keys($hooks) as $hook) if (str_contains($hook, "datamachine")) exit(1);
+' "$ROOT/carried-plugins/wp-coding-agents-integration/wp-coding-agents-integration.php" || fail "focused WordPress integration requires DMC"
+
+source "$ROOT/lib/common.sh"
+source "$ROOT/lib/source-policy.sh"
+source "$ROOT/lib/desired-state-reconciler.sh"
+
+SITE_PATH="$SITE"
+LOCAL_MODE=true
+EXTERNAL_WORDPRESS=false
+IS_STUDIO=true
+SOURCE_MODE=workspace
+RUNTIME=opencode
+CHAT_BRIDGE=""
+HOMEBOY_MODE=enabled
+INSTALL_CHAT=false
+DRY_RUN=false
+WORKSPACE_REPOSITORIES="$REPOSITORY"
+DETECTED_RUNTIMES=()
+installation_profile_normalize "$INSTALLATION_OPERATION_SETUP"
+installation_profile_write
+
+UPDATED_ITEMS=()
+KIMAKI_DATA_DIR="$TMP/kimaki"
+DM_WORKSPACE_DIR="$TMP/not-authoritative"
+DM_AGENT_FILES=""
+WITH_CLAUDE_CODE_AUTH=false
+OPENCODE_MODEL=""
+OPENCODE_SMALL_MODEL=""
+SCRIPT_DIR="$ROOT"
+source "$ROOT/runtimes/opencode.sh"
+runtime_generate_config
+
+python3 - "$SITE/opencode.json" "$REPOSITORY" <<'PY' || fail "generated OpenCode configuration omitted repository access"
+import json, sys
+data = json.load(open(sys.argv[1]))
+assert data["permission"]["external_directory"][sys.argv[2] + "/**"] == "allow"
+assert data["permission"]["edit"]["wp-content/plugins/**"] == "deny"
+PY
+
+source "$ROOT/guidance/wordpress-source.workspace.sh"
+GUIDANCE="$(guidance_render)"
+case "$GUIDANCE" in *"read-only reference"*"$REPOSITORY"*) ;; *) fail "workspace guidance did not route to the declared repository" ;; esac
+
+printf 'changed\n' >> "$REPOSITORY/plugin.php"
+git -C "$REPOSITORY" status --short | grep -q ' M plugin.php' || fail "native Git status did not observe the edit"
+git -C "$REPOSITORY" diff -- plugin.php | grep -q '+changed' || fail "native Git diff did not contain the edit"
+git -C "$REPOSITORY" add plugin.php
+git -C "$REPOSITORY" commit -qm 'test: fixture native edit'
+test "$(git -C "$REPOSITORY" status --short)" = "" || fail "native Git commit left the repository dirty"
+
+cat > "$BIN/wp" <<'SH'
+#!/bin/bash
+case "$3" in wp_coding_agents_source_mode) echo workspace ;; esac
+SH
+chmod +x "$BIN/wp"
+PATH="$BIN:$PATH" "$ROOT/verify.sh" --site-path "$SITE" --quiet || fail "verify rejected the healthy workspace fixture"
+
+python3 - "$SITE/opencode.json" "$REPOSITORY" <<'PY'
+import json, sys
+path, repository = sys.argv[1:]
+data = json.load(open(path))
+del data["permission"]["external_directory"][repository + "/**"]
+json.dump(data, open(path, "w"))
+PY
+if PATH="$BIN:$PATH" "$ROOT/verify.sh" --site-path "$SITE" --quiet; then
+  fail "verify missed a repository permission disagreement"
+fi
+
+cat > "$BIN/homeboy" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >> "$HOMEBOY_LOG"
+case "$*" in
+  "config show /worktree_providers/dmc") test -f "$HOMEBOY_PROVIDER" ;;
+  "config remove /worktree_providers/dmc") rm -f "$HOMEBOY_PROVIDER" ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$BIN/homeboy"
+PATH="$BIN:$PATH"
+source "$ROOT/lib/homeboy.sh"
+HOMEBOY_LOG="$TMP/homeboy.log"
+HOMEBOY_PROVIDER="$TMP/provider"
+touch "$HOMEBOY_PROVIDER"
+export HOMEBOY_LOG HOMEBOY_PROVIDER PATH
+UPDATED_ITEMS=()
+configure_homeboy_worktree_ownership
+test ! -e "$HOMEBOY_PROVIDER" || fail "Homeboy retained a DMC provider"
+test ! -e "$SITE/wp-content/mu-plugins/wp-coding-agents-homeboy-worktrees.php" || fail "DMC-free Homeboy ownership installed an ability callback"
+
+test ! -d "$SITE/wp-content/plugins/data-machine-code" || fail "fixture installed data-machine-code"
+echo "PASS: DMC-free workspace installation fixture"

--- a/verify.sh
+++ b/verify.sh
@@ -164,7 +164,7 @@ PY
       else
         fail "declared repository $repository is a Git checkout but opencode.json does not allow it — native edits and Git cannot reach the declared authority"
       fi
-    done < <(printf '%s\n' "$DECLARED_WORKSPACE_REPOSITORIES" | tr ' ' '\n')
+    done < <(printf '%s\n' "$DECLARED_WORKSPACE_REPOSITORIES" | tr ':' '\n')
   fi
 fi
 

--- a/verify.sh
+++ b/verify.sh
@@ -111,6 +111,10 @@ wp_opt() {
   wp_cli option get "$1" $WP_ROOT_FLAG --path="$SITE_PATH" 2>/dev/null || true
 }
 
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || true
+}
+
 SOURCE_MODE="$(wp_opt wp_coding_agents_source_mode | tr -d '[:space:]')"
 [ -n "$SOURCE_MODE" ] || SOURCE_MODE="$(wp_opt wp_coding_agents_posture | tr -d '[:space:]')"
 case "$SOURCE_MODE" in
@@ -121,6 +125,48 @@ esac
 _say "wp-coding-agents verify"
 _say "  site:        $SITE_PATH"
 _say "  source mode: ${SOURCE_MODE:-<unset>}"
+
+# ---------------------------------------------------------------------------
+# Seam 0: workspace declarations must point at native repositories and match
+# the runtime permission surface that makes them editable.
+# ---------------------------------------------------------------------------
+
+section "workspace repository agreement"
+
+if [ "$SOURCE_MODE" != "workspace" ]; then
+  skip "not a workspace-mode install"
+else
+  PROFILE="$SITE_PATH/.wp-coding-agents/installation-profile"
+  DECLARED_WORKSPACE_REPOSITORIES=""
+  if [ -f "$PROFILE" ]; then
+    DECLARED_WORKSPACE_REPOSITORIES="$(awk -F= '$1 == "workspace_repositories" { print substr($0, index($0, "=") + 1); exit }' "$PROFILE")"
+  fi
+
+  if [ -z "$DECLARED_WORKSPACE_REPOSITORIES" ]; then
+    skip "no declared workspace repositories — cannot validate repository authority"
+  elif [ ! -f "$SITE_PATH/opencode.json" ]; then
+    fail "workspace repositories are declared but opencode.json is missing — the runtime has no configured repository access"
+  else
+    while IFS= read -r repository; do
+      [ -n "$repository" ] || continue
+      if ! git -C "$repository" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        fail "declared workspace repository $repository is not a reachable Git checkout"
+        continue
+      fi
+      if python3 - "$SITE_PATH/opencode.json" "$repository" <<'PY' >/dev/null 2>&1
+import json, sys
+data = json.load(open(sys.argv[1]))
+rules = data.get("permission", {}).get("external_directory", {})
+sys.exit(0 if rules.get(sys.argv[2] + "/**") == "allow" else 1)
+PY
+      then
+        pass "declared repository $repository is a Git checkout and OpenCode may access it"
+      else
+        fail "declared repository $repository is a Git checkout but opencode.json does not allow it — native edits and Git cannot reach the declared authority"
+      fi
+    done < <(printf '%s\n' "$DECLARED_WORKSPACE_REPOSITORIES" | tr ' ' '\n')
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Seam 1: the recorded set, the manifest, and the permissions must agree
@@ -157,7 +203,7 @@ else
 
     # The reader is a deliberately unprivileged identity that cannot reach the
     # database. A manifest it cannot read is the same as no manifest.
-    MODE="$(stat -c '%a' "$MANIFEST" 2>/dev/null)"
+    MODE="$(file_mode "$MANIFEST")"
     case "$MODE" in
       *4|*5|*6|*7) pass "manifest is world-readable ($MODE) — the capture identity can read it" ;;
       *) fail "manifest mode $MODE is not world-readable — the capture identity cannot read it" ;;
@@ -283,7 +329,7 @@ else
   # creates a new inode owned by whoever ran it, so a reconcile run as root left
   # this root:root 0644 and every later one failed without saying so.
   if [ -f "$OPENCODE_JSON" ]; then
-    OJ_MODE="$(stat -c '%a' "$OPENCODE_JSON" 2>/dev/null)"
+    OJ_MODE="$(file_mode "$OPENCODE_JSON")"
     case "$OJ_MODE" in
       *[67]*) pass "opencode.json is group-writable ($OJ_MODE) — the runtime can update permissions" ;;
       *) fail "opencode.json mode $OJ_MODE is not group-writable — the reactive reconcile cannot update the permission surface" ;;


### PR DESCRIPTION
## Summary
- install and verify a workspace with Data Machine Code absent
- prove Git status, diff, and commit behavior through the supported wp-coding-agents surface
- support quoted and space-containing repository paths and remove stale DMC adapters

## Verification
- `tests/verify.sh`
- `tests/installation-profile.sh`
- `tests/homeboy-worktree-adapter.sh`
- `tests/ci-coverage.sh`
- focused workspace installation fixture passed during independent review

Closes #529

AI assistance: OpenAI GPT-5.6 Terra using OpenCode was used to implement, independently review, rebase, and verify this change under human orchestration.