### PR TITLE
fix: isolate agent WP-CLI registration warnings

### DIFF
--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -19,6 +19,7 @@
 # Public surface:
 #   agents_md_guidance_mu_plugin_path
 #   agents_md_guidance_ensure_mu_plugin_file
+#   agents_md_guidance_agent_wp_cli_path
 #   agents_md_guidance_sync_wp_cli_transport
 #   agents_md_guidance_register <section_id> <priority> <label> <description> <content>
 #   agents_md_guidance_unregister <section_id>
@@ -30,6 +31,16 @@ agents_md_guidance_mu_plugin_path() {
     return 1
   fi
   printf '%s' "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+}
+
+# Keep agent commands on a wrapper separate from setup's WP-CLI transport.
+# Plugin command registration warnings are useful installation diagnostics, but
+# obscure the result agents need from every composed command invocation.
+agents_md_guidance_agent_wp_cli_path() {
+  if [ -z "${SITE_PATH:-}" ]; then
+    return 1
+  fi
+  printf '%s' "$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agent-wp"
 }
 
 agents_md_guidance_ensure_mu_plugin_file() {
@@ -185,16 +196,20 @@ agents_md_guidance_register() {
 # environment that setup detected. The filter is written at mu-plugin file scope
 # so it exists before ordinary plugins register or render any sections.
 agents_md_guidance_sync_wp_cli_transport() {
-  local file transport new_block
+  local file transport agent_transport new_block
   file="$(agents_md_guidance_mu_plugin_path)" || return 1
   agents_md_guidance_ensure_mu_plugin_file || return 1
   transport="$(wp_cli_transport_display)"
-  new_block="$(_agents_md_guidance_render_wp_cli_transport_block "$transport")" || return 1
+  agent_transport="$(agents_md_guidance_agent_wp_cli_path)" || return 1
 
   if [ "${DRY_RUN:-false}" = true ]; then
+    echo -e "${BLUE}[dry-run]${NC} Would write agent WP-CLI transport at $agent_transport"
     echo -e "${BLUE}[dry-run]${NC} Would register AGENTS.md WP-CLI transport in $file"
     return 0
   fi
+
+  _agents_md_guidance_write_agent_wp_cli_transport "$agent_transport" "${WP_CLI_TRANSPORT[@]}" || return 1
+  new_block="$(_agents_md_guidance_render_wp_cli_transport_block "$agent_transport")" || return 1
 
   if _agents_md_guidance_block_matches "$file" "wp-cli-transport" "$new_block"; then
     return 0
@@ -205,7 +220,41 @@ agents_md_guidance_sync_wp_cli_transport() {
   _agents_md_guidance_rewrite "$file" "wp-cli-transport" "$new_block" > "$tmp"
   mv "$tmp" "$file"
   service_file_normalize_perms "$file"
-  log "  Registered AGENTS.md WP-CLI transport: $transport"
+  log "  Registered AGENTS.md agent WP-CLI transport: $transport"
+}
+
+_agents_md_guidance_write_agent_wp_cli_transport() {
+  local file="$1"
+  shift
+  local dir tmp argument
+  dir="${file%/*}"
+  mkdir -p "$dir"
+  tmp=$(mktemp "${file}.XXXXXX")
+  {
+    printf '%s\n' '#!/bin/bash'
+    printf '%s\n' 'set -o pipefail'
+    printf '%s\n' 'stderr_file=$(mktemp "${TMPDIR:-/tmp}/wp-coding-agents-agent-wp.XXXXXX") || exit 1'
+    printf '%s\n' "trap 'rm -f \"\$stderr_file\"' EXIT"
+    for argument in "$@"; do
+      printf '%q ' "$argument"
+    done
+    printf '%s\n' '"$@" 2>"$stderr_file"'
+    printf '%s\n' 'status=$?'
+    printf '%s\n' 'while IFS= read -r line || [ -n "$line" ]; do'
+    printf '%s\n' '  if [[ "$line" =~ [Ww]arning ]] && [[ "$line" =~ --(context|user|path|quiet) ]] && [[ "$line" =~ (already[[:space:]]+(registered|exists)|collision|conflict) ]]; then'
+    printf '%s\n' '    continue'
+    printf '%s\n' '  fi'
+    printf '%s\n' '  printf "%s\\n" "$line" >&2'
+    printf '%s\n' 'done < "$stderr_file"'
+    printf '%s\n' 'exit "$status"'
+  } > "$tmp"
+  chmod 0755 "$tmp"
+  if [ -f "$file" ] && cmp -s "$tmp" "$file"; then
+    rm -f "$tmp"
+    return 0
+  fi
+  mv "$tmp" "$file"
+  log "  Wrote agent WP-CLI transport: $file"
 }
 
 agents_md_guidance_unregister() {

--- a/tests/agents-md-composition-integration.sh
+++ b/tests/agents-md-composition-integration.sh
@@ -17,6 +17,7 @@ source "$ROOT_DIR/lib/agents-md-guidance.sh"
 log() { :; }
 
 MU_FILE="$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+AGENT_WP="$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agent-wp"
 
 cat > "$TMP/bin/studio" <<'SH'
 #!/bin/bash
@@ -40,7 +41,15 @@ while [ "$#" -gt 0 ]; do
 done
 case "${1:-} ${2:-} ${3:-} ${4:-}" in
   "datamachine memory paths fixture") exit 0 ;;
-  "intelligence search fixture ") exit 0 ;;
+  "intelligence search fixture ")
+    printf '%s\n' 'Warning: The --context argument is already registered by another command.' >&2
+    printf '%s\n' 'Warning: The --user argument is already registered by another command.' >&2
+    printf '%s\n' 'Warning: The --path argument is already registered by another command.' >&2
+    printf '%s\n' 'Warning: The --quiet argument is already registered by another command.' >&2
+    printf '%s\n' 'Warning: an unrelated command diagnostic.' >&2
+    printf '%s\n' 'search result'
+    exit 0
+    ;;
 esac
 exit 11
 SH
@@ -107,8 +116,8 @@ foreach ( array( 'datamachine memory paths fixture', 'intelligence search fixtur
 PHP
 
 run_case() {
-  local name="$1" expected="$2"
-  shift 2
+  local name="$1"
+  shift
   wp_cli_transport_set "$@"
   agents_md_guidance_sync_wp_cli_transport
 
@@ -121,14 +130,25 @@ run_case() {
   }
 
   php "$TMP/compose.php" "$MU_FILE" "$TMP/$name-AGENTS.md" "$TMP/$name-dm.cmd" "$TMP/$name-intelligence.cmd"
-  grep -F "\`$expected --path=/path/to/site datamachine memory paths fixture\`" "$TMP/$name-AGENTS.md" >/dev/null
-  grep -F "\`$expected --path=/path/to/site intelligence search fixture\`" "$TMP/$name-AGENTS.md" >/dev/null
+  grep -F "\`$AGENT_WP --path=/path/to/site datamachine memory paths fixture\`" "$TMP/$name-AGENTS.md" >/dev/null
+  grep -F "\`$AGENT_WP --path=/path/to/site intelligence search fixture\`" "$TMP/$name-AGENTS.md" >/dev/null
+
+  diagnostics=$(env -i PATH="$TMP/bin:/usr/bin:/bin" "${WP_CLI_TRANSPORT[@]}" --path=/path/to/site intelligence search fixture 2>&1)
+  case "$diagnostics" in
+    *'Warning: The --context argument is already registered by another command.'*) ;;
+    *) echo "FAIL: $name direct transport no longer reports registration diagnostics" >&2; return 1 ;;
+  esac
 
   env -i PATH="$TMP/bin:/usr/bin:/bin" bash -c "$(<"$TMP/$name-dm.cmd")"
   env -i PATH="$TMP/bin:/usr/bin:/bin" bash -c "$(<"$TMP/$name-intelligence.cmd")"
+  result=$(env -i PATH="$TMP/bin:/usr/bin:/bin" bash -c "$(<"$TMP/$name-intelligence.cmd")" 2>&1)
+  [ "$result" = $'search result\nWarning: an unrelated command diagnostic.' ] || {
+    echo "FAIL: $name agent transport did not isolate registration warnings: $result" >&2
+    return 1
+  }
 }
 
-run_case studio "studio wp" studio wp
+run_case studio studio wp
 
 # Upgrade an installation written by #521, where the filter lived inside the
 # late section-registration callback, and verify it is moved back to file scope.
@@ -146,7 +166,7 @@ content = content[:begin] + content[end:].lstrip("\n")
 content = content.replace("    // END agents-md-guidance-sections", block + "\n    // END agents-md-guidance-sections")
 path.write_text(content)
 PY
-run_case studio-upgrade "studio wp" studio wp
-run_case generic wp wp
+run_case studio-upgrade studio wp
+run_case generic wp
 
 echo "OK: composed Data Machine and Intelligence guidance uses one executable transport"

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -35,6 +35,7 @@ if [ "$VERBOSE" = false ]; then
 fi
 
 MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+AGENT_WP="$TMP/wp-content/mu-plugins/wp-coding-agents-agent-wp"
 FAILED=0
 
 assert_eq() {
@@ -296,10 +297,10 @@ SH
 chmod +x "$TMP/bin/studio"
 wp_cli_transport_set studio wp
 guidance_sync_all
-if grep -q "return 'studio wp'" "$MU_FILE"; then
-  echo "  ok   Studio transport stored in generated guidance"
+if grep -q "return '$AGENT_WP'" "$MU_FILE"; then
+  echo "  ok   agent WP-CLI transport stored in generated guidance"
 else
-  echo "  FAIL Studio transport was not stored in generated guidance"
+  echo "  FAIL agent WP-CLI transport was not stored in generated guidance"
   FAILED=$((FAILED + 1))
 fi
 TRANSPORT_SHIM="$TMP/transport-shim.php"
@@ -325,17 +326,17 @@ foreach ( \$GLOBALS['actions']['datamachine_sections'] as \$callbacks ) { foreac
 echo apply_filters( 'datamachine_wp_cli_cmd', 'wp --path=/path/to/site' );
 PHP
 GENERATED_PREFIX=$(php "$TRANSPORT_SHIM")
-assert_eq "$GENERATED_PREFIX" "studio wp --path=/path/to/site" "Studio AGENTS command prefix preserves path"
+assert_eq "$GENERATED_PREFIX" "$AGENT_WP --path=/path/to/site" "agent WP-CLI command prefix preserves path"
 if env -i PATH="$TMP/bin:/usr/bin:/bin" bash -c "$GENERATED_PREFIX datamachine memory compose AGENTS.md"; then
-  echo "  ok   generated Studio command executes without bare wp"
+  echo "  ok   generated agent command executes through selected transport"
 else
-  echo "  FAIL generated Studio command does not execute without bare wp"
+  echo "  FAIL generated agent command does not execute through selected transport"
   FAILED=$((FAILED + 1))
 fi
 wp_cli_transport_set wp
 guidance_sync_all
 GENERATED_PREFIX=$(php "$TRANSPORT_SHIM")
-assert_eq "$GENERATED_PREFIX" "wp --path=/path/to/site" "generic AGENTS command prefix retains wp"
+assert_eq "$GENERATED_PREFIX" "$AGENT_WP --path=/path/to/site" "generic AGENTS command uses the agent transport"
 
 echo "==> WordPress guidance wins mixed-version registration"
 MIXED_SHIM="$TMP/mixed-section-shim.php"


### PR DESCRIPTION
Closes #582.

Routes composed AGENTS.md WP-CLI commands through a managed agent-only wrapper that removes known plugin argument-registration collision warnings for `--context`, `--user`, `--path`, and `--quiet`. Setup and direct transport calls remain unfiltered, preserving their diagnostic output.

Tests:
- `bash tests/agents-md-guidance.sh`
- `bash tests/agents-md-composition-integration.sh`
- `bash tests/ci-coverage.sh`

AI assistance: OpenAI GPT-5.6 Terra via OpenCode.