### PR TITLE
Harden AGENTS.md guidance provenance

### DIFF
--- a/guidance/homeboy.sh
+++ b/guidance/homeboy.sh
@@ -114,7 +114,15 @@ _guidance_homeboy_live_block() {
   local quoted_path
   quoted_path="$(_guidance_homeboy_php_quote "$homeboy_path")"
 
-  cat <<'PHP_BLOCK' | sed "s|__WP_CODING_AGENTS_HOMEBOY_BIN__|${quoted_path//|/\\|}|g"
+  local provenance producer_version producer_source
+  provenance="$(agents_md_guidance_provenance_markdown)"
+  producer_version="$(agents_md_guidance_producer_version)"
+  producer_source="$(agents_md_guidance_producer_source)"
+  cat <<'PHP_BLOCK' | sed \
+    -e "s|__WP_CODING_AGENTS_HOMEBOY_BIN__|${quoted_path//|/\\|}|g" \
+    -e "s|__WP_CODING_AGENTS_PROVENANCE__|${provenance//|/\\|}|g" \
+    -e "s|__WP_CODING_AGENTS_PRODUCER_VERSION__|${producer_version//|/\\|}|g" \
+    -e "s|__WP_CODING_AGENTS_PRODUCER_SOURCE__|${producer_source//|/\\|}|g"
     // BEGIN agents-md-guidance:homeboy-cli
     // Absolute path resolved by wp-coding-agents at sync time. Checked live
     // at every compose so losing the binary drops the section (#254), but
@@ -136,6 +144,7 @@ _guidance_homeboy_live_block() {
             }
 
             return <<<'MD'
+__WP_CODING_AGENTS_PROVENANCE__
 ## Homeboy
 
 Homeboy orchestrates coding agents, deterministic gates, evidence, promotion, review, releases, and deployments. Homeboy owns the native Rust worktree lifecycle and Cook.
@@ -180,6 +189,8 @@ MD;
                 'label'       => 'Homeboy',
                 'description' => 'Host orchestration routing, safety, and discovery guidance.',
                 'owner'       => 'wp-coding-agents',
+                'producer_version' => '__WP_CODING_AGENTS_PRODUCER_VERSION__',
+                'producer_source'  => '__WP_CODING_AGENTS_PRODUCER_SOURCE__',
                 'freshness'   => 'live',
                 'conditions'  => 'Registered only while the homeboy binary is executable at AGENTS.md compose time.',
             )

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -26,6 +26,35 @@
 #
 # Honors DRY_RUN (logs intent, makes no changes).
 
