### PR TITLE
fix(kimaki): stop a failed system prompt patch from blocking service start

### DIFF
--- a/bridges/kimaki/post-upgrade.sh
+++ b/bridges/kimaki/post-upgrade.sh
@@ -202,7 +202,27 @@ _kimaki_patch_system_prompt() {
     return 0
   fi
 
-  SYSTEM_MESSAGE_FILE="$system_message_file" node <<'NODE'
+  # `|| patch_exit=$?` is load-bearing, not style.
+  #
+  # This file runs with `set -e` (line 50), so an unguarded `node` that exits
+  # non-zero terminates the script right here — and as ExecStartPre with no `-`
+  # prefix on the unit directive, that means the service never starts. The
+  # failure branch below was written to warn and continue, but under `set -e` it
+  # was unreachable: the shell exited before `$?` could be read.
+  #
+  # That is not theoretical. A root `npm install -g kimaki` rewrites this file
+  # root-owned, the unit runs as a non-root SERVICE_USER, and the resulting
+  # EACCES took an install down for five days across ~29,900 restart attempts
+  # (2026-08-28 to 2026-09-02). The journal for those attempts shows node's
+  # stack trace followed immediately by systemd's failure line, with neither the
+  # warning below nor the closing summary — the proof that this branch never ran.
+  #
+  # Passes 1 and 3 already established the rule for this file: a mutation of the
+  # root-owned package directory is best-effort, and being unable to perform it
+  # is worth a warning, never a failed start. Pass 2 is the only one that did not
+  # follow it. This makes it follow it.
+  local patch_exit=0
+  SYSTEM_MESSAGE_FILE="$system_message_file" node <<'NODE' || patch_exit=$?
 const fs = require('node:fs')
 
 const file = process.env.SYSTEM_MESSAGE_FILE
@@ -238,10 +258,16 @@ if (!match) {
 
 fs.writeFileSync(file, source.replace(signature, managedReturn), 'utf8')
 NODE
-  local patch_exit=$?
   if [[ "$patch_exit" -eq 0 ]]; then
     echo "kimaki-config: managed Kimaki system prompt patch active at $system_message_file"
     prompt_patch_status="active"
+  elif [[ ! -w "$system_message_file" ]]; then
+    # The common shape, and the one that caused the outage: root installed the
+    # package, a non-root SERVICE_USER runs the service. Name the remedy rather
+    # than only the symptom — the patch is applied by whoever can write the file.
+    echo "kimaki-config: WARNING: cannot write $system_message_file as $(id -un); managed Kimaki system prompt patch NOT applied"
+    echo "kimaki-config:          run 'bash $0' as root after any 'npm install -g kimaki' to apply it"
+    prompt_patch_status="unwritable"
   else
     echo "kimaki-config: WARNING: managed Kimaki system prompt patch failed for $system_message_file"
     prompt_patch_status="failed"

--- a/tests/kimaki-system-message-patch.sh
+++ b/tests/kimaki-system-message-patch.sh
@@ -44,3 +44,94 @@ NODE
 done
 
 echo "PASS: Kimaki system prompt patch supports known signatures"
+
+# ----------------------------------------------------------------------------
+# A failing prompt patch must never abort the script.
+#
+# post-upgrade.sh runs with `set -e` as ExecStartPre with no `-` prefix on the
+# unit directive, so any non-zero exit inside it stops the service from starting
+# at all. The prompt patch mutates the root-owned npm package directory, which a
+# non-root SERVICE_USER cannot write — a root `npm install -g kimaki` followed by
+# a restart took an install down for five days over ~29,900 attempts.
+#
+# These pin the rule Passes 1 and 3 already follow: failing to mutate the package
+# directory is a warning, never a failed start.
+# ----------------------------------------------------------------------------
+
+run_post_upgrade() {
+  KIMAKI_DIST_DIR="$TMP/dist" \
+  KIMAKI_SKILLS_DIR="$TMP/live-skills" \
+  KIMAKI_SKILL_SOURCE_DIR="$TMP/config/skills" \
+  KIMAKI_PLUGIN_SOURCE_DIR="$TMP/config/plugins" \
+    "$ROOT/bridges/kimaki/post-upgrade.sh" 2>&1
+}
+
+# Case 1: the patch cannot find its target signature (node exits non-zero).
+# Deliberately not a permissions test, so it is deterministic for every caller
+# including root.
+cat > "$TMP/dist/system-message.js" <<'EOF'
+export function someUnrelatedExport() {
+    return 'original';
+}
+EOF
+
+status=0
+output="$(run_post_upgrade)" || status=$?
+
+if [[ "$status" -ne 0 ]]; then
+  echo "FAIL: post-upgrade.sh exited $status when the prompt patch failed; ExecStartPre must not block service start"
+  printf '%s\n' "$output"
+  exit 1
+fi
+
+if ! grep -qF 'kimaki-config: done' <<<"$output"; then
+  echo "FAIL: post-upgrade.sh aborted before its closing summary when the prompt patch failed"
+  printf '%s\n' "$output"
+  exit 1
+fi
+
+if ! grep -qF 'prompt patch failed' <<<"$output"; then
+  echo "FAIL: a failed prompt patch must be reported in the summary"
+  printf '%s\n' "$output"
+  exit 1
+fi
+
+echo "PASS: a failed Kimaki system prompt patch warns without blocking service start"
+
+# Case 2: the exact outage shape — the target exists but is not writable by the
+# invoking user. Root bypasses file permissions, so this can only be observed as
+# a non-root caller.
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "SKIP: unwritable-target case requires a non-root caller"
+else
+  cat > "$TMP/dist/system-message.js" <<'EOF'
+export function getOpencodeSystemMessage({ sessionId, channelId }) {
+    return 'original';
+}
+EOF
+  chmod 0444 "$TMP/dist/system-message.js"
+
+  status=0
+  output="$(run_post_upgrade)" || status=$?
+  chmod 0644 "$TMP/dist/system-message.js"
+
+  if [[ "$status" -ne 0 ]]; then
+    echo "FAIL: post-upgrade.sh exited $status against an unwritable system-message.js; this is the five-day outage"
+    printf '%s\n' "$output"
+    exit 1
+  fi
+
+  if ! grep -qF 'cannot write' <<<"$output"; then
+    echo "FAIL: an unwritable system-message.js must be reported by name"
+    printf '%s\n' "$output"
+    exit 1
+  fi
+
+  if ! grep -qF 'prompt patch unwritable' <<<"$output"; then
+    echo "FAIL: an unwritable target must be distinguished from a failed patch in the summary"
+    printf '%s\n' "$output"
+    exit 1
+  fi
+
+  echo "PASS: an unwritable Kimaki system-message.js warns without blocking service start"
+fi


### PR DESCRIPTION
## The bug is one missing `||`

`post-upgrade.sh` sets `set -euo pipefail` (line 50) and is wired as `ExecStartPre` with no `-` prefix, so **any non-zero exit inside it stops the service from starting at all.**

Pass 2 invoked `node` unguarded:

```bash
SYSTEM_MESSAGE_FILE="$system_message_file" node <<'NODE'
...
NODE
local patch_exit=$?          # <- unreachable under set -e
if [[ "$patch_exit" -eq 0 ]]; then
  ...
else
  echo "...WARNING: managed Kimaki system prompt patch failed..."   # <- never printed
fi
```

The failure handling was written correctly and **could never execute** — `set -e` terminated the script at the `node` line, before `$?` was ever read.

## Why that matters in practice

The reachable shape is routine, not exotic:

```
npm install -g kimaki     runs as root -> dist/system-message.js is root:root
rendered unit             User=$SERVICE_USER (non-root)
next service start        ExecStartPre patches a root-owned file as that user
                          -> EACCES -> exit 1 -> systemd refuses to start
```

One install sat **down for five days across ~29,900 restart attempts** (2026-08-28 → 2026-09-02), recovering only when a kimaki version bump happened to let root re-patch the file out of band. Four user requests were silently dropped in that window.

The journal is the proof that the branch never ran — node's stack trace goes **straight** to systemd's failure line, with neither the warning nor the closing summary in between:

```
kimaki-config: persistent skill source available at /opt/kimaki-config/skills
node:fs:2430
Error: EACCES: permission denied, open '/usr/local/lib/node_modules/kimaki/dist/system-message.js'
...
Node.js v22.22.1
kimaki.service: Control process exited, code=exited, status=1/FAILURE
```

## Why this fix and not a chown

This file had **already settled the rule** for exactly this hazard, twice. `try_remove_package_path` (Pass 1):

> This script runs as ExecStartPre, as the SERVICE user, with `set -e` and no `-` prefix on the unit directive — so any non-zero exit here blocks the service from starting at all. The package dir is root-owned […] An unguarded `rm -rf` therefore turns a supported install shape into a service that will not boot […] Not being able to perform them is worth a warning, never a failed start.

And the obsolete-plugin removal in Pass 3 repeats it: *"Same reasoning as try_remove_package_path."*

**Pass 2 was the only one of the three not following the rule.** So this makes it follow the rule rather than introducing a new mechanism. Chowning the npm tree at install time was the other candidate, and it is strictly more machinery guarding a narrower case — it fixes the installs we provision, and does nothing for a service that dies because some *other* root process ran `npm install -g`. The invariant that actually holds is the one this file already states: mutating the package directory is best-effort.

## Changes

- `|| patch_exit=$?` on the `node` invocation, which activates the existing branch.
- An unwritable target is reported separately from a genuinely broken patch, and **names the remedy**. "Root installed it, a service user runs it" is the supported shape, not a defect, and the operator needs to know to re-run as root rather than to go hunting.
- Two regression tests in the existing `kimaki-system-message-patch.sh` (already registered in `shell.yml`).

## Verification

Both new cases **fail against the unfixed script** and pass against the fixed one — baselined, not assumed:

```
# unfixed
PASS: Kimaki system prompt patch supports known signatures
FAIL: post-upgrade.sh exited 2 when the prompt patch failed; ExecStartPre must not block service start

# fixed, as non-root
PASS: Kimaki system prompt patch supports known signatures
PASS: a failed Kimaki system prompt patch warns without blocking service start
PASS: an unwritable Kimaki system-message.js warns without blocking service start
```

- Case 1 (signature not found) is permission-free so it is deterministic for every caller including root.
- Case 2 is the exact outage shape and is **skipped when the caller is root**, since root bypasses file permissions. CI runs as `runner`, so it executes there.
- `bash -n` clean on both files; the repo's `syntax` job covers this.

## Scope

Deliberately not addressed here: the affected install's nightly workflow re-armed this every night by running `npm install -g kimaki` as root without re-patching. That is fixed separately in that repo (chubes4/h44-lacrosse#3). This PR is the reason a mistake like that could take a host down instead of merely leaving a prompt unpatched.