### PR TITLE
Fix managed Kimaki self-upgrades

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -161,12 +161,85 @@ _kimaki_instance_suffix() {
 # Install (setup-time)
 # ============================================================================
 
-bridge_install() {
-  if ! command -v kimaki &> /dev/null || [ "$DRY_RUN" = true ]; then
+# Managed non-root VPS services cannot write a root-global npm prefix, so
+# Kimaki self-upgrade fails with EACCES (#580). Derive a prefix from the
+# adopted SERVICE_HOME and install/run as SERVICE_USER. Root-service, local,
+# and external WordPress installs keep the existing global layout.
+_kimaki_uses_service_owned_prefix() {
+  [ "${LOCAL_MODE:-false}" != true ] \
+    && [ "${EXTERNAL_WORDPRESS:-false}" != true ] \
+    && [ -n "${SERVICE_USER:-}" ] \
+    && [ "$SERVICE_USER" != "root" ] \
+    && [ -n "${SERVICE_HOME:-}" ]
+}
+
+_kimaki_service_npm_prefix() {
+  printf '%s/.local' "$SERVICE_HOME"
+}
+
+_kimaki_npm_config_prefix_env() {
+  _kimaki_uses_service_owned_prefix || return 0
+  printf 'Environment=npm_config_prefix=%s\n' "$(_kimaki_service_npm_prefix)"
+}
+
+_kimaki_can_install_as_service_user() {
+  { [ "${WP_CODING_AGENTS_TEST_ASSUME_ROOT:-false}" = true ] || [ "$(id -u)" -eq 0 ]; } \
+    && command -v sudo >/dev/null 2>&1
+}
+
+_kimaki_is_service_user() {
+  [ -n "${SERVICE_USER:-}" ] && [ "$(id -un 2>/dev/null || true)" = "$SERVICE_USER" ]
+}
+
+_kimaki_run_npm_install_global() {
+  local prefix="${1:-}"
+  if [ -n "$prefix" ] && _kimaki_uses_service_owned_prefix && _kimaki_can_install_as_service_user; then
+    run_cmd sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" PATH="$PATH" \
+      npm_config_prefix="$prefix" npm install -g kimaki
+  elif [ -n "$prefix" ] && _kimaki_uses_service_owned_prefix && _kimaki_is_service_user; then
+    run_cmd env HOME="$SERVICE_HOME" PATH="$PATH" npm_config_prefix="$prefix" npm install -g kimaki
+  elif [ -z "$prefix" ]; then
     run_cmd npm install -g kimaki
+  else
+    error "Kimaki must be installed as service user '$SERVICE_USER' or by root with passwordless sudo access to that user."
+  fi
+}
+
+_kimaki_provision_service_owned_package() {
+  local prefix bin_dir prefix_bin group
+  prefix="$(_kimaki_service_npm_prefix)"
+  bin_dir="$prefix/bin"
+  prefix_bin="$bin_dir/kimaki"
+
+  if [ -x "$prefix_bin" ] && [ "${DRY_RUN:-false}" != true ]; then
+    log "Kimaki already installed: $prefix_bin"
+    return 0
+  fi
+
+  if ! _kimaki_can_install_as_service_user && ! _kimaki_is_service_user && [ "${DRY_RUN:-false}" != true ]; then
+    error "Cannot provision the service-owned Kimaki package as $(id -un): expected '$SERVICE_USER' or root with sudo."
+  fi
+
+  run_cmd mkdir -p "$bin_dir"
+  if [ "${DRY_RUN:-false}" != true ] && id -u "$SERVICE_USER" >/dev/null 2>&1; then
+    group=$(id -gn "$SERVICE_USER" 2>/dev/null || echo "$SERVICE_USER")
+    run_cmd chown "$SERVICE_USER:$group" "$prefix" "$bin_dir"
+  fi
+  _kimaki_run_npm_install_global "$prefix"
+}
+
+_kimaki_provision_package() {
+  if _kimaki_uses_service_owned_prefix; then
+    _kimaki_provision_service_owned_package
+  elif ! command -v kimaki &> /dev/null || [ "${DRY_RUN:-false}" = true ]; then
+    _kimaki_run_npm_install_global
   else
     log "Kimaki already installed: $(command -v kimaki)"
   fi
+}
+
+bridge_install() {
+  _kimaki_provision_package
 
   if [ "${EXTERNAL_WORDPRESS:-false}" = true ]; then
     _kimaki_seed_external_credential
@@ -678,18 +751,20 @@ _kimaki_install_launchd() {
 # HOME=/home/opencode — an internally inconsistent unit whose ExecStart the
 # service user cannot read, crashing the bridge on the next restart.
 #
-# Resolution order (issue option order — prefer a stable, identity-consistent
-# path over the invoking user's private home):
-#   1. A system-prefix binary (/usr/bin, /usr/local/bin, /opt/homebrew/bin):
-#      reachable by any service user, the npm-global symlink target the
-#      installer already prefers (see _kimaki_register_cli_channel, ~line 80).
-#   2. When SERVICE_USER differs from the invoking user, resolve UNDER the
+# Resolution order (identity-consistent; never the invoking user's private
+# home — #232). Managed non-root services prefer the service-owned prefix so
+# ExecStart/PATH match the writable install (#580). Root-service and local
+# installs keep the system-prefix-first layout:
+#   1. Managed non-root: $SERVICE_HOME/.local/bin/kimaki, whether or not a
+#      root-global binary also exists.
+#   2. A system-prefix binary (/usr/bin, /usr/local/bin, /opt/homebrew/bin).
+#   3. When SERVICE_USER differs from the invoking user, resolve UNDER the
 #      service user: `sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME"
 #      bash -lc 'command -v kimaki'` (mirrors lib/homeboy.sh:40). Guarded for
 #      sudo availability / non-zero exit.
-#   3. $SERVICE_HOME/.kimaki/bin/kimaki if that file exists (the canonical
-#      per-user install layout, derived from the adopted home — never /root).
-#   4. /usr/bin/kimaki as a last-resort stable default.
+#   4. $SERVICE_HOME/.kimaki/bin/kimaki if that file exists (legacy per-user
+#      layout, derived from the adopted home — never /root).
+#   5. /usr/bin/kimaki as a last-resort stable default.
 #
 # Args: $1 = fallback system-prefix default (e.g. /usr/bin/kimaki on Linux,
 #            /opt/homebrew/bin/kimaki on macOS).
@@ -697,10 +772,15 @@ _kimaki_resolve_service_bin() {
   local default_bin="${1:-/usr/bin/kimaki}"
   local candidate
 
-  # 1. Stable system-prefix binary — reachable by any service user. The list
-  #    is overridable (space-separated) only so tests can point it at a temp
-  #    prefix and exercise the service-user / SERVICE_HOME fallback paths
-  #    deterministically; production always uses the real system prefixes.
+  if _kimaki_uses_service_owned_prefix; then
+    printf '%s\n' "$(_kimaki_service_npm_prefix)/bin/kimaki"
+    return 0
+  fi
+
+  # Stable system-prefix binary — reachable by any service user. The list
+  # is overridable (space-separated) only so tests can point it at a temp
+  # prefix and exercise the service-user / SERVICE_HOME fallback paths
+  # deterministically; production always uses the real system prefixes.
   local system_bins="${KIMAKI_SYSTEM_PREFIX_BINS:-/usr/bin/kimaki /usr/local/bin/kimaki /opt/homebrew/bin/kimaki}"
   for candidate in $system_bins; do
     if [ -x "$candidate" ]; then
@@ -709,8 +789,8 @@ _kimaki_resolve_service_bin() {
     fi
   done
 
-  # 2. Resolve under the adopted service user when it differs from the
-  #    invoking user (the root-upgrade-against-opencode-unit case).
+  # Resolve under the adopted service user when it differs from the
+  # invoking user (the root-upgrade-against-opencode-unit case).
   local invoking_user running_as_root=false
   invoking_user="$(id -un 2>/dev/null || echo "")"
   if [ "${WP_CODING_AGENTS_TEST_ASSUME_ROOT:-false}" = true ] || [ "$(id -u)" -eq 0 ]; then
@@ -729,13 +809,13 @@ _kimaki_resolve_service_bin() {
     fi
   fi
 
-  # 3. Canonical per-user install layout under the ADOPTED home (not /root).
+  # Legacy per-user install layout under the ADOPTED home (not /root).
   if [ -n "${SERVICE_HOME:-}" ] && [ -f "$SERVICE_HOME/.kimaki/bin/kimaki" ]; then
     printf '%s\n' "$SERVICE_HOME/.kimaki/bin/kimaki"
     return 0
   fi
 
-  # 4. Last-resort stable default.
+  # Last-resort stable default.
   printf '%s\n' "$default_bin"
 }
 
@@ -791,11 +871,7 @@ _kimaki_install_systemd() {
   run_cmd cp -r "$SCRIPT_DIR/bridges/kimaki" "$KIMAKI_CONFIG_DIR"
   run_cmd chmod +x "$KIMAKI_CONFIG_DIR/post-upgrade.sh"
 
-  if [ "$DRY_RUN" = true ]; then
-    KIMAKI_BIN="/usr/bin/kimaki"
-  else
-    KIMAKI_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
-  fi
+  KIMAKI_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
 
   local KIMAKI_BIN_DIR NODE_BIN_DIR PATH_VALUE
   KIMAKI_BIN_DIR=$(dirname "$KIMAKI_BIN")
@@ -813,7 +889,8 @@ Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
 Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
 $(_kimaki_datamachine_wp_transport_systemd_env)
-Environment=KIMAKI_NO_DEFAULT_CHANNEL=1"
+Environment=KIMAKI_NO_DEFAULT_CHANNEL=1
+$(_kimaki_npm_config_prefix_env)"
   if [ -n "${AGENT_SLUG:-}" ]; then
     ENV_BLOCK="$ENV_BLOCK
 Environment=DATAMACHINE_AGENT_SLUG=$AGENT_SLUG"
@@ -1142,6 +1219,10 @@ bridge_update_systemd() {
   local UNIT_FILE="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}/$KIMAKI_UNIT"
   [ -f "$UNIT_FILE" ] || { warn "  $UNIT_FILE does not exist — skipping"; return 0; }
 
+  if _kimaki_uses_service_owned_prefix; then
+    _kimaki_provision_package
+  fi
+
   local CURRENT_ENV
   CURRENT_ENV=$(grep '^Environment=' "$UNIT_FILE" || true)
   CURRENT_ENV=$(_kimaki_remove_systemd_env_key "$CURRENT_ENV" DATAMACHINE_WP_CMD)
@@ -1174,7 +1255,8 @@ Environment=PATH=$PATH_VALUE
 Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
 Environment=DATAMACHINE_SITE_PATH=$SITE_PATH
 $(_kimaki_datamachine_wp_transport_systemd_env)
-Environment=KIMAKI_NO_DEFAULT_CHANNEL=1"
+Environment=KIMAKI_NO_DEFAULT_CHANNEL=1
+$(_kimaki_npm_config_prefix_env)"
   if [ -n "${KIMAKI_LOCK_PORT:-}" ]; then
     TEMPLATE_ENV="$TEMPLATE_ENV
 Environment=KIMAKI_LOCK_PORT=$KIMAKI_LOCK_PORT"

--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -194,7 +194,7 @@ _kimaki_is_service_user() {
 _kimaki_run_npm_install_global() {
   local prefix="${1:-}"
   if [ -n "$prefix" ] && _kimaki_uses_service_owned_prefix && _kimaki_can_install_as_service_user; then
-    run_cmd sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" PATH="$PATH" \
+    run_cmd sudo -n -H -u "$SERVICE_USER" env HOME="$SERVICE_HOME" \
       npm_config_prefix="$prefix" npm install -g kimaki
   elif [ -n "$prefix" ] && _kimaki_uses_service_owned_prefix && _kimaki_is_service_user; then
     run_cmd env HOME="$SERVICE_HOME" PATH="$PATH" npm_config_prefix="$prefix" npm install -g kimaki

--- a/tests/kimaki-install-existing.sh
+++ b/tests/kimaki-install-existing.sh
@@ -1,12 +1,48 @@
 #!/bin/bash
 # An installed Kimaki may keep running after printing --version. Detection must
 # not launch it just to decorate setup logs.
+#
+# #580: managed non-root VPS installs provision Kimaki into a SERVICE_HOME
+# prefix as SERVICE_USER. Root, local, and external WordPress installs keep
+# the global `npm install -g kimaki` layout.
 set -eu
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$TMP/bin"
+
+PASS=0
+FAIL=0
+fail_list=""
+
+assert() {
+  local label="$1" ok="$2"
+  if [ "$ok" = "0" ]; then
+    echo "  ok   $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $label"
+    FAIL=$((FAIL + 1))
+    fail_list="$fail_list
+  - $label"
+  fi
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  ok   $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $label"
+    echo "       expected: '$expected'"
+    echo "       actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+    fail_list="$fail_list
+  - $label"
+  fi
+}
 
 cat > "$TMP/bin/kimaki" <<'SH'
 #!/bin/sh
@@ -23,15 +59,201 @@ export DRY_RUN=false
 export EXTERNAL_WORDPRESS=true
 export LOCAL_MODE=false
 export PLATFORM=linux
+unset KIMAKI_BOT_TOKEN
 
 log() { :; }
+warn() { :; }
+error() { printf '%s\n' "$*" >&2; exit 1; }
 run_cmd() { "$@"; }
 external_wordpress_kimaki_command() { printf 'kimaki'; }
 
+# shellcheck disable=SC1091
 source "$ROOT/bridges/kimaki.sh"
 _kimaki_sync_bin_helpers() { :; }
 
+echo "==> existing install is not probed with --version"
 bridge_install
-test ! -e "$TMP/version-invoked"
+assert "did not invoke kimaki --version" "$([ ! -e "$TMP/version-invoked" ]; echo $?)"
 
+# ---------------------------------------------------------------------------
+echo "==> #580: managed non-root install runs as the service user"
+
+SERVICE_HOME="$TMP/home-opencode"
+SERVICE_USER="opencode"
+KIMAKI_DATA_DIR="$SERVICE_HOME/.kimaki"
+EXTERNAL_WORDPRESS=false
+LOCAL_MODE=false
+DRY_RUN=false
+mkdir -p "$SERVICE_HOME"
+rm -rf "$SERVICE_HOME/.local"
+: > "$TMP/sudo.log"
+: > "$TMP/npm.log"
+
+sudo() {
+  printf 'sudo %s\n' "$*" >> "$TMP/sudo.log"
+  local prefix="" arg
+  for arg in "$@"; do
+    case "$arg" in
+      npm_config_prefix=*) prefix="${arg#npm_config_prefix=}" ;;
+    esac
+  done
+  printf 'npm install -g kimaki\n' >> "$TMP/npm.log"
+  [ -n "$prefix" ] || return 0
+  mkdir -p "$prefix/bin"
+  printf '#!/bin/sh\n' > "$prefix/bin/kimaki"
+  chmod +x "$prefix/bin/kimaki"
+}
+
+npm() {
+  printf 'npm %s\n' "$*" >> "$TMP/npm.log"
+}
+
+export WP_CODING_AGENTS_TEST_ASSUME_ROOT=true
+_kimaki_provision_package
+
+prefix="$SERVICE_HOME/.local"
+assert "service-owned prefix binary installed" "$([ -x "$prefix/bin/kimaki" ]; echo $?)"
+assert "install hopped to SERVICE_USER" "$(grep -q "sudo -n -H -u opencode " "$TMP/sudo.log"; echo $?)"
+assert "install set npm_config_prefix to SERVICE_HOME/.local" \
+  "$(grep -q "npm_config_prefix=$prefix" "$TMP/sudo.log"; echo $?)"
+assert "install invoked npm install -g kimaki" "$(grep -q "npm install -g kimaki" "$TMP/npm.log"; echo $?)"
+assert "did not install into a system prefix" \
+  "$(grep -q "npm_config_prefix=/usr" "$TMP/sudo.log"; echo $((1 - $?)))"
+
+# ---------------------------------------------------------------------------
+echo "==> #580: rendered environment and binary prefer the service-owned prefix"
+
+resolved="$(_kimaki_resolve_service_bin /usr/bin/kimaki)"
+assert_eq "ExecStart binary is service-owned" "$prefix/bin/kimaki" "$resolved"
+
+prefix_env="$(_kimaki_npm_config_prefix_env)"
+assert_eq "unit sets npm_config_prefix" \
+  "Environment=npm_config_prefix=$prefix" "$(printf '%s' "$prefix_env" | tr -d '\n')"
+
+# A root-global binary must not win over the service-owned prefix.
+sys_bin="$TMP/usr-bin-kimaki"
+printf '#!/bin/sh\n' > "$sys_bin"
+chmod +x "$sys_bin"
+export KIMAKI_SYSTEM_PREFIX_BINS="$sys_bin"
+resolved_with_global="$(_kimaki_resolve_service_bin /usr/bin/kimaki)"
+assert_eq "service-owned binary preferred over system-prefix" \
+  "$prefix/bin/kimaki" "$resolved_with_global"
+unset KIMAKI_SYSTEM_PREFIX_BINS
+
+path_value="$prefix/bin:/usr/local/bin:/usr/bin:/bin"
+assert_eq "resolved bin dir is the service-owned prefix" \
+  "$prefix/bin" "$(dirname "$resolved")"
+
+SITE_PATH="$TMP/site"
+KIMAKI_CONFIG_DIR="$TMP/kimaki-config"
+KIMAKI_BIN="$resolved"
+KIMAKI_UNIT="kimaki.service"
+mkdir -p "$SITE_PATH" "$KIMAKI_CONFIG_DIR"
+_kimaki_skill_filter_args_shell() { printf ''; }
+_kimaki_datamachine_wp_transport_systemd_env() { printf 'Environment=DATAMACHINE_WP_TRANSPORT_JSON="[\"wp\"]"\n'; }
+ENV_BLOCK="Environment=HOME=$SERVICE_HOME
+Environment=PATH=$path_value
+Environment=KIMAKI_DATA_DIR=$KIMAKI_DATA_DIR
+$(_kimaki_npm_config_prefix_env)"
+rendered="$(bridge_render_systemd kimaki.service "$ENV_BLOCK")"
+assert "rendered ExecStart uses service-owned binary" \
+  "$(printf '%s\n' "$rendered" | grep -q "^ExecStart=$prefix/bin/kimaki "; echo $?)"
+assert "rendered env keeps npm_config_prefix" \
+  "$(printf '%s\n' "$rendered" | grep -q "^Environment=npm_config_prefix=$prefix$"; echo $?)"
+assert "rendered PATH starts with service-owned bin" \
+  "$(printf '%s\n' "$rendered" | grep -q "^Environment=PATH=$prefix/bin:"; echo $?)"
+
+# ---------------------------------------------------------------------------
+echo "==> #580: upgrade convergence is idempotent and does not change identity"
+
+: > "$TMP/sudo.log"
+: > "$TMP/npm.log"
+saved_user="$SERVICE_USER"
+saved_home="$SERVICE_HOME"
+_kimaki_provision_package
+assert "second provision skips npm when prefix binary exists" \
+  "$([ ! -s "$TMP/npm.log" ]; echo $?)"
+assert "SERVICE_USER unchanged" "$([ "$SERVICE_USER" = "$saved_user" ]; echo $?)"
+assert "SERVICE_HOME unchanged" "$([ "$SERVICE_HOME" = "$saved_home" ]; echo $?)"
+
+rm -f "$prefix/bin/kimaki"
+: > "$TMP/sudo.log"
+: > "$TMP/npm.log"
+_kimaki_provision_package
+assert "missing prefix binary converges with a service-user install" \
+  "$(grep -q "sudo -n -H -u opencode " "$TMP/sudo.log" && [ -x "$prefix/bin/kimaki" ]; echo $?)"
+
+# Same adopted home, second instance: same prefix.
+KIMAKI_UNIT="kimaki-site-b.service"
+assert_eq "multi-instance prefix follows SERVICE_HOME" \
+  "$SERVICE_HOME/.local" "$(_kimaki_service_npm_prefix)"
+KIMAKI_UNIT="kimaki.service"
+
+# ---------------------------------------------------------------------------
+echo "==> #580: root-service and local installs keep global npm -g"
+
+unset WP_CODING_AGENTS_TEST_ASSUME_ROOT
+: > "$TMP/sudo.log"
+: > "$TMP/npm.log"
+: > "$TMP/global.log"
+npm() {
+  printf 'npm %s\n' "$*" >> "$TMP/npm.log"
+  printf 'npm %s\n' "$*" >> "$TMP/global.log"
+}
+
+SERVICE_USER="root"
+SERVICE_HOME="/root"
+LOCAL_MODE=false
+EXTERNAL_WORDPRESS=false
+DRY_RUN=true
+_kimaki_provision_package
+assert "root-service uses npm install -g without a user prefix" \
+  "$(grep -qx "npm install -g kimaki" "$TMP/global.log"; echo $?)"
+assert "root-service does not sudo -u a service user" \
+  "$([ ! -s "$TMP/sudo.log" ]; echo $?)"
+assert "root-service does not set npm_config_prefix" \
+  "$(grep -q npm_config_prefix "$TMP/global.log"; echo $((1 - $?)))"
+assert_eq "root-service leaves npm_config_prefix env unset" \
+  "" "$(_kimaki_npm_config_prefix_env | tr -d '\n')"
+
+sys_bin="$TMP/usr-bin-kimaki"
+export KIMAKI_SYSTEM_PREFIX_BINS="$sys_bin"
+assert_eq "root-service prefers system-prefix binary" \
+  "$sys_bin" "$(_kimaki_resolve_service_bin /usr/bin/kimaki)"
+unset KIMAKI_SYSTEM_PREFIX_BINS
+
+: > "$TMP/sudo.log"
+: > "$TMP/global.log"
+SERVICE_USER="$(id -un)"
+SERVICE_HOME="$HOME"
+LOCAL_MODE=true
+EXTERNAL_WORDPRESS=false
+DRY_RUN=true
+_kimaki_provision_package
+assert "local mode uses npm install -g without a user prefix" \
+  "$(grep -qx "npm install -g kimaki" "$TMP/global.log"; echo $?)"
+assert "local mode does not sudo -u a service user" \
+  "$([ ! -s "$TMP/sudo.log" ]; echo $?)"
+assert_eq "local mode leaves npm_config_prefix env unset" \
+  "" "$(_kimaki_npm_config_prefix_env | tr -d '\n')"
+
+: > "$TMP/sudo.log"
+: > "$TMP/global.log"
+LOCAL_MODE=false
+EXTERNAL_WORDPRESS=true
+SERVICE_USER="opencode"
+SERVICE_HOME="$TMP/home-opencode"
+DRY_RUN=true
+_kimaki_provision_package
+assert "external WordPress uses npm install -g without a service prefix" \
+  "$(grep -qx "npm install -g kimaki" "$TMP/global.log"; echo $?)"
+assert_eq "external WordPress leaves npm_config_prefix env unset" \
+  "" "$(_kimaki_npm_config_prefix_env | tr -d '\n')"
+
+echo
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAIL: $FAIL assertion(s):$fail_list"
+  exit 1
+fi
+echo "OK: all $PASS kimaki install assertions passed"
 echo "PASS: tests/kimaki-install-existing.sh"

--- a/tests/kimaki-multi-instance.sh
+++ b/tests/kimaki-multi-instance.sh
@@ -129,6 +129,7 @@ UPDATED_ITEMS=()
 WP_CMD=wp
 IS_STUDIO=false
 systemctl() { :; }
+_kimaki_provision_package() { :; }
 
 other_before=$(cksum "$SYSTEMD_UNIT_DIR/kimaki.service")
 bridge_update_systemd

--- a/tests/service-identity-adoption.sh
+++ b/tests/service-identity-adoption.sh
@@ -218,6 +218,9 @@ KIMAKI_DATA_DIR="$ADOPTED_HOME/.kimaki"
 # Per-user install layout under the ADOPTED (non-root) home.
 printf '#!/bin/sh\n' > "$ADOPTED_HOME/.kimaki/bin/kimaki"
 chmod +x "$ADOPTED_HOME/.kimaki/bin/kimaki"
+mkdir -p "$ADOPTED_HOME/.local/bin"
+printf '#!/bin/sh\n' > "$ADOPTED_HOME/.local/bin/kimaki"
+chmod +x "$ADOPTED_HOME/.local/bin/kimaki"
 
 # No system-prefix binary exists in this sandbox (yet).
 export KIMAKI_SYSTEM_PREFIX_BINS="$BIN232/usr-bin-kimaki $BIN232/usr-local-kimaki"
@@ -238,17 +241,19 @@ PATH_SAVE="$PATH"
 export PATH="$CLEANBIN"
 
 RESOLVED_BIN=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
-assert "resolved bin is under adopted SERVICE_HOME" \
-  "$([ "$RESOLVED_BIN" = "$ADOPTED_HOME/.kimaki/bin/kimaki" ]; echo $?)"
+assert "resolved bin is under adopted SERVICE_HOME prefix" \
+  "$([ "$RESOLVED_BIN" = "$ADOPTED_HOME/.local/bin/kimaki" ]; echo $?)"
 assert "resolved bin is NOT under /root" \
   "$([[ "$RESOLVED_BIN" != /root/* ]]; echo $?)"
 
-# A real system-prefix binary wins over the per-user home (issue option 1).
+# A real system-prefix binary must not win over the service-owned prefix
+# for a managed non-root unit (#580). Self-upgrade has to write the prefix
+# the service user owns, not the root-global install.
 printf '#!/bin/sh\n' > "$BIN232/usr-bin-kimaki"
 chmod +x "$BIN232/usr-bin-kimaki"
 RESOLVED_SYS=$(_kimaki_resolve_service_bin "/usr/bin/kimaki")
-assert "system-prefix binary preferred over per-user home" \
-  "$([ "$RESOLVED_SYS" = "$BIN232/usr-bin-kimaki" ]; echo $?)"
+assert "service-owned prefix preferred over system-prefix for non-root" \
+  "$([ "$RESOLVED_SYS" = "$ADOPTED_HOME/.local/bin/kimaki" ]; echo $?)"
 
 export PATH="$PATH_SAVE"
 unset KIMAKI_SYSTEM_PREFIX_BINS WP_CODING_AGENTS_TEST_ASSUME_ROOT


### PR DESCRIPTION
## Summary

- install managed non-root Kimaki into a prefix owned by the configured service user
- render systemd `ExecStart`, `PATH`, and `npm_config_prefix` against that writable installation
- converge existing root-global/non-root-service installations without weakening permissions or adding sudo grants
- preserve root-service, local, external WordPress, and multi-instance behavior

Fixes #580. Related to #203.

## Verification

- `bash tests/kimaki-install-existing.sh` (28 assertions)
- `bash tests/service-identity-adoption.sh` (27 assertions)
- `bash tests/bridge-render.sh`
- `bash -n bridges/kimaki.sh tests/kimaki-install-existing.sh tests/service-identity-adoption.sh`
- `git diff --check`
- Homeboy audit: zero introduced findings

`tests/service-migration.sh` retains four pre-existing macOS fixture failures that reproduce unchanged on `main`; this change does not touch those paths.

---
AI assistance disclosure: xAI Grok 4.6 via OpenCode and Homeboy produced the initial candidate; GPT-5.6 Sol via OpenCode reviewed it, corrected identity/error handling and test isolation, and ran verification under Chris Huber direction.