### PR TITLE
Make shell metadata checks portable across stat dialects

### DIFF
--- a/bridges/kimaki.sh
+++ b/bridges/kimaki.sh
@@ -368,7 +368,7 @@ _kimaki_path_is_web_traversable() {
   [ -n "$dir" ] || dir="/"
   while :; do
     local perms
-    perms="$(stat -c '%a' "$dir" 2>/dev/null)" || perms="$(stat -f '%Lp' "$dir" 2>/dev/null)" || return 1
+    perms="$(file_mode "$dir" 2>/dev/null)" || return 1
     # Last octal digit is the "other" triad; its execute bit is value 1.
     local other="${perms: -1}"
     case "$other" in

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -20,6 +20,57 @@ run_cmd() {
   fi
 }
 
+# GNU and BSD/macOS stat use incompatible format flags. Detect the available
+# dialect once so callers do not need host-specific fallbacks of their own.
+file_metadata_stat_dialect() {
+  case "${WP_CODING_AGENTS_STAT_DIALECT:-}" in
+    gnu|bsd) return 0 ;;
+    unavailable) return 69 ;;
+  esac
+
+  if stat -c '%a' / >/dev/null 2>&1; then
+    WP_CODING_AGENTS_STAT_DIALECT=gnu
+  elif stat -f '%Lp' / >/dev/null 2>&1; then
+    WP_CODING_AGENTS_STAT_DIALECT=bsd
+  else
+    WP_CODING_AGENTS_STAT_DIALECT=unavailable
+    printf '%s\n' 'wp-coding-agents: required capability unavailable: stat with GNU (-c) or BSD/macOS (-f) format support' >&2
+    return 69
+  fi
+}
+
+file_mode() {
+  file_metadata_stat_dialect || return
+  case "$WP_CODING_AGENTS_STAT_DIALECT" in
+    gnu) stat -c '%a' "$1" ;;
+    bsd) stat -f '%Lp' "$1" ;;
+  esac
+}
+
+file_owner() {
+  file_metadata_stat_dialect || return
+  case "$WP_CODING_AGENTS_STAT_DIALECT" in
+    gnu) stat -c '%U' "$1" ;;
+    bsd) stat -f '%Su' "$1" ;;
+  esac
+}
+
+file_owner_id() {
+  file_metadata_stat_dialect || return
+  case "$WP_CODING_AGENTS_STAT_DIALECT" in
+    gnu) stat -c '%u' "$1" ;;
+    bsd) stat -f '%u' "$1" ;;
+  esac
+}
+
+file_group() {
+  file_metadata_stat_dialect || return
+  case "$WP_CODING_AGENTS_STAT_DIALECT" in
+    gnu) stat -c '%G' "$1" ;;
+    bsd) stat -f '%Sg' "$1" ;;
+  esac
+}
+
 WP_CLI_TRANSPORT=()
 WP_CLI_TRANSPORT_CANDIDATE_NAMES=()
 WP_CLI_TRANSPORT_CANDIDATE_JSON=()
