### PR TITLE
Fix local Kimaki plugin path resolution after desired-state sync

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -842,6 +842,14 @@ EnvironmentFile=-$(ai_gateway_env_file)"
 # Upgrade-time config sync (Phase 2)
 # ============================================================================
 
+bridge_managed_plugins_dir() {
+  if [ "$LOCAL_MODE" = true ]; then
+    printf '%s/kimaki-config/plugins' "$KIMAKI_DATA_DIR"
+  else
+    printf '/opt/kimaki-config/plugins'
+  fi
+}
+
 bridge_sync_config() {
   # Resolve paths per environment.
   #   VPS:   plugins live at /opt/kimaki-config/plugins (referenced by opencode.json,
@@ -856,14 +864,14 @@ bridge_sync_config() {
   local BACKUP_DIR
   if [ "$LOCAL_MODE" = true ]; then
     KIMAKI_CONFIG_DIR="${KIMAKI_DATA_DIR}/kimaki-config"
-    KIMAKI_PLUGINS_DIR="${KIMAKI_CONFIG_DIR}/plugins"
+    KIMAKI_PLUGINS_DIR="$(bridge_managed_plugins_dir)"
     BACKUP_DIR="${KIMAKI_DATA_DIR}/backups/kimaki-config.$TIMESTAMP"
     log "Phase 2: Syncing kimaki config (local mode)..."
     log "  Config dir:  $KIMAKI_CONFIG_DIR"
     log "  Plugins dir: $KIMAKI_PLUGINS_DIR (durable opencode target)"
   else
     KIMAKI_CONFIG_DIR="/opt/kimaki-config"
-    KIMAKI_PLUGINS_DIR="/opt/kimaki-config/plugins"
+    KIMAKI_PLUGINS_DIR="$(bridge_managed_plugins_dir)"
     if [ "$(id -u)" -eq 0 ]; then
       BACKUP_DIR="/opt/kimaki-config.backup.$TIMESTAMP"
     else
@@ -1594,7 +1602,8 @@ bridge_vps_start_preamble() {
 
 # Verify-block addendum printed by upgrade.sh after the standard status line.
 bridge_verify_extra() {
-  local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
+  local PLUGINS_DIR
+  PLUGINS_DIR="$(bridge_managed_plugins_dir)"
   echo "test -f $PLUGINS_DIR/dm-context-filter.ts && test -f $PLUGINS_DIR/dm-agent-sync.ts   # managed OpenCode plugins installed"
   echo "command -v kimaki >/dev/null   # native Kimaki binary available"
 }

--- a/tests/opencode-local-plugin-path.sh
+++ b/tests/opencode-local-plugin-path.sh
@@ -36,6 +36,14 @@ source "$SCRIPT_DIR/lib/source-policy.sh"
 SOURCE_MODE="${SOURCE_MODE:-workspace}"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/runtimes/opencode.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/bridges/kimaki.sh"
+
+RESOLVED_KIMAKI_PLUGINS_DIR=/opt/kimaki-config/plugins
+[ "$(bridge_managed_plugins_dir)" = "$KIMAKI_DATA_DIR/kimaki-config/plugins" ] || {
+  echo "FAIL: local plugin path depended on child-process bridge state"
+  exit 1
+}
 
 runtime_generate_config
 

--- a/tests/upgrade-opencode-auth-plugin-sync.sh
+++ b/tests/upgrade-opencode-auth-plugin-sync.sh
@@ -20,5 +20,6 @@ require_source "upgrade_install_opencode_claude_code_auth_plugin()" "upgrade-own
 require_source 'source_path="$SCRIPT_DIR/runtimes/opencode/plugins/claude-code-auth.ts"' "copy from released OpenCode auth plugin source"
 require_source "upgrade_install_opencode_claude_code_auth_plugin" "opencode.json drift phase installs auth plugin"
 require_source 'CLAUDE_CODE_AUTH_PLUGIN="$(upgrade_opencode_claude_code_auth_plugin_path)"' "repair helper receives site-local auth plugin path"
+require_source 'PLUGINS_DIR="$(bridge_managed_plugins_dir)"' "repair resolves the persistent bridge plugin path in the parent process"
 
 echo "PASS: tests/upgrade-opencode-auth-plugin-sync.sh"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -829,8 +829,12 @@ check_opencode_json_drift() {
 
   local BRIDGE_ARG="${CHAT_BRIDGE:-none}"
 
-  # Kimaki plugins dir — match what bridges/kimaki.sh::bridge_sync_config resolved.
+  # Resolve independently because desired-state bridge sync runs in a child
+  # process and cannot return shell variables to this parent process.
   local PLUGINS_DIR="${RESOLVED_KIMAKI_PLUGINS_DIR:-/opt/kimaki-config/plugins}"
+  if declare -F bridge_managed_plugins_dir >/dev/null 2>&1; then
+    PLUGINS_DIR="$(bridge_managed_plugins_dir)"
+  fi
   upgrade_install_opencode_claude_code_auth_plugin
   local CLAUDE_CODE_AUTH_PLUGIN=""
   local claude_code_auth_args=()


### PR DESCRIPTION
## Summary

- resolve Kimaki managed plugin paths deterministically from the current environment
- stop relying on shell variables produced inside desired-state child execution
- use the same resolver for config sync, `opencode.json` repair, and emitted verification
- prove stale `/opt` child state cannot override local macOS paths

## Verification

- `bash tests/opencode-local-plugin-path.sh`
- `bash tests/repair-opencode-json.sh`
- `bash tests/upgrade-opencode-auth-plugin-sync.sh`
- `bash tests/bridge-service-adapters.sh`
- `bash -n upgrade.sh bridges/kimaki.sh tests/opencode-local-plugin-path.sh tests/upgrade-opencode-auth-plugin-sync.sh`

Closes #565.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the live desired-state subprocess boundary, implemented and verified the repair, and orchestrated the tracked worktree, commit, and PR submission.