### PR TITLE
fix(opencode): upgrade manifests written before general_agent existed

### DIFF
--- a/lib/project-opencode-subagents.py
+++ b/lib/project-opencode-subagents.py
@@ -217,6 +217,16 @@ def manifest(path, root):
     if not isinstance(data.get("skill_permission", {}), dict): fail("managed manifest skill permission is invalid")
     permission({"skill": data.get("skill_permission", {})}, "managed manifest skill permission")
     if data.get("general_agent") is not None and not isinstance(data["general_agent"], dict): fail("managed manifest general agent is invalid")
+    # Both return paths must have the same shape, because main() subscripts this
+    # result directly. A manifest on disk was written by whatever version was
+    # installed at the time, so every key added here is absent from every
+    # manifest already written — the fresh-install default above is not the
+    # migration. general_agent shipped in v1.21.0 and made `previous["general_agent"]`
+    # raise KeyError on every install upgrading from <= v1.20.2, which is every
+    # install that had ever run. Defaulting on read is what makes a new key
+    # backward compatible; validate above, normalize here, subscript freely after.
+    for key, default in (("agents", []), ("artifacts", []), ("task_permission", None), ("skill_permission", {}), ("general_agent", None)):
+        data.setdefault(key, default)
     return data
 
 

--- a/tests/opencode-subagents.sh
+++ b/tests/opencode-subagents.sh
@@ -197,6 +197,44 @@ opencode_project_subagents
 after="$(shasum "$SITE_PATH/.opencode/agents/writer.md" "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json")"
 [ "$before" = "$after" ] || FAILED=$((FAILED + 1))
 printf '  ok   repeated graph reconciliation is byte-stable\n'
+
+echo '==> upgrade from a manifest written before general_agent existed'
+# The exact on-disk state left by <= v1.20.2: the manifest has no general_agent
+# key and opencode.json has no agent.general, because neither existed yet. Every
+# install that had ever run was in this state, so this is the ONLY path that
+# matters for a new manifest key -- the fresh-install default cannot cover it.
+# v1.21.0 subscripted previous["general_agent"] directly and raised KeyError
+# here, which aborted upgrade.sh on real hosts.
+python3 - "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json" "$SITE_PATH/opencode.json" <<'PY'
+import json, sys
+manifest_path, config_path = sys.argv[1], sys.argv[2]
+manifest = json.load(open(manifest_path))
+manifest.pop('general_agent', None)
+# v1.20.2 also never granted task.general, and the manifest records what it
+# wrote. Leaving it here would make the config below look user-edited rather
+# than merely older, which is a different rejection than the one under test.
+manifest.get('task_permission', {}).pop('general', None)
+json.dump(manifest, open(manifest_path, 'w'))
+config = json.load(open(config_path))
+config.get('agent', {}).pop('general', None)
+if config.get('agent') == {}: config.pop('agent')
+config['permission']['task'].pop('general', None)
+json.dump(config, open(config_path, 'w'))
+PY
+if opencode_project_subagents; then
+  printf '  ok   a pre-general_agent manifest upgrades instead of raising KeyError\n'
+else
+  printf '  FAIL a pre-general_agent manifest must upgrade, not abort the projection\n'
+  FAILED=$((FAILED + 1))
+fi
+assert_python 'the upgrade adopts the native general subagent it previously lacked' "$SITE_PATH/.opencode/.wp-coding-agents-subagents.json" "$SITE_PATH/opencode.json" <<'PY'
+import json, sys
+manifest = json.load(open(sys.argv[1]))
+config = json.load(open(sys.argv[2]))
+assert manifest['general_agent'] == {'model': 'openai/gpt-5'}, manifest.get('general_agent')
+assert config['agent']['general'] == {'model': 'openai/gpt-5'}, config.get('agent')
+assert config['permission']['task']['general'] == 'allow'
+PY
 python3 - "$TMP/graph.json" <<'PY'
 import json, sys
 p = sys.argv[1]


### PR DESCRIPTION
## Regression shipped in v1.21.0

`manifest()` has two return paths:

```python
def manifest(path, root):
    if not path.exists():
        return {..., "general_agent": None}   # <- new key added here in v1.21.0
    ...
    return data                               # <- the file, exactly as written
```

v1.21.0 added `general_agent` to the **fresh-install** branch, then subscripted it directly in `main()`:

```python
if current_general_agent not in (None, previous["general_agent"]):
```

A manifest on disk was written by whatever version wrote it. v1.20.2 persisted:

```python
{"sentinel", "agents", "artifacts", "task_permission", "skill_permission"}
```

No `general_agent`. So **every install upgrading from <= v1.20.2 raises `KeyError: 'general_agent'`** — which is every install that had ever run. Only a genuinely fresh install takes the branch that has the key.

## Impact

The projection is a hard step in `upgrade.sh`, so the whole upgrade aborts and the host stops applying managed configuration partway through. Observed on a live VPS immediately after taking v1.21.0:

```
File "/root/wp-coding-agents/lib/project-opencode-subagents.py", line 284, in main
  if current_general_agent not in (None, previous["general_agent"])
KeyError: 'general_agent'
[wp-coding-agents] OpenCode subagent projection failed (projector); correct the reported failure before retrying.
```

## The fix

Normalize on read, so both return paths have the same shape and the existing direct subscripts stay valid:

```python
for key, default in (("agents", []), ("artifacts", []), ("task_permission", None),
                     ("skill_permission", {}), ("general_agent", None)):
    data.setdefault(key, default)
```

Adding the key to the fresh-install default is not a migration — that branch is precisely the case a migration cannot affect. Defaulting on read is what makes a new manifest key backward compatible. The keys are defaulted as a set rather than one-off because the next key added will have exactly this problem again, and the function's contract is that its result is safe to subscript.

Note the file was already defensive in validation (`data.get("general_agent")` on the line above) and then direct in use. Same split that caused this.

## Test

Writes the real v1.20.2 on-disk state — no `general_agent` in the manifest, no `agent.general` in `opencode.json`, and no `task.general` in either, since v1.20.2 wrote none of them — then asserts the projection upgrades and adopts the native subagent.

Baselined against the unfixed projector rather than assumed:

```
# unfixed
KeyError: 'general_agent'
FAIL a pre-general_agent manifest must upgrade, not abort the projection

# fixed
ok   a pre-general_agent manifest upgrades instead of raising KeyError
ok   the upgrade adopts the native general subagent it previously lacked
```

Full `tests/opencode-subagents.sh` passes, exit 0.

## Note on how this was found

Caught by running the real nightly maintenance job against a live host after cutting v1.21.0, rather than by CI. CI only ever exercises the fresh-install branch, so no existing test could see it — which is the general shape worth noting: **a new key in a persisted structure is an upgrade-path change, and the upgrade path is the branch tests do not take by default.**