+# Producer provenance is derived from content, never a build time or host path.
+# A checkout records its immutable commit; packaged installs use a digest of the
+# guidance producer surface instead.
+agents_md_guidance_producer_version() {
+  tr -d '[:space:]' < "$SCRIPT_DIR/VERSION" 2>/dev/null || printf 'unknown'
+}
+
+agents_md_guidance_producer_source() {
+  local commit digest
+  commit="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)"
+  if [ -n "$commit" ]; then
+    printf 'commit:%s' "$commit"
+    return 0
+  fi
+
+  digest=$(cd "$SCRIPT_DIR" && {
+    for file in VERSION lib/agents-md-guidance.sh guidance/*.sh; do
+      [ -f "$file" ] && shasum -a 256 "$file"
+    done
+  } | shasum -a 256 | awk '{print $1}')
+  printf 'sha256:%s' "${digest:-unknown}"
+}
+
+agents_md_guidance_provenance_markdown() {
+  printf '<!-- wp-coding-agents-provenance: version=%s source=%s -->' \
+    "$(agents_md_guidance_producer_version)" \
+    "$(agents_md_guidance_producer_source)"
+}
+
 agents_md_guidance_mu_plugin_path() {
   if [ -z "${SITE_PATH:-}" ]; then
     return 1
@@ -297,6 +326,8 @@ _agents_md_guidance_render_block() {
   AGENTS_MD_GUIDANCE_LABEL="$label" \
   AGENTS_MD_GUIDANCE_DESCRIPTION="$description" \
   AGENTS_MD_GUIDANCE_CONTENT="$content" \
+  AGENTS_MD_GUIDANCE_PRODUCER_VERSION="$(agents_md_guidance_producer_version)" \
+  AGENTS_MD_GUIDANCE_PRODUCER_SOURCE="$(agents_md_guidance_producer_source)" \
   AGENTS_MD_GUIDANCE_FRESHNESS="${AGENTS_MD_GUIDANCE_FRESHNESS:-conditional}" \
   AGENTS_MD_GUIDANCE_CONDITIONS="${AGENTS_MD_GUIDANCE_CONDITIONS:-Registered by wp-coding-agents when the integration is available; removed when unavailable.}" \
   python3 <<'PY'
@@ -309,6 +340,8 @@ priority = os.environ["AGENTS_MD_GUIDANCE_PRIORITY"]
 label = os.environ["AGENTS_MD_GUIDANCE_LABEL"]
 description = os.environ.get("AGENTS_MD_GUIDANCE_DESCRIPTION", "")
 content = os.environ["AGENTS_MD_GUIDANCE_CONTENT"].rstrip("\n")
+producer_version = os.environ["AGENTS_MD_GUIDANCE_PRODUCER_VERSION"]
+producer_source = os.environ["AGENTS_MD_GUIDANCE_PRODUCER_SOURCE"]
 freshness = os.environ.get("AGENTS_MD_GUIDANCE_FRESHNESS", "conditional")
 conditions = os.environ.get("AGENTS_MD_GUIDANCE_CONDITIONS", "")
 
@@ -331,6 +364,7 @@ print(f"        '{esc(section_id)}',")
 print(f"        {priority_int},")
 print("        static function () {")
 print("            return <<<'MD'")
+print(f"<!-- wp-coding-agents-provenance: version={producer_version} source={producer_source} -->")
 print(content)
 print("MD;")
 print("        },")
@@ -338,6 +372,8 @@ print("        array(")
 print(f"            'label'       => '{esc(label)}',")
 print(f"            'description' => '{esc(description)}',")
 print("            'owner'       => 'wp-coding-agents',")
+print(f"            'producer_version' => '{esc(producer_version)}',")
+print(f"            'producer_source'  => '{esc(producer_source)}',")
 print(f"            'freshness'   => '{esc(freshness)}',")
 print(f"            'conditions'  => '{esc(conditions)}',")
 print("        )")

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -27,32 +27,94 @@
 # Honors DRY_RUN (logs intent, makes no changes).
 
 # Producer provenance is derived from content, never a build time or host path.
-# A checkout records its immutable commit; packaged installs use a digest of the
-# guidance producer surface instead.
+# Only a clean checkout can claim its commit identity. Dirty checkouts and
+# packages instead identify the guidance producer surface deterministically.
 agents_md_guidance_producer_version() {
-  tr -d '[:space:]' < "$SCRIPT_DIR/VERSION" 2>/dev/null || printf 'unknown'
+  local version
+  IFS= read -r version < "$SCRIPT_DIR/VERSION" || version="unknown"
+  printf '%s' "${version:-unknown}"
+}
+
+_agents_md_guidance_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum
+  else
+    return 127
+  fi
+}
+
+_agents_md_guidance_surface_digest() {
+  command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || return 1
+  command -v awk >/dev/null 2>&1 || return 1
+  (
+    cd "$SCRIPT_DIR" || exit 1
+    for file in VERSION lib/agents-md-guidance.sh guidance/*.sh; do
+      [ -f "$file" ] || continue
+      printf '%s\0' "$file"
+      _agents_md_guidance_sha256 < "$file" | awk '{print $1}'
+    done
+  ) | _agents_md_guidance_sha256 | awk '{print $1}'
 }
 
 agents_md_guidance_producer_source() {
-  local commit digest
-  commit="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)"
-  if [ -n "$commit" ]; then
-    printf 'commit:%s' "$commit"
-    return 0
+  local commit digest version state
+  version="$(agents_md_guidance_producer_version)"
+  if git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [ -z "$(git -C "$SCRIPT_DIR" status --porcelain --untracked-files=all 2>/dev/null)" ]; then
+      commit="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)"
+      if [ -n "$commit" ]; then
+        printf 'commit:%s' "$commit"
+        return 0
+      fi
+    fi
+    state="dirty"
+  else
+    state="package"
   fi
 
-  digest=$(cd "$SCRIPT_DIR" && {
-    for file in VERSION lib/agents-md-guidance.sh guidance/*.sh; do
-      [ -f "$file" ] && shasum -a 256 "$file"
-    done
-  } | shasum -a 256 | awk '{print $1}')
-  printf 'sha256:%s' "${digest:-unknown}"
+  digest="$(_agents_md_guidance_surface_digest || true)"
+  if [ -n "$digest" ]; then
+    printf '%s-sha256:%s' "$state" "$digest"
+  else
+    # Minimal packaged environments may not ship either hashing utility. The
+    # version fallback is explicit and remains deterministic for a release.
+    printf '%s-version:%s' "$state" "$version"
+  fi
 }
 
 agents_md_guidance_provenance_markdown() {
   printf '<!-- wp-coding-agents-provenance: version=%s source=%s -->' \
     "$(agents_md_guidance_producer_version)" \
     "$(agents_md_guidance_producer_source)"
+}
+
+agents_md_guidance_composed_producer() {
+  [ -f "$1" ] || return 0
+  sed -n 's/.*wp-coding-agents-provenance: version=\([^ ]*\) source=\([^ ]*\).*/version=\1 source=\2/p' "$1" | sort -u
+}
+
+# Returns 0 for current active guidance, 2 when AGENTS.md guidance is gated,
+# and 1 when an active composed section was not produced by this source.
+agents_md_guidance_verify_composed_provenance() {
+  local composed expected
+  composed="$(agents_md_guidance_composed_producer "$1")"
+  [ -n "$composed" ] || return 2
+  expected="version=$(agents_md_guidance_producer_version) source=$(agents_md_guidance_producer_source)"
+  [ "$composed" = "$expected" ]
+}
+
+# Restore the file state recorded before a compose attempt. A failed compose may
+# have created a partial file even where no AGENTS.md previously existed.
+agents_md_guidance_restore_precompose_state() {
+  local agents_md="$1" backup="$2" had_agents_md="$3"
+  if [ "$had_agents_md" = true ]; then
+    cp "$backup" "$agents_md"
+    service_file_normalize_perms "$agents_md"
+  else
+    rm -f "$agents_md"
+  fi
 }
 
 agents_md_guidance_mu_plugin_path() {

--- a/lib/agents-md-guidance.sh
+++ b/lib/agents-md-guidance.sh
@@ -95,14 +95,28 @@ agents_md_guidance_composed_producer() {
   sed -n 's/.*wp-coding-agents-provenance: version=\([^ ]*\) source=\([^ ]*\).*/version=\1 source=\2/p' "$1" | sort -u
 }
 
-# Returns 0 for current active guidance, 2 when AGENTS.md guidance is gated,
-# and 1 when an active composed section was not produced by this source.
+# Returns 0 for current guidance and 1 for stale or missing provenance.
 agents_md_guidance_verify_composed_provenance() {
   local composed expected
   composed="$(agents_md_guidance_composed_producer "$1")"
-  [ -n "$composed" ] || return 2
+  [ -n "$composed" ] || return 1
   expected="version=$(agents_md_guidance_producer_version) source=$(agents_md_guidance_producer_source)"
   [ "$composed" = "$expected" ]
+}
+
+# Query Data Machine's actual runtime AGENTS.md gate. The supplied command is
+# the WP-CLI runner (for example, wp_cli or wp_run_as_service_user). Return 0
+# for enabled, 1 for explicitly disabled, 2 when the gate is unavailable, and
+# 3 when WordPress cannot authoritatively answer.
+agents_md_guidance_composition_gate() {
+  local state
+  state="$("$@" eval 'if ( ! function_exists( "datamachine_agents_md_enabled" ) ) { echo "unavailable"; } elseif ( datamachine_agents_md_enabled() ) { echo "enabled"; } else { echo "disabled"; }' 2>/dev/null)" || return 3
+  case "$state" in
+    enabled) return 0 ;;
+    disabled) return 1 ;;
+    unavailable) return 2 ;;
+    *) return 3 ;;
+  esac
 }
 
 # Restore the file state recorded before a compose attempt. A failed compose may