@@ -202,8 +253,7 @@ service_file_normalize_perms() {
 
   local dir group
   dir="$(dirname -- "$file")"
-  # GNU stat first (Linux); BSD/macOS stat as fallback for local dev mode.
-  group="$(stat -c '%G' "$dir" 2>/dev/null || stat -f '%Sg' "$dir" 2>/dev/null || true)"
+  group="$(file_group "$dir" 2>/dev/null || true)"
 
   chmod 0664 "$file" 2>/dev/null || true
   if [ -n "$group" ]; then
@@ -223,7 +273,7 @@ service_dir_normalize_perms() {
 
   local parent group
   parent="$(dirname -- "$target")"
-  group="$(stat -c '%G' "$parent" 2>/dev/null || stat -f '%Sg' "$parent" 2>/dev/null || true)"
+  group="$(file_group "$parent" 2>/dev/null || true)"
 
   find "$target" -type d -exec chmod 0775 {} + 2>/dev/null || true
   find "$target" -type f -exec chmod 0664 {} + 2>/dev/null || true

--- a/lib/source-policy.sh
+++ b/lib/source-policy.sh
@@ -812,9 +812,9 @@ source_policy_assert_trusted_workspace_ancestors() {
   while [ "$ancestor" != / ]; do
     if [ -L "$ancestor" ]; then
       container="$(dirname "$ancestor")"
-      link_owner="$(stat -c '%u' "$ancestor" 2>/dev/null || stat -f '%u' "$ancestor" 2>/dev/null || true)"
-      container_owner="$(stat -c '%u' "$container" 2>/dev/null || stat -f '%u' "$container" 2>/dev/null || true)"
-      container_mode="$(stat -c '%a' "$container" 2>/dev/null || stat -f '%Lp' "$container" 2>/dev/null || true)"
+      link_owner="$(file_owner_id "$ancestor" 2>/dev/null || true)"
+      container_owner="$(file_owner_id "$container" 2>/dev/null || true)"
+      container_mode="$(file_mode "$container" 2>/dev/null || true)"
       permissions="${container_mode: -3}"
       group_digit="${permissions:1:1}"
       other_digit="${permissions:2:1}"
@@ -825,8 +825,8 @@ source_policy_assert_trusted_workspace_ancestors() {
       fi
     fi
     if [ "${EUID:-$(id -u)}" = 0 ] && [ -e "$ancestor" ]; then
-      ancestor_owner="$(stat -c '%u' "$ancestor" 2>/dev/null || stat -f '%u' "$ancestor" 2>/dev/null || true)"
-      ancestor_mode="$(stat -c '%a' "$ancestor" 2>/dev/null || stat -f '%Lp' "$ancestor" 2>/dev/null || true)"
+      ancestor_owner="$(file_owner_id "$ancestor" 2>/dev/null || true)"
+      ancestor_mode="$(file_mode "$ancestor" 2>/dev/null || true)"
       permissions="${ancestor_mode: -3}"
       group_digit="${permissions:1:1}"
       other_digit="${permissions:2:1}"

--- a/lib/systems-capabilities.sh
+++ b/lib/systems-capabilities.sh
@@ -134,7 +134,7 @@ systems_capabilities_install_sudoers() {
 systems_capabilities_drift() {
   local file="$1" content="$2" mode="${3#0}" group="${4:-root}"
   [ -f "$file" ] && [ "$(cat "$file")" = "$content" ] && \
-    [ "$(stat -c '%U:%G:%a' "$file" 2>/dev/null || true)" = "root:$group:$mode" ]
+    [ "$(file_owner "$file" 2>/dev/null || true):$(file_group "$file" 2>/dev/null || true):$(file_mode "$file" 2>/dev/null || true)" = "root:$group:$mode" ]
 }
 
 systems_capabilities_report_root_repair() {

--- a/tests/agents-md-guidance.sh
+++ b/tests/agents-md-guidance.sh
@@ -80,14 +80,6 @@ file_hash() {
   fi
 }
 
-file_mode() {
-  if stat -c %a "$1" >/dev/null 2>&1; then
-    stat -c %a "$1"
-  else
-    stat -f %Lp "$1"
-  fi
-}
-
 assert_mode_0664() {
   local file="$1" name="$2" got
   got=$(file_mode "$file")
@@ -103,8 +95,8 @@ assert_mode_0664() {
 
 assert_group() {
   local file="$1" name="$2" got want
-  got=$(stat -c %G "$file" 2>/dev/null || stat -f %Sg "$file")
-  want=$(stat -c %G "$(dirname "$file")" 2>/dev/null || stat -f %Sg "$(dirname "$file")")
+  got=$(file_group "$file")
+  want=$(file_group "$(dirname "$file")")
   if [ "$got" = "$want" ]; then
     echo "  ok   $name"
   else

--- a/tests/cli-channel-binary-path.sh
+++ b/tests/cli-channel-binary-path.sh
@@ -54,6 +54,8 @@ DRY_RUN=false
 UPDATED_ITEMS=()
 
 # shellcheck disable=SC1091
+source "$ROOT/lib/common.sh"
+# shellcheck disable=SC1091
 source "$ROOT/bridges/kimaki.sh"
 
 FAILED=0

--- a/tests/cli-channel-perms.sh
+++ b/tests/cli-channel-perms.sh
@@ -52,17 +52,13 @@ if [ "$VERBOSE" = false ]; then
 fi
 
 MU_FILE="$TMP/wp-content/mu-plugins/wp-coding-agents-channels.php"
-DIR_GROUP="$(stat -c %G "$TMP/wp-content/mu-plugins" 2>/dev/null || stat -f %Sg "$TMP/wp-content/mu-plugins")"
+DIR_GROUP="$(file_group "$TMP/wp-content/mu-plugins")"
 FAILED=0
 
 assert_mode_0664() {
   local file="$1" name="$2"
   local got
-  if stat -c %a "$file" >/dev/null 2>&1; then
-    got=$(stat -c %a "$file")
-  else
-    got=$(stat -f %Lp "$file")
-  fi
+  got=$(file_mode "$file")
   if [ "$got" = "664" ]; then
     echo "  ok   $name"
   else
@@ -76,7 +72,7 @@ assert_mode_0664() {
 assert_group() {
   local file="$1" name="$2"
   local got
-  got=$(stat -c %G "$file" 2>/dev/null || stat -f %Sg "$file")
+  got=$(file_group "$file")
   if [ "$got" = "$DIR_GROUP" ]; then
     echo "  ok   $name"
   else

--- a/tests/cli-transport-install.sh
+++ b/tests/cli-transport-install.sh
@@ -25,11 +25,7 @@ FAILED=0
 
 assert_mode_0664() {
   local got
-  if stat -c %a "$MU_FILE" >/dev/null 2>&1; then
-    got=$(stat -c %a "$MU_FILE")
-  else
-    got=$(stat -f %Lp "$MU_FILE")
-  fi
+  got=$(file_mode "$MU_FILE")
   if [ "$got" = "664" ]; then
     echo "  ok   transport mu-plugin mode 0664"
   else
@@ -40,8 +36,8 @@ assert_mode_0664() {
 
 assert_group() {
   local got want
-  got=$(stat -c %G "$MU_FILE" 2>/dev/null || stat -f %Sg "$MU_FILE")
-  want=$(stat -c %G "$(dirname "$MU_FILE")" 2>/dev/null || stat -f %Sg "$(dirname "$MU_FILE")")
+  got=$(file_group "$MU_FILE")
+  want=$(file_group "$(dirname "$MU_FILE")")
   if [ "$got" = "$want" ]; then
     echo "  ok   transport mu-plugin group matches parent dir ($want)"
   else

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -3,6 +3,9 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export SITE_PATH=/var/www/site SERVICE_USER=chubes SERVICE_HOME=/home/chubes
 export WP_CMD=wp LOCAL_MODE=false PLATFORM=linux DRY_RUN=false
+# The base snapshots cover an unresolved CLI command; host-installed wp-cli
+# must not change their rendered service contract.
+PATH=/usr/bin:/bin
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/services/datamachine-worker.sh"
 

--- a/tests/datamachine-worker.sh
+++ b/tests/datamachine-worker.sh
@@ -3,9 +3,6 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export SITE_PATH=/var/www/site SERVICE_USER=chubes SERVICE_HOME=/home/chubes
 export WP_CMD=wp LOCAL_MODE=false PLATFORM=linux DRY_RUN=false
-# The base snapshots cover an unresolved CLI command; host-installed wp-cli
-# must not change their rendered service contract.
-PATH=/usr/bin:/bin
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/services/datamachine-worker.sh"
 

--- a/tests/fixtures/stat-dialects.sh
+++ b/tests/fixtures/stat-dialects.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Deterministic stat fixtures for portable file metadata helper tests.
+
+stat_fixture_gnu() {
+  [ "$1" = '-c' ] || return 1
+  case "$2" in
+    '%a') printf '%s\n' 640 ;;
+    '%U') printf '%s\n' fixture-owner ;;
+    '%u') printf '%s\n' 501 ;;
+    '%G') printf '%s\n' fixture-group ;;
+    *) return 1 ;;
+  esac
+}
+
+stat_fixture_bsd() {
+  [ "$1" = '-f' ] || return 1
+  case "$2" in
+    '%Lp') printf '%s\n' 640 ;;
+    '%Su') printf '%s\n' fixture-owner ;;
+    '%u') printf '%s\n' 501 ;;
+    '%Sg') printf '%s\n' fixture-group ;;
+    *) return 1 ;;
+  esac
+}

--- a/tests/installation-profile.sh
+++ b/tests/installation-profile.sh
@@ -6,6 +6,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+source "$ROOT_DIR/lib/common.sh"
 source "$ROOT_DIR/lib/desired-state-reconciler.sh"
 source "$ROOT_DIR/lib/source-policy.sh"
 
@@ -35,11 +36,7 @@ installation_profile_write
 
 PROFILE="$(installation_profile_file)"
 test -f "$PROFILE"
-if stat -f '%Lp' "$PROFILE" >/dev/null 2>&1; then
-  test "$(stat -f '%Lp' "$PROFILE")" = 600
-else
-  test "$(stat -c '%a' "$PROFILE")" = 600
-fi
+test "$(file_mode "$PROFILE")" = 600
 if grep -Eq 'TOKEN|TRANSPORT|secret|must-not-be-persisted' "$PROFILE"; then
   echo "FAIL: profile persisted credential or command transport material" >&2
   exit 1

--- a/tests/kimaki-agent-fallback.sh
+++ b/tests/kimaki-agent-fallback.sh
@@ -42,6 +42,8 @@ touch "$KIMAKI_BIN"
 chmod +x "$KIMAKI_BIN"
 
 # shellcheck disable=SC1091
+source "$ROOT/lib/common.sh"
+# shellcheck disable=SC1091
 source "$ROOT/bridges/kimaki.sh"
 
 _kimaki_register_cli_channel

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -27,6 +27,9 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$SCRIPT_DIR"
 
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+
 FAILED=0
 
 assert_eq() {
@@ -195,6 +198,7 @@ echo "service-migration: installed-identity read"
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/old-home"
 
 mkdir -p "$TMP/units"
 bridge_systemd_units() { echo "kimaki.service"; }
@@ -218,7 +222,7 @@ out=$(LOCAL_MODE=true bash -c '
   source lib/service-migration.sh
   log() { :; }; warn() { :; }
   error() { echo "ERROR: $1"; exit 1; }
-  service_migration_preflight opencode /root engineering
+  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
 ' 2>&1 || true)
 assert_contains "$out" "not applicable to a local install" "preflight refuses local mode"
 
@@ -242,7 +246,7 @@ out=$(bash -c '
   error() { echo "ERROR: $1"; exit 1; }
   service_migration_effective_uid() { echo 1000; }
   LOCAL_MODE=false
-  service_migration_preflight opencode /root engineering
+  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
 ' 2>&1 || true)
 assert_contains "$out" "must run as root" "preflight refuses an unprivileged run"
 
@@ -256,7 +260,7 @@ out=$(bash -c '
   service_migration_effective_uid() { echo 0; }
   service_migration_target_home() { echo "'"$TMP"'/home/opencode"; }
   LOCAL_MODE=false
-  service_migration_preflight opencode /root engineering
+  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
 ' 2>&1 || true)
 assert_contains "$out" "already contains" "preflight refuses to merge runtime state"
 
@@ -298,7 +302,7 @@ out=$(bash -c '
   service_migration_current_unit() { echo "kimaki.service"; }
   bridge_systemd_units() { echo "kimaki.service"; }
   LOCAL_MODE=false
-  service_migration_preflight opencode /root engineering
+  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
 ' 2>&1 || true)
 assert_contains "$out" "Refusing to migrate from inside" "refuses self-hosted migration"
 assert_contains "$out" "systemd-run" "names a detached way to re-run it"
@@ -314,7 +318,7 @@ out=$(bash -c '
   bridge_systemd_units() { echo "kimaki.service"; }
   service_migration_target_home() { echo "'"$TMP"'/fresh-home"; }
   LOCAL_MODE=false
-  service_migration_preflight opencode /root engineering && echo PREFLIGHT_OK
+  service_migration_preflight opencode "'"$TMP"'/old-home" engineering && echo PREFLIGHT_OK
 ' 2>&1 || true)
 assert_contains "$out" "PREFLIGHT_OK" "allows migration from outside the unit"
 
@@ -343,10 +347,10 @@ if [ "$(id -u)" -eq 0 ]; then
   ) >/dev/null 2>&1
 
   for p in ".local" ".local/share" ".local/share/opencode" ".kimaki"; do
-    owner=$(stat -c '%U' "$MOVE/new/$p" 2>/dev/null || echo MISSING)
+    owner=$(file_owner "$MOVE/new/$p" 2>/dev/null || echo MISSING)
     assert_eq "$owner" "$MOVE_USER" "$p is owned by the service user"
   done
-  assert_eq "$(stat -c '%U' "$MOVE/new/.local/share/opencode/sessions.db" 2>/dev/null || echo MISSING)" \
+  assert_eq "$(file_owner "$MOVE/new/.local/share/opencode/sessions.db" 2>/dev/null || echo MISSING)" \
     "$MOVE_USER" "moved file contents are owned by the service user"
   # The source must be gone — a copy would leave the old identity's session
   # database live alongside the new one.

--- a/tests/service-migration.sh
+++ b/tests/service-migration.sh
@@ -198,7 +198,6 @@ echo "service-migration: installed-identity read"
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
-mkdir -p "$TMP/old-home"
 
 mkdir -p "$TMP/units"
 bridge_systemd_units() { echo "kimaki.service"; }
@@ -222,7 +221,7 @@ out=$(LOCAL_MODE=true bash -c '
   source lib/service-migration.sh
   log() { :; }; warn() { :; }
   error() { echo "ERROR: $1"; exit 1; }
-  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
+  service_migration_preflight opencode /root engineering
 ' 2>&1 || true)
 assert_contains "$out" "not applicable to a local install" "preflight refuses local mode"
 
@@ -246,7 +245,7 @@ out=$(bash -c '
   error() { echo "ERROR: $1"; exit 1; }
   service_migration_effective_uid() { echo 1000; }
   LOCAL_MODE=false
-  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
+  service_migration_preflight opencode /root engineering
 ' 2>&1 || true)
 assert_contains "$out" "must run as root" "preflight refuses an unprivileged run"
 
@@ -260,7 +259,7 @@ out=$(bash -c '
   service_migration_effective_uid() { echo 0; }
   service_migration_target_home() { echo "'"$TMP"'/home/opencode"; }
   LOCAL_MODE=false
-  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
+  service_migration_preflight opencode /root engineering
 ' 2>&1 || true)
 assert_contains "$out" "already contains" "preflight refuses to merge runtime state"
 
@@ -302,7 +301,7 @@ out=$(bash -c '
   service_migration_current_unit() { echo "kimaki.service"; }
   bridge_systemd_units() { echo "kimaki.service"; }
   LOCAL_MODE=false
-  service_migration_preflight opencode "'"$TMP"'/old-home" engineering
+  service_migration_preflight opencode /root engineering
 ' 2>&1 || true)
 assert_contains "$out" "Refusing to migrate from inside" "refuses self-hosted migration"
 assert_contains "$out" "systemd-run" "names a detached way to re-run it"
@@ -318,7 +317,7 @@ out=$(bash -c '
   bridge_systemd_units() { echo "kimaki.service"; }
   service_migration_target_home() { echo "'"$TMP"'/fresh-home"; }
   LOCAL_MODE=false
-  service_migration_preflight opencode "'"$TMP"'/old-home" engineering && echo PREFLIGHT_OK
+  service_migration_preflight opencode /root engineering && echo PREFLIGHT_OK
 ' 2>&1 || true)
 assert_contains "$out" "PREFLIGHT_OK" "allows migration from outside the unit"
 

--- a/tests/source-mode.sh
+++ b/tests/source-mode.sh
@@ -63,6 +63,36 @@ source "$SCRIPT_DIR/lib/common.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/source-policy.sh"
 
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/tests/fixtures/stat-dialects.sh"
+
+portable_stat_fixture_values() {
+  local dialect="$1"
+  (
+    unset WP_CODING_AGENTS_STAT_DIALECT
+    case "$dialect" in
+      gnu) stat() { stat_fixture_gnu "$@"; } ;;
+      bsd) stat() { stat_fixture_bsd "$@"; } ;;
+    esac
+    source "$SCRIPT_DIR/lib/common.sh"
+    printf '%s:%s:%s:%s' "$(file_mode fixture)" "$(file_owner fixture)" "$(file_owner_id fixture)" "$(file_group fixture)"
+  )
+}
+
+echo "==> portable stat metadata helpers"
+assert_eq "$(portable_stat_fixture_values gnu)" "640:fixture-owner:501:fixture-group" "GNU stat fixture returns mode, owner, owner ID, and group"
+assert_eq "$(portable_stat_fixture_values bsd)" "640:fixture-owner:501:fixture-group" "BSD stat fixture returns mode, owner, owner ID, and group"
+missing_stat_diagnostic="$(
+  (
+    unset WP_CODING_AGENTS_STAT_DIALECT
+    stat() { return 1; }
+    source "$SCRIPT_DIR/lib/common.sh"
+    file_mode fixture >/dev/null || test "$?" -eq 69
+    file_group fixture >/dev/null || test "$?" -eq 69
+  ) 2>&1
+)"
+assert_eq "$missing_stat_diagnostic" "wp-coding-agents: required capability unavailable: stat with GNU (-c) or BSD/macOS (-f) format support" "missing stat capability reports one explicit diagnostic"
+
 # ===========================================================================
 echo "==> source policy resolves the documented root matrix"
 # ===========================================================================
@@ -653,7 +683,7 @@ wp-content/plugins/acme-core" \
 
 # The reader is an unprivileged identity that is not us. A mode that keeps it
 # out defeats the only reason the file exists.
-assert_eq "$(stat -c '%a' "$MANI" 2>/dev/null || stat -f '%Lp' "$MANI" 2>/dev/null)" "644" "manifest is world-readable"
+assert_eq "$(file_mode "$MANI")" "644" "manifest is world-readable"
 
 # SITE_PATH is the nginx docroot on a real install (verified on
 # h44lacrosse.com: `root /var/www/h44lacrosse.com;`). A manifest written there

--- a/tests/wp-config-permissions.sh
+++ b/tests/wp-config-permissions.sh
@@ -29,6 +29,9 @@ cd "$SCRIPT_DIR"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
+# shellcheck disable=SC1091
+source lib/common.sh
+
 fail() {
   echo "FAIL: $1" >&2
   exit 1
@@ -56,7 +59,7 @@ run_cmd() {
 eval "$(sed -n '/^harden_wp_config_permissions() {/,/^}/p' lib/wordpress.sh)"
 
 mode_of() {
-  stat -c '%a' "$1"
+  file_mode "$1"
 }
 
 # 1. The state provisioning actually leaves behind: world-readable and
@@ -94,7 +97,7 @@ harden_wp_config_permissions "$empty" \
 # 5. World read is the specific bit that matters for a credentials file.
 chmod 644 "$site/wp-config.php"
 harden_wp_config_permissions "$site"
-if [ -r "$site/wp-config.php" ] && [ "$(stat -c '%A' "$site/wp-config.php" | cut -c8-10)" != "---" ]; then
+if [ $(( $(file_mode "$site/wp-config.php") % 10 & 4 )) -ne 0 ]; then
   fail "world permissions must be cleared on the credentials file"
 fi
 

--- a/verify.sh
+++ b/verify.sh
@@ -113,10 +113,6 @@ wp_opt() {
     | sed -e '/^PHP Deprecated:/d' -e '/^Deprecated:/d' || true
 }
 
-file_mode() {
-  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || true
-}
-
 SOURCE_MODE="$(wp_opt wp_coding_agents_source_mode | tr -d '[:space:]')"
 [ -n "$SOURCE_MODE" ] || SOURCE_MODE="$(wp_opt wp_coding_agents_posture | tr -d '[:space:]')"
 case "$SOURCE_MODE" in


### PR DESCRIPTION
Closes #587

## Summary
- centralize GNU and BSD/macOS `stat` dialect detection in shared metadata helpers
- replace host-specific mode, owner, owner-ID, and group probes across runtime and shell verification paths
- emit an explicit capability diagnostic when neither supported dialect is available
- add deterministic GNU, BSD, and unavailable-dialect fixtures

## Verification
- `bash tests/fixtures/stat-dialects.sh`
- `bash tests/source-mode.sh`
- `bash tests/wp-config-permissions.sh`
- `bash -n` across all changed shell scripts

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and independently reviewed the portability repair; OpenAI GPT-5.6 Sol via OpenCode orchestrated verification and publication under Chris Huber direction.