### PR TITLE
Fix retired option verification with noisy WP-CLI output

### DIFF
--- a/lib/integration-adapters.sh
+++ b/lib/integration-adapters.sh
@@ -99,20 +99,22 @@ _integration_adapter_verify_managed_release() {
 }
 
 _integration_adapter_cleanup_retired_homeboy_option() {
-  local count
   if [ "${DRY_RUN:-false}" = true ]; then
     echo -e "${BLUE:-}[dry-run]${NC:-} wp option delete datamachine_code_homeboy_available"
     return 0
   fi
-  count="$(wp_cmd option list --search=datamachine_code_homeboy_available --format=count 2>/dev/null || true)"
-  [ "$count" = 0 ] && return 0
+  _integration_adapter_retired_homeboy_option_absent && return 0
   wp_cmd option delete datamachine_code_homeboy_available >/dev/null 2>&1 || return 1
   reconciler_adapter_changed
 }
 
 _integration_adapter_verify_retired_homeboy_option() {
   [ "${DRY_RUN:-false}" = true ] && return 0
-  [ "$(wp_cmd option list --search=datamachine_code_homeboy_available --format=count 2>/dev/null)" = 0 ]
+  _integration_adapter_retired_homeboy_option_absent
+}
+
+_integration_adapter_retired_homeboy_option_absent() {
+  wp_cmd eval '$missing = new stdClass(); exit( $missing === get_option( "datamachine_code_homeboy_available", $missing ) ? 0 : 1 );' >/dev/null 2>&1
 }
 
 _integration_adapter_preserve_copied_dmc() {

--- a/tests/convergence-orchestrator.sh
+++ b/tests/convergence-orchestrator.sh
@@ -50,7 +50,7 @@ configure_homeboy_wordpress_extension() { :; }
 homeboy_required() { return 1; }
 wp_cmd() {
   case "$1 $2" in
-    'eval $missing = new stdClass(); exit( $missing === get_option( "datamachine_code_homeboy_available", $missing ) ? 0 : 1 );') return 0 ;;
+    eval*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/tests/convergence-orchestrator.sh
+++ b/tests/convergence-orchestrator.sh
@@ -50,7 +50,7 @@ configure_homeboy_wordpress_extension() { :; }
 homeboy_required() { return 1; }
 wp_cmd() {
   case "$1 $2" in
-    'option list') printf '0\n' ;;
+    'eval $missing = new stdClass(); exit( $missing === get_option( "datamachine_code_homeboy_available", $missing ) ? 0 : 1 );') return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/tests/integration-adapters.sh
+++ b/tests/integration-adapters.sh
@@ -20,12 +20,9 @@ configure_homeboy_wordpress_extension() { printf 'homeboy\n' >> "$HOMEBOY_TRACE"
 homeboy_required() { return 1; }
 wp_cmd() {
   case "$1 $2" in
-    'option list')
-      if [ "${3:-}" = '--search=datamachine_code_homeboy_available' ]; then
-        [ -e "$RETIRED_HOMEBOY_OPTION_STATE" ] && printf '1\n' || printf '0\n'
-      else
-        printf '0\n'
-      fi
+    'eval $missing = new stdClass(); exit( $missing === get_option( "datamachine_code_homeboy_available", $missing ) ? 0 : 1 );')
+      printf 'Deprecated: diagnostic text on stdout\n'
+      [ ! -e "$RETIRED_HOMEBOY_OPTION_STATE" ]
       ;;
     'option delete') rm -f "$RETIRED_HOMEBOY_OPTION_STATE" ;;
     'plugin is-active') return 0 ;;


### PR DESCRIPTION
## Summary

- probe retired Homeboy option absence through `wp eval` exit status instead of parsing `wp option list` output
- use an identity-safe sentinel so every persisted option value remains distinguishable from absence
- retain fail-closed behavior when WordPress cannot verify state
- cover diagnostic text emitted on stdout

## Verification

- `bash tests/integration-adapters.sh`
- `bash -n lib/integration-adapters.sh tests/integration-adapters.sh`
- live PHP 8.5/WP-CLI probe returned success while deprecation diagnostics were emitted

Closes #563.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the live upgrade failure, implemented and verified the focused repair, and orchestrated the tracked worktree, commit, and PR submission.