--- a/tests/agents-md-composition-integration.sh
+++ b/tests/agents-md-composition-integration.sh
@@ -3,6 +3,7 @@
 set -eu
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$ROOT_DIR"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -168,5 +169,76 @@ path.write_text(content)
 PY
 run_case studio-upgrade studio wp
 run_case generic wp
+
+echo "==> upgrade restores AGENTS.md after failed or stale composition"
+UPGRADE_TMP="$TMP/upgrade"
+mkdir -p "$UPGRADE_TMP/bin"
+cat > "$UPGRADE_TMP/bin/wp" <<'SH'
+#!/bin/bash
+for arg in "$@"; do
+  case "$arg" in
+    eval)
+      printf '%s\n' "${COMPOSE_GATE:-enabled}"
+      exit 0
+      ;;
+  esac
+done
+if [ "${1:-}" = "datamachine" ] && [ "${2:-}" = "memory" ] && [ "${3:-}" = "compose" ]; then
+  case "${COMPOSE_CASE:-}" in
+    partial-fail)
+      # Runtime instruction setup composes first. Leave no file there so the
+      # phase under test is the first writer of AGENTS.md.
+      if [ ! -e "${COMPOSE_COUNT_FILE:-/dev/null}" ]; then touch "$COMPOSE_COUNT_FILE"; exit 0; fi
+      printf '%s\n' 'partial compose output' > AGENTS.md
+      exit 1
+      ;;
+    missing-success) printf '%s\n' 'successful compose without provenance'; exit 0 ;;
+    stale-success) printf '%s\n' '<!-- wp-coding-agents-provenance: version=old source=commit:stale -->' > AGENTS.md; exit 0 ;;
+  esac
+fi
+exit 0
+SH
+chmod +x "$UPGRADE_TMP/bin/wp"
+
+assert_upgrade_failure_restores() {
+  local name="$1" initial="$2" case_name="$3" site output
+  site="$UPGRADE_TMP/$name"
+  mkdir -p "$site/wp-content/mu-plugins"
+  : > "$site/wp-config.php"
+  if [ -n "$initial" ]; then
+    printf '%s' "$initial" > "$site/AGENTS.md"
+    cp "$site/AGENTS.md" "$site/original"
+    : > "$site/compose-count"
+  fi
+  if output=$(PATH="$UPGRADE_TMP/bin:$PATH" COMPOSE_CASE="$case_name" COMPOSE_COUNT_FILE="$site/compose-count" COMPOSE_GATE=enabled \
+    bash "$ROOT_DIR/upgrade.sh" --local --runtime opencode --wp-path "$site" --agents-md-only --skip-plugins 2>&1); then
+    echo "FAIL: $name upgrade unexpectedly succeeded" >&2
+    exit 1
+  fi
+  if [ -n "$initial" ]; then
+    cmp -s "$site/original" "$site/AGENTS.md" || { echo "FAIL: $name did not restore AGENTS.md byte-for-byte: $output" >&2; exit 1; }
+  elif [ -e "$site/AGENTS.md" ]; then
+    echo "FAIL: $name left a newly-created partial AGENTS.md: $output" >&2
+    exit 1
+  fi
+}
+
+assert_upgrade_failure_restores partial-compose $'## User guidance\nexact bytes\n' partial-fail
+assert_upgrade_failure_restores new-partial-compose '' partial-fail
+assert_upgrade_failure_restores missing-provenance-compose $'## User guidance\nexact bytes\n' missing-success
+assert_upgrade_failure_restores stale-compose $'## User guidance\nexact bytes\n' stale-success
+
+VERIFY_SITE="$UPGRADE_TMP/verify"
+mkdir -p "$VERIFY_SITE/wp-content/mu-plugins"
+: > "$VERIFY_SITE/wp-config.php"
+printf '%s\n' "$(agents_md_guidance_provenance_markdown)" > "$VERIFY_SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+if VERIFY_OUTPUT=$(PATH="$UPGRADE_TMP/bin:$PATH" COMPOSE_GATE=enabled bash "$ROOT_DIR/verify.sh" --site-path "$VERIFY_SITE" 2>&1); then
+  echo "FAIL: verify accepted installed guidance with missing composed provenance" >&2
+  exit 1
+fi
+case "$VERIFY_OUTPUT" in
+  *'installed guidance is version='*'not explicitly disabled or unavailable'*) ;;
+  *) echo "FAIL: verify did not identify installed-present/composed-missing provenance drift: $VERIFY_OUTPUT" >&2; exit 1 ;;
+esac
 
 echo "OK: composed Data Machine and Intelligence guidance uses one executable transport"

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -217,6 +217,8 @@ namespace {
         'priority' => \$call[2] ?? null,
         'label' => \$call[4]['label'] ?? null,
         'owner' => \$call[4]['owner'] ?? null,
+        'producer_version' => \$call[4]['producer_version'] ?? null,
+        'producer_source' => \$call[4]['producer_source'] ?? null,
         'freshness' => \$call[4]['freshness'] ?? null,
         'conditions' => \$call[4]['conditions'] ?? null,
         'content' => \$content,
@@ -225,7 +227,9 @@ namespace {
 PHP
 
 RESULT=$(php "$SHIM")
-EXPECTED='{"filename":"AGENTS.md","slug":"sample-guidance","priority":36,"label":"Sample guidance","owner":"wp-coding-agents","freshness":"conditional","conditions":"Registered by wp-coding-agents when the integration is available; removed when unavailable.","content":"## Sample guidance"}'
+PRODUCER_VERSION="$(agents_md_guidance_producer_version)"
+PRODUCER_SOURCE="$(agents_md_guidance_producer_source)"
+EXPECTED="{\"filename\":\"AGENTS.md\",\"slug\":\"sample-guidance\",\"priority\":36,\"label\":\"Sample guidance\",\"owner\":\"wp-coding-agents\",\"producer_version\":\"$PRODUCER_VERSION\",\"producer_source\":\"$PRODUCER_SOURCE\",\"freshness\":\"conditional\",\"conditions\":\"Registered by wp-coding-agents when the integration is available; removed when unavailable.\",\"content\":\"<!-- wp-coding-agents-provenance: version=$PRODUCER_VERSION source=$PRODUCER_SOURCE -->\\n## Sample guidance\"}"
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives generic guidance section"
 
 echo "==> unregister generic guidance"
@@ -405,6 +409,8 @@ PATH="$TMP/homeboy-bin:$PATH"
 export PATH
 guidance_sync_unit homeboy
 assert_contains "$MU_FILE" 'Homeboy remains the normal owner of tracked coding work.' "Homeboy guidance preserves normal ownership"
+assert_contains "$MU_FILE" "wp-coding-agents-provenance: version=$PRODUCER_VERSION source=$PRODUCER_SOURCE" "Homeboy guidance records its producer provenance"
+assert_contains "$MU_FILE" "'producer_version' => '$PRODUCER_VERSION'" "Homeboy metadata records its producer version"
 assert_contains "$MU_FILE" 'homeboy agent-task cook --preview' "Homeboy guidance validates the selected route"
 assert_contains "$MU_FILE" 'homeboy agent-task cook --help-full' "Homeboy guidance discovers exact alternative routes"
 assert_contains "$MU_FILE" 'configured attempt and provider-rotation budget' "Homeboy guidance bounds recovery"

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -23,6 +23,9 @@ source "$SCRIPT_DIR/guidance/_dispatch.sh"
 SOURCE_MODE="${SOURCE_MODE:-workspace}"
 UPDATED_ITEMS=()
 
+PRODUCER_VERSION="$(agents_md_guidance_producer_version)"
+PRODUCER_SOURCE="$(agents_md_guidance_producer_source)"
+
 VERBOSE=false
 for arg in "$@"; do
   case "$arg" in
@@ -144,6 +147,74 @@ else
   FAILED=$((FAILED + 1))
 fi
 
+echo "==> provenance identities distinguish dirty and packaged producers"
+DIRTY="$TMP/dirty"
+mkdir -p "$DIRTY/lib" "$DIRTY/guidance"
+cp "$SCRIPT_DIR/VERSION" "$DIRTY/VERSION"
+cp "$SCRIPT_DIR/lib/agents-md-guidance.sh" "$DIRTY/lib/agents-md-guidance.sh"
+cp "$SCRIPT_DIR"/guidance/*.sh "$DIRTY/guidance/"
+git -C "$DIRTY" init -q
+git -C "$DIRTY" add .
+git -C "$DIRTY" -c user.email=tests@example.invalid -c user.name=tests commit -qm fixture
+printf '%s\n' '# dirty fixture' >> "$DIRTY/guidance/homeboy.sh"
+DIRTY_SOURCE=$(SCRIPT_DIR="$DIRTY"; source "$DIRTY/lib/agents-md-guidance.sh"; agents_md_guidance_producer_source)
+case "$DIRTY_SOURCE" in
+  dirty-sha256:*|dirty-version:*) echo "  ok   dirty checkout never claims a clean commit identity" ;;
+  *) echo "  FAIL dirty checkout claimed unexpected producer identity: $PRODUCER_SOURCE"; FAILED=$((FAILED + 1)) ;;
+esac
+
+PACKAGE="$TMP/package"
+mkdir -p "$PACKAGE/lib"
+cp "$SCRIPT_DIR/VERSION" "$PACKAGE/VERSION"
+cp "$SCRIPT_DIR/lib/agents-md-guidance.sh" "$PACKAGE/lib/agents-md-guidance.sh"
+mkdir -p "$PACKAGE/guidance"
+cp "$SCRIPT_DIR"/guidance/*.sh "$PACKAGE/guidance/"
+PACKAGE_SOURCE=$(SCRIPT_DIR="$PACKAGE"; source "$PACKAGE/lib/agents-md-guidance.sh"; agents_md_guidance_producer_source)
+case "$PACKAGE_SOURCE" in
+  package-sha256:*) echo "  ok   packaged producer uses portable content identity" ;;
+  *) echo "  FAIL packaged producer identity: $PACKAGE_SOURCE"; FAILED=$((FAILED + 1)) ;;
+esac
+PACKAGE_FALLBACK=$(PATH="/nonexistent"; SCRIPT_DIR="$PACKAGE"; source "$PACKAGE/lib/agents-md-guidance.sh"; agents_md_guidance_producer_source)
+assert_eq "$PACKAGE_FALLBACK" "package-version:$PRODUCER_VERSION" "packaged producer has an explicit no-hash fallback"
+
+echo "==> old producer recomposes to current guidance"
+OLD_PRODUCER='version=1.21.1 source=commit:0000000000000000000000000000000000000000'
+printf '%s\n' "<!-- wp-coding-agents-provenance: $OLD_PRODUCER -->" > "$TMP/AGENTS.md"
+if agents_md_guidance_verify_composed_provenance "$TMP/AGENTS.md"; then
+  echo "  FAIL old composed producer was accepted as current"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   old composed producer requires recompose"
+fi
+printf '%s\n' "$(agents_md_guidance_provenance_markdown)" 'request explicit operator authorization before invoking a coding runtime directly' > "$TMP/AGENTS.md"
+if agents_md_guidance_verify_composed_provenance "$TMP/AGENTS.md"; then
+  echo "  ok   recompose produces current provenance and recovery behavior"
+else
+  echo "  FAIL recomposed guidance was not current"
+  FAILED=$((FAILED + 1))
+fi
+printf '%s\n' '## Guidance intentionally disabled' > "$TMP/AGENTS.md"
+if agents_md_guidance_verify_composed_provenance "$TMP/AGENTS.md"; then
+  echo "  FAIL disabled guidance was incorrectly active"
+  FAILED=$((FAILED + 1))
+else
+  STATUS=$?
+  assert_eq "$STATUS" "2" "disabled guidance is a healthy gated state"
+fi
+printf '%s\n' '## User guidance before failed compose' > "$TMP/precompose"
+cp "$TMP/precompose" "$TMP/precompose.backup"
+printf '%s\n' 'partial stale compose output' > "$TMP/precompose"
+agents_md_guidance_restore_precompose_state "$TMP/precompose" "$TMP/precompose.backup" true
+assert_eq "$(<"$TMP/precompose")" '## User guidance before failed compose' "failed or stale compose restores existing user guidance"
+printf '%s\n' 'partial output without predecessor' > "$TMP/new-precompose"
+agents_md_guidance_restore_precompose_state "$TMP/new-precompose" "$TMP/missing-backup" false
+if [ -e "$TMP/new-precompose" ]; then
+  echo "  FAIL failed compose left a new partial AGENTS.md"
+  FAILED=$((FAILED + 1))
+else
+  echo "  ok   failed compose removes a new partial AGENTS.md"
+fi
+
 echo "==> re-register generic guidance (idempotent)"
 HASH_BEFORE=$(file_hash "$MU_FILE")
 agents_md_guidance_register "sample-guidance" 36 "Sample guidance" "Sample generated guidance." "## Sample guidance"
@@ -227,8 +298,6 @@ namespace {
 PHP
 
 RESULT=$(php "$SHIM")
-PRODUCER_VERSION="$(agents_md_guidance_producer_version)"
-PRODUCER_SOURCE="$(agents_md_guidance_producer_source)"
 EXPECTED="{\"filename\":\"AGENTS.md\",\"slug\":\"sample-guidance\",\"priority\":36,\"label\":\"Sample guidance\",\"owner\":\"wp-coding-agents\",\"producer_version\":\"$PRODUCER_VERSION\",\"producer_source\":\"$PRODUCER_SOURCE\",\"freshness\":\"conditional\",\"conditions\":\"Registered by wp-coding-agents when the integration is available; removed when unavailable.\",\"content\":\"<!-- wp-coding-agents-provenance: version=$PRODUCER_VERSION source=$PRODUCER_SOURCE -->\\n## Sample guidance\"}"
 assert_eq "$RESULT" "$EXPECTED" "SectionRegistry receives generic guidance section"
 

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -199,7 +199,7 @@ if agents_md_guidance_verify_composed_provenance "$TMP/AGENTS.md"; then
   FAILED=$((FAILED + 1))
 else
   STATUS=$?
-  assert_eq "$STATUS" "2" "disabled guidance is a healthy gated state"
+  assert_eq "$STATUS" "1" "missing provenance requires an authoritative gate check"
 fi
 printf '%s\n' '## User guidance before failed compose' > "$TMP/precompose"
 cp "$TMP/precompose" "$TMP/precompose.backup"
@@ -315,6 +315,7 @@ fi
 assert_php_lint "$MU_FILE" "post-unregister file parses with php -l"
 
 echo "==> sync WordPress coding-agent boundaries"
+wp_cli_transport_set wp
 # Emulate an existing installation created before wp-coding-agents registered
 # its sections at a deterministic late priority.
 python3 - "$MU_FILE" <<'PY'

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -88,6 +88,9 @@ run_verify() {
 write_manifest wp-content/plugins/acme-core wp-content/themes/acme
 write_opencode wp-content/plugins/acme-core wp-content/themes/acme
 write_unit kimaki.service opencode /home/opencode
+CURRENT_PRODUCER="version=$(tr -d '[:space:]' < VERSION) source=commit:$(git rev-parse HEAD)"
+printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/AGENTS.md"
 
 echo "verify: a healthy install passes"
 OUT="$(run_verify)"
@@ -105,6 +108,26 @@ else
   echo "  FAIL healthy install exited non-zero"
   FAILED=$((FAILED + 1))
 fi
+
+echo ""
+echo "verify: guidance provenance exposes source/install/runtime drift"
+
+# The source checkout includes #573's bounded direct-runtime fallback, while
+# the installed mu-plugin and composed AGENTS.md were produced before it.
+if grep -Fq 'request explicit operator authorization before invoking a coding runtime directly' guidance/homeboy.sh; then
+  echo "  ok   source checkout contains the #573 recovery policy"
+else
+  echo "  FAIL source checkout is missing the #573 recovery policy"
+  FAILED=$((FAILED + 1))
+fi
+OLD_PRODUCER='version=1.21.1 source=commit:0000000000000000000000000000000000000000'
+printf '%s\n' "<!-- wp-coding-agents-provenance: $OLD_PRODUCER -->" > "$SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+printf '%s\n%s\n' "<!-- wp-coding-agents-provenance: $OLD_PRODUCER -->" '## Homeboy' > "$SITE/AGENTS.md"
+OUT="$(run_verify)"
+assert_contains "$OUT" 'installed guidance plugin is version=1.21.1' "distinguishes installed plugin freshness"
+assert_contains "$OUT" 'generated AGENTS.md matches the installed guidance plugin' "distinguishes generated-file freshness"
+assert_contains "$OUT" 'runtime/service guidance is version=1.21.1' "distinguishes runtime/service freshness"
+assert_contains "$OUT" 'remedy: ./upgrade.sh --agents-md-only' "reports one safe generic recomposition command"
 
 echo ""
 echo "verify: it catches the defects that reached a live site"

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -88,7 +88,8 @@ run_verify() {
 write_manifest wp-content/plugins/acme-core wp-content/themes/acme
 write_opencode wp-content/plugins/acme-core wp-content/themes/acme
 write_unit kimaki.service opencode /home/opencode
-CURRENT_PRODUCER="version=$(tr -d '[:space:]' < VERSION) source=commit:$(git rev-parse HEAD)"
+source lib/agents-md-guidance.sh
+CURRENT_PRODUCER="version=$(agents_md_guidance_producer_version) source=$(agents_md_guidance_producer_source)"
 printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
 printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/AGENTS.md"
 
@@ -128,6 +129,16 @@ assert_contains "$OUT" 'installed guidance plugin is version=1.21.1' "distinguis
 assert_contains "$OUT" 'generated AGENTS.md matches the installed guidance plugin' "distinguishes generated-file freshness"
 assert_contains "$OUT" 'runtime/service guidance is version=1.21.1' "distinguishes runtime/service freshness"
 assert_contains "$OUT" 'remedy: ./upgrade.sh --agents-md-only' "reports one safe generic recomposition command"
+
+echo ""
+echo "verify: disabled guidance is healthy but gated"
+rm -f "$SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+printf '%s\n' '## User-owned AGENTS guidance' > "$SITE/AGENTS.md"
+OUT="$(run_verify)"
+assert_contains "$OUT" 'AGENTS.md guidance is unavailable or disabled; freshness is gated' "distinguishes disabled guidance from stale output"
+refute_contains "$OUT" 'generated AGENTS.md has no producer provenance' "does not misclassify disabled guidance as stale"
+printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/AGENTS.md"
 
 echo ""
 echo "verify: it catches the defects that reached a live site"

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -43,6 +43,11 @@ touch "$SITE/wp-content/mu-plugins/wp-coding-agents-source-reconcile.php" \
 cat > "$TMP/wp" <<'WP'
 #!/bin/bash
 # Stub: `wp option get <name>`
+for arg in "$@"; do
+  [ "$arg" = eval ] || continue
+  printf '%s\n' unavailable
+  exit 0
+done
 for a in "$@"; do case "$a" in --path=*) ;; esac; done
 [ "${WP_STUB_NOISE:-}" != 1 ] || printf '%s\n\n%s\n' \
   'PHP Deprecated: dependency diagnostic' \
@@ -135,7 +140,7 @@ echo "verify: disabled guidance is healthy but gated"
 rm -f "$SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
 printf '%s\n' '## User-owned AGENTS guidance' > "$SITE/AGENTS.md"
 OUT="$(run_verify)"
-assert_contains "$OUT" 'AGENTS.md guidance is unavailable or disabled; freshness is gated' "distinguishes disabled guidance from stale output"
+assert_contains "$OUT" 'Data Machine AGENTS.md composition is disabled or unavailable; freshness is gated' "distinguishes disabled guidance from stale output"
 refute_contains "$OUT" 'generated AGENTS.md has no producer provenance' "does not misclassify disabled guidance as stale"
 printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
 printf '%s\n' "<!-- wp-coding-agents-provenance: $CURRENT_PRODUCER -->" > "$SITE/AGENTS.md"

--- a/tests/workspace-installation.sh
+++ b/tests/workspace-installation.sh
@@ -82,6 +82,11 @@ test "$(git -C "$REPOSITORY" status --short)" = "" || fail "native Git commit le
 
 cat > "$BIN/wp" <<'SH'
 #!/bin/bash
+for arg in "$@"; do
+  [ "$arg" = eval ] || continue
+  printf '%s\n' unavailable
+  exit 0
+done
 case "$3" in wp_coding_agents_source_mode) echo workspace ;; esac
 SH
 chmod +x "$BIN/wp"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1092,18 +1092,29 @@ regenerate_agents_md() {
   # identity ran it, and without this every other writer is locked out until the
   # next normalize.
   if (cd "$SITE_PATH" && wp_run_as_service_user datamachine memory compose AGENTS.md >/dev/null 2>&1); then
-    local expected_producer composed_producer provenance_status
+    local expected_producer composed_producer provenance_status gate_status
     expected_producer="version=$(agents_md_guidance_producer_version) source=$(agents_md_guidance_producer_source)"
     composed_producer="$(agents_md_guidance_composed_producer "$AGENTS_MD")"
     agents_md_guidance_verify_composed_provenance "$AGENTS_MD" || provenance_status=$?
     if [ "${provenance_status:-0}" = 1 ]; then
-      warn "  AGENTS.md remains stale after compose ($composed_producer; expected $expected_producer)"
-      agents_md_guidance_restore_precompose_state "$AGENTS_MD" "$BACKUP" "$HAD_AGENTS_MD"
-      warn "  Restored AGENTS.md to its pre-compose state"
-      return 1
-    fi
-    if [ "${provenance_status:-0}" = 2 ]; then
-      log "  wp-coding-agents AGENTS.md guidance is unavailable or disabled; provenance verification is gated"
+      if [ -z "$composed_producer" ]; then
+        gate_status=0
+        agents_md_guidance_composition_gate wp_run_as_service_user || gate_status=$?
+        case "$gate_status" in
+          1|2) log "  Data Machine AGENTS.md composition is disabled or unavailable; provenance verification is gated" ;;
+          *)
+            warn "  AGENTS.md is missing wp-coding-agents provenance after compose (expected $expected_producer)"
+            agents_md_guidance_restore_precompose_state "$AGENTS_MD" "$BACKUP" "$HAD_AGENTS_MD"
+            warn "  Restored AGENTS.md to its pre-compose state"
+            return 1
+            ;;
+        esac
+      else
+        warn "  AGENTS.md remains stale after compose ($composed_producer; expected $expected_producer)"
+        agents_md_guidance_restore_precompose_state "$AGENTS_MD" "$BACKUP" "$HAD_AGENTS_MD"
+        warn "  Restored AGENTS.md to its pre-compose state"
+        return 1
+      fi
     fi
     service_file_normalize_perms "$AGENTS_MD"
     if [ -f "$BACKUP" ] && cmp -s "$BACKUP" "$AGENTS_MD"; then

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1067,8 +1067,11 @@ regenerate_agents_md() {
     return 0
   fi
 
-  # Backup existing (compose writes in-place to the registered location)
+  # Backup existing (compose writes in-place to the registered location).
+  # Every unsuccessful or stale recompose restores this exact user state.
+  local HAD_AGENTS_MD=false
   if [ -f "$AGENTS_MD" ]; then
+    HAD_AGENTS_MD=true
     cp "$AGENTS_MD" "$BACKUP"
     service_file_normalize_perms "$BACKUP"
     log "  Backup: $BACKUP"
@@ -1089,6 +1092,19 @@ regenerate_agents_md() {
   # identity ran it, and without this every other writer is locked out until the
   # next normalize.
   if (cd "$SITE_PATH" && wp_run_as_service_user datamachine memory compose AGENTS.md >/dev/null 2>&1); then
+    local expected_producer composed_producer provenance_status
+    expected_producer="version=$(agents_md_guidance_producer_version) source=$(agents_md_guidance_producer_source)"
+    composed_producer="$(agents_md_guidance_composed_producer "$AGENTS_MD")"
+    agents_md_guidance_verify_composed_provenance "$AGENTS_MD" || provenance_status=$?
+    if [ "${provenance_status:-0}" = 1 ]; then
+      warn "  AGENTS.md remains stale after compose ($composed_producer; expected $expected_producer)"
+      agents_md_guidance_restore_precompose_state "$AGENTS_MD" "$BACKUP" "$HAD_AGENTS_MD"
+      warn "  Restored AGENTS.md to its pre-compose state"
+      return 1
+    fi
+    if [ "${provenance_status:-0}" = 2 ]; then
+      log "  wp-coding-agents AGENTS.md guidance is unavailable or disabled; provenance verification is gated"
+    fi
     service_file_normalize_perms "$AGENTS_MD"
     if [ -f "$BACKUP" ] && cmp -s "$BACKUP" "$AGENTS_MD"; then
       log "  AGENTS.md unchanged"
@@ -1103,13 +1119,11 @@ regenerate_agents_md() {
     fi
     agents_md_prune_backups "$SITE_PATH"
   else
-    warn "  datamachine memory compose failed — AGENTS.md unchanged"
-    # Restore from backup if compose wrote a partial file
-    if [ -f "$BACKUP" ] && [ -f "$AGENTS_MD" ] && ! cmp -s "$BACKUP" "$AGENTS_MD"; then
-      cp "$BACKUP" "$AGENTS_MD"
-      service_file_normalize_perms "$AGENTS_MD"
-      warn "  Restored AGENTS.md from backup"
-    fi
+    warn "  datamachine memory compose failed"
+    # Restore a partial write, or remove a newly-created partial file.
+    agents_md_guidance_restore_precompose_state "$AGENTS_MD" "$BACKUP" "$HAD_AGENTS_MD"
+    warn "  Restored AGENTS.md to its pre-compose state"
+    return 1
   fi
 
   # Symlink CLAUDE.md → AGENTS.md so Claude-model OpenCode sessions get the same DM context.

--- a/verify.sh
+++ b/verify.sh
@@ -149,8 +149,15 @@ pass "source checkout producer: $EXPECTED_PRODUCER"
 
 INSTALLED_PRODUCER="$(guidance_producers "$GUIDANCE_PLUGIN")"
 if [ -z "$INSTALLED_PRODUCER" ]; then
-  fail "installed guidance plugin has no producer provenance — source checkout is $EXPECTED_PRODUCER"
-  GUIDANCE_DRIFT=true
+  GATE_STATUS=0
+  agents_md_guidance_composition_gate wp_cli $WP_ROOT_FLAG --path="$SITE_PATH" || GATE_STATUS=$?
+  case "$GATE_STATUS" in
+    1|2) pass "Data Machine AGENTS.md composition is disabled or unavailable; installed guidance is gated" ;;
+    *)
+      fail "installed guidance plugin has no producer provenance — source checkout is $EXPECTED_PRODUCER"
+      GUIDANCE_DRIFT=true
+      ;;
+  esac
 elif [ "$INSTALLED_PRODUCER" = "$EXPECTED_PRODUCER" ]; then
   pass "installed guidance plugin matches the source checkout"
 else
@@ -159,13 +166,16 @@ else
 fi
 
 COMPOSED_PRODUCER="$(guidance_producers "$COMPOSED_GUIDANCE")"
-if [ -z "$COMPOSED_PRODUCER" ] && [ -z "$INSTALLED_PRODUCER" ]; then
-  # Data Machine may intentionally disable AGENTS.md composition, or the
-  # optional guidance integration may be unavailable. No active guidance means
-  # there is nothing stale to remediate with a recomposition command.
-  pass "wp-coding-agents AGENTS.md guidance is unavailable or disabled; freshness is gated"
-elif [ -z "$COMPOSED_PRODUCER" ]; then
-  pass "wp-coding-agents AGENTS.md guidance is disabled; freshness is gated"
+if [ -z "$COMPOSED_PRODUCER" ]; then
+  GATE_STATUS=0
+  agents_md_guidance_composition_gate wp_cli $WP_ROOT_FLAG --path="$SITE_PATH" || GATE_STATUS=$?
+  case "${GATE_STATUS:-0}" in
+    1|2) pass "Data Machine AGENTS.md composition is disabled or unavailable; freshness is gated" ;;
+    *)
+      fail "generated AGENTS.md has no producer provenance — installed guidance is ${INSTALLED_PRODUCER:-unknown}; Data Machine AGENTS.md composition is not explicitly disabled or unavailable"
+      GUIDANCE_DRIFT=true
+      ;;
+  esac
 elif [ "$COMPOSED_PRODUCER" = "$INSTALLED_PRODUCER" ]; then
   pass "generated AGENTS.md matches the installed guidance plugin"
 else

--- a/verify.sh
+++ b/verify.sh
@@ -39,6 +39,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/source-policy.sh"
+source "$SCRIPT_DIR/lib/agents-md-guidance.sh"
 
 QUIET=false
 JSON=false
@@ -127,6 +128,57 @@ esac
 _say "wp-coding-agents verify"
 _say "  site:        $SITE_PATH"
 _say "  source mode: ${SOURCE_MODE:-<unset>}"
+
+# ---------------------------------------------------------------------------
+# Guidance producer freshness
+# ---------------------------------------------------------------------------
+
+section "guidance producer freshness"
+
+EXPECTED_PRODUCER="version=$(agents_md_guidance_producer_version) source=$(agents_md_guidance_producer_source)"
+GUIDANCE_PLUGIN="$SITE_PATH/wp-content/mu-plugins/wp-coding-agents-agents-md.php"
+COMPOSED_GUIDANCE="$SITE_PATH/AGENTS.md"
+GUIDANCE_DRIFT=false
+
+guidance_producers() {
+  [ -f "$1" ] || return 0
+  sed -n 's/.*wp-coding-agents-provenance: version=\([^ ]*\) source=\([^ ]*\).*/version=\1 source=\2/p' "$1" | sort -u
+}
+
+pass "source checkout producer: $EXPECTED_PRODUCER"
+
+INSTALLED_PRODUCER="$(guidance_producers "$GUIDANCE_PLUGIN")"
+if [ -z "$INSTALLED_PRODUCER" ]; then
+  fail "installed guidance plugin has no producer provenance — source checkout is $EXPECTED_PRODUCER"
+  GUIDANCE_DRIFT=true
+elif [ "$INSTALLED_PRODUCER" = "$EXPECTED_PRODUCER" ]; then
+  pass "installed guidance plugin matches the source checkout"
+else
+  fail "installed guidance plugin is $INSTALLED_PRODUCER; source checkout is $EXPECTED_PRODUCER"
+  GUIDANCE_DRIFT=true
+fi
+
+COMPOSED_PRODUCER="$(guidance_producers "$COMPOSED_GUIDANCE")"
+if [ -z "$COMPOSED_PRODUCER" ]; then
+  fail "generated AGENTS.md has no producer provenance — installed guidance is ${INSTALLED_PRODUCER:-unknown}"
+  GUIDANCE_DRIFT=true
+elif [ "$COMPOSED_PRODUCER" = "$INSTALLED_PRODUCER" ]; then
+  pass "generated AGENTS.md matches the installed guidance plugin"
+else
+  fail "generated AGENTS.md is $COMPOSED_PRODUCER; installed guidance plugin is $INSTALLED_PRODUCER"
+  GUIDANCE_DRIFT=true
+fi
+
+if [ "$COMPOSED_PRODUCER" = "$EXPECTED_PRODUCER" ]; then
+  pass "runtime/service guidance is current for new sessions"
+else
+  fail "runtime/service guidance is $COMPOSED_PRODUCER; source checkout is $EXPECTED_PRODUCER"
+  GUIDANCE_DRIFT=true
+fi
+
+if [ "$GUIDANCE_DRIFT" = true ]; then
+  _say "  remedy: ./upgrade.sh --agents-md-only"
+fi
 
 # ---------------------------------------------------------------------------
 # Seam 0: workspace declarations must point at native repositories and match

--- a/verify.sh
+++ b/verify.sh
@@ -159,9 +159,13 @@ else
 fi
 
 COMPOSED_PRODUCER="$(guidance_producers "$COMPOSED_GUIDANCE")"
-if [ -z "$COMPOSED_PRODUCER" ]; then
-  fail "generated AGENTS.md has no producer provenance — installed guidance is ${INSTALLED_PRODUCER:-unknown}"
-  GUIDANCE_DRIFT=true
+if [ -z "$COMPOSED_PRODUCER" ] && [ -z "$INSTALLED_PRODUCER" ]; then
+  # Data Machine may intentionally disable AGENTS.md composition, or the
+  # optional guidance integration may be unavailable. No active guidance means
+  # there is nothing stale to remediate with a recomposition command.
+  pass "wp-coding-agents AGENTS.md guidance is unavailable or disabled; freshness is gated"
+elif [ -z "$COMPOSED_PRODUCER" ]; then
+  pass "wp-coding-agents AGENTS.md guidance is disabled; freshness is gated"
 elif [ "$COMPOSED_PRODUCER" = "$INSTALLED_PRODUCER" ]; then
   pass "generated AGENTS.md matches the installed guidance plugin"
 else
@@ -169,7 +173,9 @@ else
   GUIDANCE_DRIFT=true
 fi
 
-if [ "$COMPOSED_PRODUCER" = "$EXPECTED_PRODUCER" ]; then
+if [ -z "$COMPOSED_PRODUCER" ]; then
+  : # The active guidance gate above is a healthy, intentionally unverifiable state.
+elif [ "$COMPOSED_PRODUCER" = "$EXPECTED_PRODUCER" ]; then
   pass "runtime/service guidance is current for new sessions"
 else
   fail "runtime/service guidance is $COMPOSED_PRODUCER; source checkout is $EXPECTED_PRODUCER"


### PR DESCRIPTION
Fixes #585

## Summary
- record deterministic producer provenance for clean, dirty, and packaged guidance sources
- distinguish authoritative disabled/unavailable composition from stale generated guidance
- make `upgrade.sh --agents-md-only` restore prior user state and fail when recomposition fails or remains stale
- add integration coverage that executes the real upgrade flow and verifies byte-for-byte restoration

## Verification
- `bash tests/agents-md-guidance.sh`
- `bash tests/agents-md-composition-integration.sh`
- `bash tests/verify.sh`
- `bash tests/workspace-installation.sh`
- `bash -n` on changed shell files
- `git diff --check`

The complete shell sweep also ran; four pre-existing host-dependent assertions in `tests/service-migration.sh` remain unrelated to this change.

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and iteratively corrected the change. OpenAI GPT-5.6 Sol via OpenCode orchestrated independent reviews, verification, and PR finalization.